### PR TITLE
[APP-2866] Update iOS Privacy Policy based on new requirements from Apple

### DIFF
--- a/ExampleSwift/ExampleSwift.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ExampleSwift/ExampleSwift.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ExampleSwift/ExampleSwift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ExampleSwift/ExampleSwift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ExampleSwift/ExampleSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ExampleSwift/ExampleSwift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "62dc5f9606142e259275d938027b59c944959560f934dd2210d0e0cc4420a08d",
+  "pins" : [
+    {
+      "identity" : "attentive-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attentive-mobile/attentive-ios-sdk",
+      "state" : {
+        "branch" : "main",
+        "revision" : "ab9b8725f97cd9ea70b548b8adac1c6b54a73bfe"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,8 @@ let package = Package(
 	targets: [
 		.target(
 			name: "ATTNSDKFramework",
-			path: "Sources/"
+			path: "Sources/",
+			resources: [ .process("Resources") ]
 		)
 	]
 )

--- a/Sources/Internal/ATTNVersion.h
+++ b/Sources/Internal/ATTNVersion.h
@@ -10,6 +10,6 @@
 
 // This should match the Podspec version
 // If there's a way to define the version in one place and use it both here and the Podspec then we should do it - I don't know of a way
-NSString* const SDK_VERSION = @"0.5.0";
+NSString* const SDK_VERSION = @"0.5.1";
 
 #endif /* ATTNVersion_h */

--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/attentive-ios-sdk.podspec
+++ b/attentive-ios-sdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'attentive-ios-sdk'
-  s.version          = '0.5.0'
+  s.version          = '0.5.1'
   s.summary          = 'Attentive IOS SDK'
 
 # This description is used to generate tags and improve search results.
@@ -32,9 +32,9 @@ The Attentive IOS SDK provides the functionality to render Attentive signup unit
 
   s.source_files = 'Sources/**/*'
   
-  # s.resource_bundles = {
-  #   'attentive-ios-sdk' => ['attentive-ios-sdk/Assets/*.png']
-  # }
+  s.resource_bundles = {
+    'attentive-ios-sdk' => ['Resources/PrivacyInfo.xcprivacy']
+  }
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'

--- a/attentive-ios-sdk.podspec
+++ b/attentive-ios-sdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'attentive-ios-sdk'
-  s.version          = '0.5.1'
+  s.version          = '0.5.0'
   s.summary          = 'Attentive IOS SDK'
 
 # This description is used to generate tags and improve search results.
@@ -32,9 +32,9 @@ The Attentive IOS SDK provides the functionality to render Attentive signup unit
 
   s.source_files = 'Sources/**/*'
   
-  s.resource_bundles = {
-    'attentive-ios-sdk' => ['Resources/PrivacyInfo.xcprivacy']
-  }
+  # s.resource_bundles = {
+  #   'attentive-ios-sdk' => ['attentive-ios-sdk/Assets/*.png']
+  # }
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		69BA6D6F29BA3B1700CCA573 /* ATTNCreativeUrlFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 69BA6D6E29BA3B1700CCA573 /* ATTNCreativeUrlFormatterTest.m */; };
 		69BA6D7129BA3B5900CCA573 /* ATTNCreativeUrlFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 69BA6D7029BA3B5900CCA573 /* ATTNCreativeUrlFormatter.m */; };
 		69BA6D7329BA3B9000CCA573 /* ATTNCreativeUrlFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 69BA6D7229BA3B9000CCA573 /* ATTNCreativeUrlFormatter.h */; };
+		FBF5C2942BEE65830022FE6B /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = FBF5C2932BEE65830022FE6B /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -163,6 +164,7 @@
 		69BA6D6E29BA3B1700CCA573 /* ATTNCreativeUrlFormatterTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ATTNCreativeUrlFormatterTest.m; path = Tests/ATTNCreativeUrlFormatterTest.m; sourceTree = "<group>"; };
 		69BA6D7029BA3B5900CCA573 /* ATTNCreativeUrlFormatter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ATTNCreativeUrlFormatter.m; path = Sources/ATTNCreativeUrlFormatter.m; sourceTree = "<group>"; };
 		69BA6D7229BA3B9000CCA573 /* ATTNCreativeUrlFormatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ATTNCreativeUrlFormatter.h; path = Sources/ATTNCreativeUrlFormatter.h; sourceTree = "<group>"; };
+		FBF5C2932BEE65830022FE6B /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -232,6 +234,7 @@
 		58332ED9292EC21100B1ECF3 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				FBF5C2922BEE65650022FE6B /* Resources */,
 				58C9CA5429E5EE6700EF036E /* Internal */,
 				5806DE772977570100C18FFA /* Events */,
 				6972874E29353FEA003F1BEC /* ATTNPersistentStorage.h */,
@@ -336,6 +339,15 @@
 			);
 			name = Internal;
 			path = Sources/Internal;
+			sourceTree = "<group>";
+		};
+		FBF5C2922BEE65650022FE6B /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				FBF5C2932BEE65830022FE6B /* PrivacyInfo.xcprivacy */,
+			);
+			name = Resources;
+			path = Sources/Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -452,6 +464,7 @@
 			files = (
 				58332EE1292EC26000B1ECF3 /* LICENSE in Resources */,
 				58332EE0292EC26000B1ECF3 /* README.md in Resources */,
+				FBF5C2942BEE65830022FE6B /* PrivacyInfo.xcprivacy in Resources */,
 				58332EDD292EC25500B1ECF3 /* attentive-ios-sdk.podspec in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [x] Other

[Jira Link](https://attentivemobile.atlassian.net/browse/APP-2866)

## What's new?
Added PrivacyInfo.xcprivacy to include a description of usages of UserDefaults within the SDK. As per Apple [Documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc), **CA92.1** included since it is not modifying any other external App data. 

Bumped version to 0.5.1.

**Note:** These changes are for SPM only.

## Testing

- Generated XCFramework to verify if the .xcpricacy is included in the framework bundle
- Integrated into the Sample App with SPM to verify if the .xcpricacy exists as well.

```

// Iphone Device Archive 
xcodebuild archive \
-scheme attentive-ios-sdk-framework \
-configuration Release \
-destination 'generic/platform=iOS' \
-archivePath './build/attentive-ios-sdk-framework.framework-iphoneos.xcarchive' \
SKIP_INSTALL=NO \
BUILD_LIBRARIES_FOR_DISTRIBUTION=YES

// Simulator Archive 
xcodebuild archive \
-scheme attentive-ios-sdk-framework \
-configuration Release \
-destination 'generic/platform=iOS Simulator' \
-archivePath './build/attentive-ios-sdk-framework.framework-iphonesimulator.xcarchive' \
SKIP_INSTALL=NO \
BUILD_LIBRARIES_FOR_DISTRIBUTION=YES

// Generate XCFramework
xcodebuild -create-xcframework \
-framework './build/attentive-ios-sdk-framework.framework-iphoneos.xcarchive/Products/Library/Frameworks/attentive_ios_sdk_framework.framework' \
-framework './build/attentive-ios-sdk-framework.framework-iphonesimulator.xcarchive/Products/Library/Frameworks/attentive_ios_sdk_framework.framework' \
-output './build/attentive-ios-sdk-framework.xcframework'

```

## Screenshots

### XCFramework generated by scripts
![Screenshot 2024-05-13 at 9 33 06 AM](https://github.com/attentive-mobile/attentive-ios-sdk/assets/11541905/36bb8a4e-4f6e-4091-aaa2-1e2869d5a0b2)

### SPM Integration with custom branch
![Screenshot 2024-05-13 at 9 34 05 AM](https://github.com/attentive-mobile/attentive-ios-sdk/assets/11541905/7683704c-f263-4e88-ade0-769f96e67da2)
