### PR TITLE
[APP-2866] Update iOS Privacy Policy based on new requirements from Apple

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
     branches: 
       - main
       - feature/*
+      - release/*
   workflow_dispatch:
 
 concurrency:

--- a/Sources/Internal/ATTNVersion.h
+++ b/Sources/Internal/ATTNVersion.h
@@ -10,6 +10,6 @@
 
 // This should match the Podspec version
 // If there's a way to define the version in one place and use it both here and the Podspec then we should do it - I don't know of a way
-NSString* const SDK_VERSION = @"0.4.4";
+NSString* const SDK_VERSION = @"0.4.5";
 
 #endif /* ATTNVersion_h */

--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/attentive-ios-sdk.podspec
+++ b/attentive-ios-sdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'attentive-ios-sdk'
-  s.version          = '0.4.4'
+  s.version          = '0.4.5'
   s.summary          = 'Attentive IOS SDK'
 
 # This description is used to generate tags and improve search results.
@@ -32,9 +32,8 @@ The Attentive IOS SDK provides the functionality to render Attentive signup unit
 
   s.source_files = 'Sources/**/*'
   
-  # s.resource_bundles = {
-  #   'attentive-ios-sdk' => ['attentive-ios-sdk/Assets/*.png']
-  # }
+   s.resource_bundles = {'attentive-ios-sdk' => ['Sources/**/PrivacyInfo.xcprivacy']
+   }
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'

--- a/attentive-ios-sdk.podspec
+++ b/attentive-ios-sdk.podspec
@@ -32,8 +32,7 @@ The Attentive IOS SDK provides the functionality to render Attentive signup unit
 
   s.source_files = 'Sources/**/*'
   
-   s.resource_bundles = {'attentive-ios-sdk' => ['Sources/**/PrivacyInfo.xcprivacy']
-   }
+  s.resource_bundles = {'attentive-ios-sdk' => ['Sources/Resources/PrivacyInfo.xcprivacy']}
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		69BA6D6F29BA3B1700CCA573 /* ATTNCreativeUrlFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 69BA6D6E29BA3B1700CCA573 /* ATTNCreativeUrlFormatterTest.m */; };
 		69BA6D7129BA3B5900CCA573 /* ATTNCreativeUrlFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 69BA6D7029BA3B5900CCA573 /* ATTNCreativeUrlFormatter.m */; };
 		69BA6D7329BA3B9000CCA573 /* ATTNCreativeUrlFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 69BA6D7229BA3B9000CCA573 /* ATTNCreativeUrlFormatter.h */; };
+		FB45B2652BF29EB00042A482 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = FB45B2632BF29EB00042A482 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -107,7 +108,7 @@
 		58332ED0292EC20700B1ECF3 /* ATTNSDK.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ATTNSDK.m; path = Sources/ATTNSDK.m; sourceTree = "<group>"; };
 		58332ED1292EC20700B1ECF3 /* ATTNSDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ATTNSDK.h; path = Sources/ATTNSDK.h; sourceTree = "<group>"; };
 		58332ED2292EC20700B1ECF3 /* ATTNUserIdentity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ATTNUserIdentity.h; path = Sources/ATTNUserIdentity.h; sourceTree = "<group>"; };
-		58332EDC292EC25500B1ECF3 /* attentive-ios-sdk.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "attentive-ios-sdk.podspec"; sourceTree = "<group>"; };
+		58332EDC292EC25500B1ECF3 /* attentive-ios-sdk.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "attentive-ios-sdk.podspec"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		58332EDE292EC26000B1ECF3 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		58332EDF292EC26000B1ECF3 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		583C29F829C101A300EABBC9 /* ATTNUserAgentBuilderTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ATTNUserAgentBuilderTest.m; path = Tests/ATTNUserAgentBuilderTest.m; sourceTree = "<group>"; };
@@ -163,6 +164,7 @@
 		69BA6D6E29BA3B1700CCA573 /* ATTNCreativeUrlFormatterTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ATTNCreativeUrlFormatterTest.m; path = Tests/ATTNCreativeUrlFormatterTest.m; sourceTree = "<group>"; };
 		69BA6D7029BA3B5900CCA573 /* ATTNCreativeUrlFormatter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = ATTNCreativeUrlFormatter.m; path = Sources/ATTNCreativeUrlFormatter.m; sourceTree = "<group>"; };
 		69BA6D7229BA3B9000CCA573 /* ATTNCreativeUrlFormatter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = ATTNCreativeUrlFormatter.h; path = Sources/ATTNCreativeUrlFormatter.h; sourceTree = "<group>"; };
+		FB45B2632BF29EB00042A482 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -232,6 +234,7 @@
 		58332ED9292EC21100B1ECF3 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				FB45B2642BF29EB00042A482 /* Resources */,
 				58C9CA5429E5EE6700EF036E /* Internal */,
 				5806DE772977570100C18FFA /* Events */,
 				6972874E29353FEA003F1BEC /* ATTNPersistentStorage.h */,
@@ -336,6 +339,15 @@
 			);
 			name = Internal;
 			path = Sources/Internal;
+			sourceTree = "<group>";
+		};
+		FB45B2642BF29EB00042A482 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				FB45B2632BF29EB00042A482 /* PrivacyInfo.xcprivacy */,
+			);
+			name = Resources;
+			path = Sources/Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -452,6 +464,7 @@
 			files = (
 				58332EE1292EC26000B1ECF3 /* LICENSE in Resources */,
 				58332EE0292EC26000B1ECF3 /* README.md in Resources */,
+				FB45B2652BF29EB00042A482 /* PrivacyInfo.xcprivacy in Resources */,
 				58332EDD292EC25500B1ECF3 /* attentive-ios-sdk.podspec in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [x] Other

[Jira Link](https://attentivemobile.atlassian.net/browse/APP-2866)

## What's new?
Added PrivacyInfo.xcprivacy to include a description of usages of UserDefaults within the SDK. As per Apple [Documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc), **CA92.1** included since it is not modifying any other external App data. 

Bumped version to 0.4.5.

## Testing

- Generated XCFramework to verify if the .xcpricacy is included in the framework bundle
- Integrated into the Example App with pod install

```

// Iphone Device Archive 
xcodebuild archive \
-scheme attentive-ios-sdk-framework \
-configuration Release \
-destination 'generic/platform=iOS' \
-archivePath './build/attentive-ios-sdk-framework.framework-iphoneos.xcarchive' \
SKIP_INSTALL=NO \
BUILD_LIBRARIES_FOR_DISTRIBUTION=YES

// Simulator Archive 
xcodebuild archive \
-scheme attentive-ios-sdk-framework \
-configuration Release \
-destination 'generic/platform=iOS Simulator' \
-archivePath './build/attentive-ios-sdk-framework.framework-iphonesimulator.xcarchive' \
SKIP_INSTALL=NO \
BUILD_LIBRARIES_FOR_DISTRIBUTION=YES

// Generate XCFramework
xcodebuild -create-xcframework \
-framework './build/attentive-ios-sdk-framework.framework-iphoneos.xcarchive/Products/Library/Frameworks/attentive_ios_sdk_framework.framework' \
-framework './build/attentive-ios-sdk-framework.framework-iphonesimulator.xcarchive/Products/Library/Frameworks/attentive_ios_sdk_framework.framework' \
-output './build/attentive-ios-sdk-framework.xcframework'

```

## Screenshots

### XCFramework generated by scripts
![cocoapods](https://github.com/attentive-mobile/attentive-ios-sdk/assets/11541905/3957684d-5e10-47e2-b684-3d0bf622fb06)

