### PR TITLE
Changes event requests from GET to POST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: "Play"
-        run: xcodebuild -project "attentive-ios-sdk.xcodeproj" -scheme "attentive-ios-sdk Tests" -destination "platform=iOS Simulator,OS=16.1,name=iPhone 13 Pro" test
+        run: xcodebuild -project "attentive-ios-sdk.xcodeproj" -scheme "attentive-ios-sdk-framework" -destination "platform=iOS Simulator,OS=16.1,name=iPhone 13 Pro" test

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -27,8 +27,8 @@
 		69CCAF5C28DCDE5A007620BD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 69CCAF5B28DCDE5A007620BD /* Assets.xcassets */; };
 		69CCAF5F28DCDE5A007620BD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 69CCAF5D28DCDE5A007620BD /* LaunchScreen.storyboard */; };
 		69CCAF6228DCDE5A007620BD /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 69CCAF6128DCDE5A007620BD /* main.m */; };
-		C77C85E38A76EFB4A30A63ED /* Pods_Example___Pod.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E225173AF4DB16299D85458 /* Pods_Example___Pod.framework */; };
 		69D3C14C299EF2D10027934F /* CreativeUITest.m in Sources */ = {isa = PBXBuildFile; fileRef = 69D3C14B299EF2D10027934F /* CreativeUITest.m */; };
+		C77C85E38A76EFB4A30A63ED /* Pods_Example___Pod.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E225173AF4DB16299D85458 /* Pods_Example___Pod.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -280,8 +280,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				69CCAF4B28DCDE57007620BD /* Example - Pod */,
 				58317964292EEEAA0003D6B0 /* Example - Local */,
+				69CCAF4B28DCDE57007620BD /* Example - Pod */,
 				69D3C148299EF2D10027934F /* CreativeUITest */,
 			);
 		};

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Example - Local.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Example - Local.xcscheme
@@ -22,9 +22,9 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
-            buildForArchiving = "YES"
+            buildForArchiving = "NO"
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
@@ -40,11 +40,27 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "COM_ATTENTIVE_EXAMPLE_MODE"
+            value = "production"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "COM_ATTENTIVE_EXAMPLE_HOST"
+            value = "local"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "COM_ATTENTIVE_EXAMPLE_DOMAIN"
+            value = "mobileapps"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "69D3C148299EF2D10027934F"
@@ -75,23 +91,6 @@
             ReferencedContainer = "container:Example.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "COM_ATTENTIVE_EXAMPLE_HOST"
-            value = "local"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "COM_ATTENTIVE_EXAMPLE_DOMAIN"
-            value = "mobileapps"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
-            key = "COM_ATTENTIVE_EXAMPLE_MODE"
-            value = "production"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/Example.xcodeproj/xcshareddata/xcschemes/Example - Pod.xcscheme
+++ b/Example/Example.xcodeproj/xcshareddata/xcschemes/Example - Pod.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -9,15 +9,15 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "58D52E18292EC52B00CF32DE"
-               BuildableName = "attentive-ios-sdk Tests.xctest"
-               BlueprintName = "attentive-ios-sdk Tests"
-               ReferencedContainer = "container:attentive-ios-sdk.xcodeproj">
+               BlueprintIdentifier = "69CCAF4B28DCDE57007620BD"
+               BuildableName = "Example - Pod.app"
+               BlueprintName = "Example - Pod"
+               ReferencedContainer = "container:Example.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -28,17 +28,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "58D52E18292EC52B00CF32DE"
-               BuildableName = "attentive-ios-sdk Tests.xctest"
-               BlueprintName = "attentive-ios-sdk Tests"
-               ReferencedContainer = "container:attentive-ios-sdk.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -51,6 +40,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "69CCAF4B28DCDE57007620BD"
+            BuildableName = "Example - Pod.app"
+            BlueprintName = "Example - Pod"
+            ReferencedContainer = "container:Example.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -58,15 +57,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "58D52E18292EC52B00CF32DE"
-            BuildableName = "attentive-ios-sdk Tests.xctest"
-            BlueprintName = "attentive-ios-sdk Tests"
-            ReferencedContainer = "container:attentive-ios-sdk.xcodeproj">
+            BlueprintIdentifier = "69CCAF4B28DCDE57007620BD"
+            BuildableName = "Example - Pod.app"
+            BlueprintName = "Example - Pod"
+            ReferencedContainer = "container:Example.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/Example/ImportAttentiveSDK.h
+++ b/Example/Example/ImportAttentiveSDK.h
@@ -9,21 +9,9 @@
 // or 2) the published attentive-ios-sdk pod.
 
 // Use the framework from your local attentive-ios-sdk project
-#if __has_include(<attentive_ios_sdk/ATTNSDK.h>)
-#import <attentive_ios_sdk/ATTNSDKFramework.h>
+#if __has_include(<attentive_ios_sdk_framework/ATTNSDK.h>)
+#import <attentive_ios_sdk_framework/ATTNSDKFramework.h>
 #else
-// Use the published pod version of the attentive-ios-sdk
-// Since we build the pod into a static library, we should import all the needed public headers here (i.e. there is no umbrella header file)
-#import "ATTNSDK.h"
-#import "ATTNUserIdentity.h"
-#import "ATTNEventTracker.h"
-#import "ATTNPurchaseEvent.h"
-#import "ATTNAddToCartEvent.h"
-#import "ATTNProductViewEvent.h"
-#import "ATTNItem.h"
-#import "ATTNPrice.h"
-#import "ATTNOrder.h"
-#import "ATTNCart.h"
-// If for some reason we switched to building the pod into a dynamic framework, we can use this umbrella import instead:
-// #import "attentive_ios_sdk/attentive-ios-sdk-umbrella.h"
+// Load the headers from the attentive-ios-sdk Pod
+#import "attentive_ios_sdk/attentive-ios-sdk-umbrella.h"
 #endif

--- a/Framework/ATTNSDKFramework.h
+++ b/Framework/ATTNSDKFramework.h
@@ -6,15 +6,15 @@ FOUNDATION_EXPORT const unsigned char ATTNSDKFrameworkVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <attentive_ios_sdk/PublicHeader.h>
 
-#import <attentive_ios_sdk/ATTNSDK.h>
-#import <attentive_ios_sdk/ATTNUserIdentity.h>
-#import <attentive_ios_sdk/ATTNEventTracker.h>
-#import <attentive_ios_sdk/ATTNPurchaseEvent.h>
-#import <attentive_ios_sdk/ATTNItem.h>
-#import <attentive_ios_sdk/ATTNPrice.h>
-#import <attentive_ios_sdk/ATTNEvent.h>
-#import <attentive_ios_sdk/ATTNPurchaseEvent.h>
-#import <attentive_ios_sdk/ATTNProductViewEvent.h>
-#import <attentive_ios_sdk/ATTNAddToCartEvent.h>
-#import <attentive_ios_sdk/ATTNOrder.h>
-#import <attentive_ios_sdk/ATTNCart.h>
+#import <attentive_ios_sdk_framework/ATTNSDK.h>
+#import <attentive_ios_sdk_framework/ATTNUserIdentity.h>
+#import <attentive_ios_sdk_framework/ATTNEventTracker.h>
+#import <attentive_ios_sdk_framework/ATTNPurchaseEvent.h>
+#import <attentive_ios_sdk_framework/ATTNItem.h>
+#import <attentive_ios_sdk_framework/ATTNPrice.h>
+#import <attentive_ios_sdk_framework/ATTNEvent.h>
+#import <attentive_ios_sdk_framework/ATTNPurchaseEvent.h>
+#import <attentive_ios_sdk_framework/ATTNProductViewEvent.h>
+#import <attentive_ios_sdk_framework/ATTNAddToCartEvent.h>
+#import <attentive_ios_sdk_framework/ATTNOrder.h>
+#import <attentive_ios_sdk_framework/ATTNCart.h>

--- a/Sources/ATTNAPI.m
+++ b/Sources/ATTNAPI.m
@@ -147,8 +147,9 @@ static NSString* const EVENT_TYPE_USER_IDENTIFIER_COLLECTED = @"idn";
 
 - (void)sendEventInternalForRequest:(EventRequest*)request userIdentity: (ATTNUserIdentity*)userIdentity domain:(NSString*) domain callback:(ATTNAPICallback)callback{
     NSURL* url = [self constructEventUrlComponentsForEventRequest:request userIdentity:userIdentity domain:domain].URL;
-
-    NSURLSessionDataTask* task = [_urlSession dataTaskWithURL:url completionHandler:^ void (NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+    NSMutableURLRequest* urlRequest = [NSMutableURLRequest requestWithURL:url];
+    [urlRequest setHTTPMethod:@"POST"];
+    NSURLSessionDataTask* task = [_urlSession dataTaskWithRequest:urlRequest completionHandler:^ void (NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
 
         NSString * message;
         if (error) {
@@ -289,7 +290,8 @@ static NSString* const EVENT_TYPE_USER_IDENTIFIER_COLLECTED = @"idn";
     NSString* urlString = [NSString stringWithFormat:DTAG_URL_FORMAT, domain];
     
     NSURL* url = [NSURL URLWithString:urlString];
-    NSURLSessionDataTask* task = [_urlSession dataTaskWithURL:url completionHandler:^ void (NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:url];
+    NSURLSessionDataTask* task = [_urlSession dataTaskWithRequest:request completionHandler:^ void (NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         if (error) {
             NSLog(@"Error getting the geo-adjusted domain. Error: '%@'", [error description]);
             completionHandler(nil, error);
@@ -324,7 +326,9 @@ static NSString* const EVENT_TYPE_USER_IDENTIFIER_COLLECTED = @"idn";
 
 - (void)sendUserIdentityInternal:(ATTNUserIdentity *)userIdentity domain:(NSString *)domain callback:(ATTNAPICallback)callback {
     NSURL* url = [self constructUserIdentityUrl:userIdentity domain:domain].URL;
-    NSURLSessionDataTask* task = [_urlSession dataTaskWithURL:url completionHandler:^ void (NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+    NSMutableURLRequest* request = [NSMutableURLRequest requestWithURL:url];
+    [request setHTTPMethod:@"POST"];
+    NSURLSessionDataTask* task = [_urlSession dataTaskWithRequest:request completionHandler:^ void (NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
 
         NSString * message;
         if (error) {

--- a/attentive-ios-sdk.xcodeproj/xcshareddata/xcschemes/attentive-ios-sdk-framework.xcscheme
+++ b/attentive-ios-sdk.xcodeproj/xcshareddata/xcschemes/attentive-ios-sdk-framework.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:attentive-ios-sdk.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58D52E18292EC52B00CF32DE"
+               BuildableName = "attentive-ios-sdk Tests.xctest"
+               BlueprintName = "attentive-ios-sdk Tests"
+               ReferencedContainer = "container:attentive-ios-sdk.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +42,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "58D52E18292EC52B00CF32DE"
+               BuildableName = "attentive-ios-sdk Tests.xctest"
+               BlueprintName = "attentive-ios-sdk Tests"
+               ReferencedContainer = "container:attentive-ios-sdk.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
* Changes event requests from GET to POST
* Fixes a regression with the Example app that caused the domain to always be overridden with the test domain
* Removed the `attentive-ios-sdk Tests` scheme. To run the SDK tests, just use the Test action on the `attentive-ios-sdk-framework` scheme