### PR TITLE
Update UI Tests for AWS Device Farm

### DIFF
--- a/Example/CreativeUITest/CreativeUITest.m
+++ b/Example/CreativeUITest/CreativeUITest.m
@@ -61,7 +61,7 @@
     [emailField typeText:@"testemail@attentivemobile.com"];
     
     // Tap something else on the creative to dismiss the keyboard
-    [app.staticTexts[@"UNLOCK"] tap];
+    [app.staticTexts[@"10% OFF"] tap];
     
     // Submit email
     XCTAssertTrue([app.buttons[@"CONTINUE"] waitForExistenceWithTimeout:5.0]);
@@ -71,10 +71,20 @@
     XCTAssertTrue([app.buttons[@"GET 10% OFF NOW when you sign up for email and texts"] waitForExistenceWithTimeout:5.0]);
     [app.buttons[@"GET 10% OFF NOW when you sign up for email and texts"] tap];
 
-    // Assert that the SMS app is opened with prepoulated text
-    XCUIApplication * smsApp = [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.MobileSMS"];
-    XCTAssertTrue([smsApp.textFields[@"Message"] waitForExistenceWithTimeout:5.0]);
-    XCTAssertTrue([smsApp.textFields[@"Message"].value containsString:@"Send this text to subscribe to recurring automated personalized marketing alerts (e.g. cart reminders) from Attentive Mobile Apps Test"]);
+
+    NSString * envHost = [[[NSProcessInfo processInfo] environment] objectForKey:@"com.attentive.Example.HOST"];
+
+    if ([envHost isEqualToString:@"device_farm"]) {
+        // Assert that the creative is closed because device farm doesn't allow the
+        // SMS app to be installed or used
+        XCTAssertTrue([app.buttons[@"Push me for Creative!"] waitForExistenceWithTimeout:5.0]);
+        XCTAssertEqual(app.buttons[@"Push me for Creative!"].isHittable, true);
+    } else {
+        // Assert that the SMS app is opened with prepopulated text
+        XCUIApplication * smsApp = [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.MobileSMS"];
+        XCTAssertTrue([smsApp.textFields[@"Message"] waitForExistenceWithTimeout:5.0]);
+        XCTAssertTrue([smsApp.textFields[@"Message"].value containsString:@"Send this text to subscribe to recurring automated personalized marketing alerts (e.g. cart reminders) from Attentive Mobile Apps Test"]);
+    }
 }
 
 
@@ -123,7 +133,7 @@
     app.launchEnvironment = @{
         @"com.attentive.Example.DOMAIN": @"mobileapps",
         @"com.attentive.Example.MODE": mode,
-        @"com.attentive.Example.PERSISTENT_DOMAIN_TO_REMOVE": @"com.attentive.Example"
+        @"com.attentive.Example.REMOVE_PERSISTENT_DOMAIN": @"com.attentive.ios.sdk.Example"
     };
     [app launch];
 }

--- a/Example/CreativeUITest/CreativeUITest.m
+++ b/Example/CreativeUITest/CreativeUITest.m
@@ -71,16 +71,10 @@
     XCTAssertTrue([app.buttons[@"GET 10% OFF NOW when you sign up for email and texts"] waitForExistenceWithTimeout:5.0]);
     [app.buttons[@"GET 10% OFF NOW when you sign up for email and texts"] tap];
 
-
-    NSString * envHost = [[[NSProcessInfo processInfo] environment] objectForKey:@"com.attentive.Example.HOST"];
-
-    if ([envHost isEqualToString:@"device_farm"]) {
-        // Assert that the creative is closed because device farm doesn't allow the
-        // SMS app to be installed or used
-        XCTAssertTrue([app.buttons[@"Push me for Creative!"] waitForExistenceWithTimeout:5.0]);
-        XCTAssertEqual(app.buttons[@"Push me for Creative!"].isHittable, true);
-    } else {
-        // Assert that the SMS app is opened with prepopulated text
+    // Assert that the SMS app is opened with prepopulated text if running locally
+    // (AWS Device Farm doesn't allow use of SMS apps)
+    NSString * envHost = [[[NSProcessInfo processInfo] environment] objectForKey:@"COM_ATTENTIVE_EXAMPLE_HOST"];
+    if ([envHost isEqualToString:@"local"]) {
         XCUIApplication * smsApp = [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.MobileSMS"];
         XCTAssertTrue([smsApp.textFields[@"Message"] waitForExistenceWithTimeout:5.0]);
         XCTAssertTrue([smsApp.textFields[@"Message"].value containsString:@"Send this text to subscribe to recurring automated personalized marketing alerts (e.g. cart reminders) from Attentive Mobile Apps Test"]);
@@ -125,15 +119,16 @@
 
 + (void)resetUserDefaults {
     // Reset user defaults for example app, not the test runner
+    // TODO - fix this domain name
     [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:@"com.attentive.Example"];
 }
 
 
 - (void)launchAppWithMode:(NSString *) mode {
     app.launchEnvironment = @{
-        @"com.attentive.Example.DOMAIN": @"mobileapps",
-        @"com.attentive.Example.MODE": mode,
-        @"com.attentive.Example.REMOVE_PERSISTENT_DOMAIN": @"com.attentive.ios.sdk.Example"
+        @"COM_ATTENTIVE_EXAMPLE_DOMAIN": @"mobileapps",
+        @"COM_ATTENTIVE_EXAMPLE_MODE": mode,
+        @"COM_ATTENTIVE_EXAMPLE_IS_UI_TEST": @"YES",
     };
     [app launch];
 }

--- a/Example/CreativeUITest/CreativeUITest.m
+++ b/Example/CreativeUITest/CreativeUITest.m
@@ -119,7 +119,6 @@
 
 + (void)resetUserDefaults {
     // Reset user defaults for example app, not the test runner
-    // TODO - fix this domain name
     [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:@"com.attentive.Example"];
 }
 

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -412,7 +412,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 22B7R538JL;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -426,7 +426,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.ios.sdk.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -442,7 +442,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 22B7R538JL;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -456,7 +456,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.ios.sdk.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -584,7 +584,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 22B7R538JL;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -599,7 +599,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.ios.sdk.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -614,7 +614,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 22B7R538JL;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -629,7 +629,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.ios.sdk.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -645,7 +645,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 22B7R538JL;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "";
@@ -682,7 +682,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 22B7R538JL;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = "";

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -409,8 +409,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 22B7R538JL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -424,8 +426,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.ios.sdk.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -436,8 +439,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 22B7R538JL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -451,8 +456,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.ios.sdk.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -578,6 +584,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 22B7R538JL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -592,10 +599,10 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.ios.sdk.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -607,6 +614,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 22B7R538JL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -621,10 +629,10 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = "$(inherited)";
-				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.Example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.ios.sdk.Example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};
@@ -633,13 +641,32 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 22B7R538JL;
+				FRAMEWORK_SEARCH_PATHS = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(LD_RUNPATH_SEARCH_PATHS_SHALLOW_BUNDLE_$(SHALLOW_BUNDLE))",
+				);
+				LIBRARY_SEARCH_PATHS = "";
+				MACH_O_TYPE = mh_bundle;
+				MACOSX_DEPLOYMENT_TARGET = 12.6;
 				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-framework",
+					XCTest,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.Example.CreativeUITest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "Example - Local";
@@ -651,13 +678,32 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 22B7R538JL;
+				FRAMEWORK_SEARCH_PATHS = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(LD_RUNPATH_SEARCH_PATHS_SHALLOW_BUNDLE_$(SHALLOW_BUNDLE))",
+				);
+				LIBRARY_SEARCH_PATHS = "";
+				MACH_O_TYPE = mh_bundle;
+				MACOSX_DEPLOYMENT_TARGET = 12.6;
 				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-framework",
+					XCTest,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.attentive.Example.CreativeUITest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = "Example - Local";

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Example - Local.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Example - Local.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:Example.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "69D3C148299EF2D10027934F"
+               BuildableName = "CreativeUITest.xctest"
+               BlueprintName = "CreativeUITest"
+               ReferencedContainer = "container:Example.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -62,6 +76,11 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "com.attentive.Example.HOST"
+            value = "local"
+            isEnabled = "YES">
+         </EnvironmentVariable>
          <EnvironmentVariable
             key = "com.attentive.Example.DOMAIN"
             value = "mobileapps"

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Example - Local.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Example - Local.xcscheme
@@ -77,17 +77,17 @@
       </BuildableProductRunnable>
       <EnvironmentVariables>
          <EnvironmentVariable
-            key = "com.attentive.Example.HOST"
+            key = "COM_ATTENTIVE_EXAMPLE_HOST"
             value = "local"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "com.attentive.Example.DOMAIN"
+            key = "COM_ATTENTIVE_EXAMPLE_DOMAIN"
             value = "mobileapps"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
-            key = "com.attentive.Example.MODE"
+            key = "COM_ATTENTIVE_EXAMPLE_MODE"
             value = "production"
             isEnabled = "YES">
          </EnvironmentVariable>

--- a/Example/Example/ViewController.m
+++ b/Example/Example/ViewController.m
@@ -78,8 +78,8 @@ ATTNSDK *sdk;
 // Method for setting up UI Tests. Only used for testing purposes
 - (void)setupForUITests {
     // Override the hard-coded domain & mode with the values from the environment variables
-    NSString * envDomain = [[[NSProcessInfo processInfo] environment] objectForKey:@"com.attentive.Example.DOMAIN"];
-    NSString * envMode = [[[NSProcessInfo processInfo] environment] objectForKey:@"com.attentive.Example.MODE"];
+    NSString * envDomain = [[[NSProcessInfo processInfo] environment] objectForKey:@"COM_ATTENTIVE_EXAMPLE_DOMAIN"];
+    NSString * envMode = [[[NSProcessInfo processInfo] environment] objectForKey:@"COM_ATTENTIVE_EXAMPLE_MODE"];
 
     if (envDomain != nil) {
         _domain = envDomain;
@@ -90,8 +90,8 @@ ATTNSDK *sdk;
 
     // Reset the standard user defaults - this must be done from within the app to avoid
     // race conditions
-    NSString * persistentDomainToRemove = [[[NSProcessInfo processInfo] environment] objectForKey:@"com.attentive.Example.REMOVE_PERSISTENT_DOMAIN"];
-    if ([persistentDomainToRemove isEqualToString:@"YES"]) {
+    NSString * isUITest = [[[NSProcessInfo processInfo] environment] objectForKey:@"COM_ATTENTIVE_EXAMPLE_IS_UI_TEST"];
+    if ([isUITest isEqualToString:@"YES"]) {
         NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
         [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:bundleIdentifier];
     }

--- a/Example/Example/ViewController.m
+++ b/Example/Example/ViewController.m
@@ -21,7 +21,7 @@ ATTNSDK *sdk;
     self.view.backgroundColor = [UIColor systemGray3Color];
     
     // Replace with your Attentive domain to test with your Attentive account
-    _domain = @"YOUR_ATTENTIVE_DOMAIN";
+    _domain = @"mobileapps";
     _mode = @"production";
 
     // Setup for Testing purposes only
@@ -78,14 +78,22 @@ ATTNSDK *sdk;
 // Method for setting up UI Tests. Only used for testing purposes
 - (void)setupForUITests {
     // Override the hard-coded domain & mode with the values from the environment variables
-    _domain = [[[NSProcessInfo processInfo] environment] objectForKey:@"com.attentive.Example.DOMAIN"];
-    _mode = [[[NSProcessInfo processInfo] environment] objectForKey:@"com.attentive.Example.MODE"];
+    NSString * envDomain = [[[NSProcessInfo processInfo] environment] objectForKey:@"com.attentive.Example.DOMAIN"];
+    NSString * envMode = [[[NSProcessInfo processInfo] environment] objectForKey:@"com.attentive.Example.MODE"];
+
+    if (envDomain != nil) {
+        _domain = envDomain;
+    }
+    if (envMode != nil) {
+        _mode = envMode;
+    }
 
     // Reset the standard user defaults - this must be done from within the app to avoid
     // race conditions
-    NSString * persistentDomainToRemove = [[[NSProcessInfo processInfo] environment] objectForKey:@"com.attentive.Example.PERSISTENT_DOMAIN_TO_REMOVE"];
-    if ([persistentDomainToRemove isEqualToString:@"com.attentive.Example"]) {
-        [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:persistentDomainToRemove];
+    NSString * persistentDomainToRemove = [[[NSProcessInfo processInfo] environment] objectForKey:@"com.attentive.Example.REMOVE_PERSISTENT_DOMAIN"];
+    if ([persistentDomainToRemove isEqualToString:@"YES"]) {
+        NSString *bundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+        [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:bundleIdentifier];
     }
 }
 

--- a/Example/Example/ViewController.m
+++ b/Example/Example/ViewController.m
@@ -21,7 +21,7 @@ ATTNSDK *sdk;
     self.view.backgroundColor = [UIColor systemGray3Color];
     
     // Replace with your Attentive domain to test with your Attentive account
-    _domain = @"mobileapps";
+    _domain = @"YOUR_ATTENTIVE_DOMAIN";
     _mode = @"production";
 
     // Setup for Testing purposes only


### PR DESCRIPTION
- tap 10% OFF instead of UNLOCk since it's more in the center of the app & is less likely to be cut off
- only verify the sms app is opened locally since aws device farm doesn't allow use of sms apps
- update env variables names to respect env variable naming conventions
- fix setupUITest function to only override domain & mode when they are set