### PR TITLE
Update test setup string to match existing accessibility labels

### DIFF
--- a/Example/CreativeUITest/CreativeUITest.m
+++ b/Example/CreativeUITest/CreativeUITest.m
@@ -79,7 +79,7 @@
     XCTAssertTrue([smsApp.textFields[@"Message"] waitForExistenceWithTimeout:5.0]);
     XCTAssertTrue([smsApp.textFields[@"Message"].value containsString:@"Send this text to subscribe to recurring automated personalized marketing alerts (e.g. cart reminders) from Attentive Mobile Apps Test"]);
   }
-} 
+}
 
 
 - (void)testLoadCreative_clickPrivacyLink_opensPrivacyPageInWebApp {

--- a/Example/CreativeUITest/CreativeUITest.m
+++ b/Example/CreativeUITest/CreativeUITest.m
@@ -41,8 +41,8 @@
   [app.buttons[@"Push me for Creative!"] tap];
 
   // Close the creative
-  XCTAssertTrue([app.webViews.buttons[@"close"] waitForExistenceWithTimeout:5.0]);
-  [app.webViews.buttons[@"close"] tap];
+  XCTAssertTrue([app.webViews.buttons[@"Dismiss this popup"] waitForExistenceWithTimeout:5.0]);
+  [app.webViews.buttons[@"Dismiss this popup"] tap];
 
   // Assert that the creative is closed
   XCTAssertTrue([app.buttons[@"Push me for Creative!"] waitForExistenceWithTimeout:5.0]);
@@ -79,7 +79,7 @@
     XCTAssertTrue([smsApp.textFields[@"Message"] waitForExistenceWithTimeout:5.0]);
     XCTAssertTrue([smsApp.textFields[@"Message"].value containsString:@"Send this text to subscribe to recurring automated personalized marketing alerts (e.g. cart reminders) from Attentive Mobile Apps Test"]);
   }
-}
+} 
 
 
 - (void)testLoadCreative_clickPrivacyLink_opensPrivacyPageInWebApp {
@@ -101,7 +101,7 @@
   [app.buttons[@"Push me for Creative!"] tap];
 
   // Verify debug page shows
-  XCTAssertTrue([app.staticTexts[@"Debug output JSON:"] waitForExistenceWithTimeout:5.0]);
+  XCTAssertTrue([app.staticTexts[@"Debug output JSON"] waitForExistenceWithTimeout:5.0]);
 }
 
 


### PR DESCRIPTION
We updated our accessibility labels, which affected the test suite. This PR re-aligns that functionality. 