### PR TITLE
Update regex to better parse attn domains

### DIFF
--- a/Sources/ATTNAPI.m
+++ b/Sources/ATTNAPI.m
@@ -510,8 +510,6 @@ static NSString* const EVENT_TYPE_CUSTOM_EVENT = @"ce";
     return nil;
   }
 
-  NSLog(@"Found attn domain is: %@", [tag substringWithRange:domainRange]);
-
   return [tag substringWithRange:domainRange];
 }
 

--- a/Sources/ATTNAPI.m
+++ b/Sources/ATTNAPI.m
@@ -483,7 +483,7 @@ static NSString* const EVENT_TYPE_CUSTOM_EVENT = @"ce";
 
 + (NSString* _Nullable)extractDomainFromTag:(NSString*)tag {
   NSError* error = nil;
-  NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern:@"window.__attentive_domain='(.*?).attn.tv'" options:0 error:&error];
+  NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern:@"='([a-z0-9-]+)[.]attn[.]tv'" options:0 error:&error];
 
   if (error) {
     NSLog(@"Error building the domain regex. Error: '%@'", [error description]);
@@ -509,6 +509,8 @@ static NSString* const EVENT_TYPE_CUSTOM_EVENT = @"ce";
     NSLog(@"No match found for Attentive domain in the tag.");
     return nil;
   }
+
+  NSLog(@"Found attn domain is: %@", [tag substringWithRange:domainRange]);
 
   return [tag substringWithRange:domainRange];
 }

--- a/Tests/ATTNAPITest.m
+++ b/Tests/ATTNAPITest.m
@@ -86,7 +86,7 @@ static NSString* const TEST_GEO_ADJUSTED_DOMAIN = @"some-domain-ca";
   if ([[url absoluteString] containsString:@"cdn.attn.tv"]) {
     _didCallDtag = true;
     return [[NSURLSessionDataTaskMock alloc] initWithHandler:^(NSData* data, NSURLResponse* response, NSError* error) {
-      completionHandler([[NSString stringWithFormat:@"window.__attentive_domain='%@.attn.tv'", TEST_GEO_ADJUSTED_DOMAIN] dataUsingEncoding:NSUTF8StringEncoding], [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:nil headerFields:nil], nil);
+      completionHandler([[NSString stringWithFormat:@"a='%@.attn.tv'", TEST_GEO_ADJUSTED_DOMAIN] dataUsingEncoding:NSUTF8StringEncoding], [[NSHTTPURLResponse alloc] initWithURL:url statusCode:200 HTTPVersion:nil headerFields:nil], nil);
     }];
   }
 


### PR DESCRIPTION
Update regex to account for dtags that are compiled with the attn domain set to a variable, instead of directly on the window.

Dtags come from compiled JS, so when we update the compilation, the naming of the attn domain variable might change. We need to insulate our matching against this.

will extract domain successfully from:
- legacy dtag `<sampleDtagContent>,window.__attentive_domain='test-company-ca.attn.tv',`
- manually edited dtag `a='testcompany.attn.tv',<sampleDtagContent>,window.__attentive_domain='testcompany.attn.tv',`
- modern dtag `<sampleDtagContent>,a='test-company.attn.tv',`