### PR TITLE
Caches geoadjusted domain

### DIFF
--- a/Sources/ATTNAPI.m
+++ b/Sources/ATTNAPI.m
@@ -74,6 +74,7 @@ static NSString* const EVENT_TYPE_USER_IDENTIFIER_COLLECTED = @"idn";
     NSURLSession* _Nonnull _urlSession;
     NSNumberFormatter* _Nonnull _priceFormatter;
     NSString* _Nonnull _domain;
+    NSString* _Nullable _cachedGeoAdjustedDomain;
 }
 
 - (instancetype)initWithDomain:(NSString*)domain {
@@ -87,6 +88,7 @@ static NSString* const EVENT_TYPE_USER_IDENTIFIER_COLLECTED = @"idn";
         _domain = domain;
         _priceFormatter = [NSNumberFormatter new];
         [_priceFormatter setMinimumFractionDigits:2];
+        _cachedGeoAdjustedDomain = nil;
     }
     
     return [super init];
@@ -252,6 +254,13 @@ static NSString* const EVENT_TYPE_USER_IDENTIFIER_COLLECTED = @"idn";
 }
 
 - (void)getGeoAdjustedDomain:(NSString *)domain completionHandler:(void (^)(NSString* _Nullable, NSError* _Nullable)) completionHandler {
+    if (_cachedGeoAdjustedDomain != nil) {
+        completionHandler(_cachedGeoAdjustedDomain, nil);
+        return;
+    }
+    
+    NSLog(@"%@", [NSString stringWithFormat:@"Getting the geoAdjustedDomain for domain '%@'...", domain]);
+    
     NSString* urlString = [NSString stringWithFormat:DTAG_URL_FORMAT, domain];
     
     NSURL* url = [NSURL URLWithString:urlString];
@@ -281,6 +290,7 @@ static NSString* const EVENT_TYPE_USER_IDENTIFIER_COLLECTED = @"idn";
             return;
         }
         
+        _cachedGeoAdjustedDomain = geoAdjustedDomain;
         completionHandler(geoAdjustedDomain, nil);
     }];
     
@@ -467,6 +477,11 @@ static NSString* const EVENT_TYPE_USER_IDENTIFIER_COLLECTED = @"idn";
 // For testing only
 - (void)setSession:(NSURLSession*)session {
     _urlSession = session;
+}
+
+// For testing only
+- (NSString* _Nullable)getCachedGeoAdjustedDomain {
+    return _cachedGeoAdjustedDomain;
 }
 
 @end

--- a/Tests/ATTNAPITest.m
+++ b/Tests/ATTNAPITest.m
@@ -18,6 +18,7 @@
 #import "ATTNCart.h"
 
 static NSString* const TEST_DOMAIN = @"some-domain";
+static NSString* const TEST_GEO_ADJUSTED_DOMAIN = @"some-domain";
 
 @interface ATTNAPI (Testing)
 
@@ -26,6 +27,8 @@ static NSString* const TEST_DOMAIN = @"some-domain";
 - (void)getGeoAdjustedDomain:(NSString *)domain completionHandler:(void (^)(NSString* _Nullable, NSError* _Nullable))completionHandler;
 
 - (NSURL*)constructUserIdentityUrl:(ATTNUserIdentity *)userIdentity domain:(NSString *)domain;
+
+- (NSString*)getCachedGeoAdjustedDomain;
 
 @end
 
@@ -80,7 +83,7 @@ static NSString* const TEST_DOMAIN = @"some-domain";
     if ([[url absoluteString] containsString:@"cdn.attn.tv"]) {
         _didCallDtag = true;
         return [[NSURLSessionDataTaskMock alloc] initWithHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
-            completionHandler([@"window.__attentive_domain='some-domain.attn.tv'" dataUsingEncoding:NSUTF8StringEncoding], [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:nil headerFields:nil], nil);
+            completionHandler([[NSString stringWithFormat:@"window.__attentive_domain='%@.attn.tv'", TEST_GEO_ADJUSTED_DOMAIN] dataUsingEncoding:NSUTF8StringEncoding], [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:nil headerFields:nil], nil);
         }];
     }
     
@@ -301,6 +304,43 @@ static NSString* const TEST_DOMAIN = @"some-domain";
     XCTAssertEqualObjects(productView.items[0].name, metadata[@"name"]);
     NSString* quantity = [NSString stringWithFormat:@"%d", productView.items[0].quantity];
     XCTAssertEqualObjects(quantity, metadata[@"quantity"]);
+}
+
+- (void)testSendEvent_multipleEventsSent_onlyGetsGeoAdjustedDomainOnce {
+    NSURLSessionMock* sessionMock = [[NSURLSessionMock alloc] init];
+    ATTNAPI* api = [[ATTNAPI alloc] initWithDomain:TEST_DOMAIN urlSession:sessionMock];
+    ATTNAddToCartEvent* addToCart1 = [self buildAddToCart];
+    ATTNAddToCartEvent* addToCart2 = [self buildAddToCart];
+    ATTNUserIdentity* userIdentity = [self buildUserIdentity];
+    
+    [api sendEvent:addToCart1 userIdentity:userIdentity];
+    XCTAssertTrue(sessionMock.didCallEventsApi);
+    XCTAssertEqual(2, sessionMock.urlCalls.count);
+    
+    [api sendEvent:addToCart2 userIdentity:userIdentity];
+    XCTAssertTrue(sessionMock.didCallEventsApi);
+    XCTAssertEqual(3, sessionMock.urlCalls.count);
+    
+    int numberOfGeoAdjustedDomainCalls = 0;
+    for (NSURL* urlCall in sessionMock.urlCalls) {
+        if ([urlCall.host isEqualToString:@"cdn.attn.tv"]) {
+            numberOfGeoAdjustedDomainCalls++;
+        }
+    }
+    XCTAssertEqual(1, numberOfGeoAdjustedDomainCalls);
+}
+
+- (void)testGetGeoAdjustedDomain_notCachedYet_savesTheCorrectDomainValue {
+    NSURLSessionMock* sessionMock = [[NSURLSessionMock alloc] init];
+    ATTNAPI* api = [[ATTNAPI alloc] initWithDomain:TEST_DOMAIN urlSession:sessionMock];
+    
+    XCTAssertNil([api getCachedGeoAdjustedDomain]);
+    
+    [api getGeoAdjustedDomain:TEST_DOMAIN completionHandler:^(NSString * _Nullable geoAdjustedDomain, NSError * _Nullable error) {
+        XCTAssertEqualObjects(TEST_GEO_ADJUSTED_DOMAIN, geoAdjustedDomain);
+    }];
+    
+    XCTAssertEqualObjects(TEST_GEO_ADJUSTED_DOMAIN, [api getCachedGeoAdjustedDomain]);
 }
 
 - (NSDictionary*)getMetadataFromUrl:(NSURL*)url {

--- a/Tests/ATTNAPITest.m
+++ b/Tests/ATTNAPITest.m
@@ -18,7 +18,7 @@
 #import "ATTNCart.h"
 
 static NSString* const TEST_DOMAIN = @"some-domain";
-static NSString* const TEST_GEO_ADJUSTED_DOMAIN = @"some-domain";
+static NSString* const TEST_GEO_ADJUSTED_DOMAIN = @"some-domain-ca";
 
 @interface ATTNAPI (Testing)
 


### PR DESCRIPTION
* Caches the geoadjusted domain (GAD) so that subsequent calls don't have to call our API again to get the GAD
* This implementation is simple and more optimized than the current code, but it is not optimal. Why is it not optimal? There can still be multiple calls to get the GAD. Here's how: Assume the GAD is not cached. Event 1 is being sent by the SDK and it triggers an async call to get the GAD. Before that call finishes Event 2 is then sent by the SDK - this triggers another async call to get the GAD. Each of these calls will complete, in some unknown order, and each will overwrite the cachedGeoAdjustedDomain. We should not get different GAD values from each call, so the cached GAD will end up being the same.