### PR TITLE
[APP-2881] Add a log level of verbose/standard/light to the SDK Config

### DIFF
--- a/Example/CreativeUITest/CreativeUITest.swift
+++ b/Example/CreativeUITest/CreativeUITest.swift
@@ -30,7 +30,7 @@ final class CreativeUITest: XCTestCase, BaseXCTestCase {
 
     HomePage
       .tapOnPushMeToCreative()
-      .addDelay(seconds: 4)
+      .addDelay(seconds: 5)
 
     CreativePage
       .tapOnCloseCreative()

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
   name: "ATTNSDKFramework",
-  platforms: [.iOS(.v12)],
+  platforms: [.iOS(.v14)],
   products: [
     .library(name: "ATTNSDKFramework", targets: ["ATTNSDKFramework", "ATTNSDKFrameworkObjc"])
   ],

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -64,7 +64,7 @@ final class ATTNAPI: ATTNAPIProtocol {
       }
 
       guard let geoAdjustedDomain = geoAdjustedDomain else { return }
-      Loggers.network.trace("Successfully returned geoAdjustedDomain: \(geoAdjustedDomain, privacy: .public)")
+      Loggers.network.debug("Successfully returned geoAdjustedDomain: \(geoAdjustedDomain, privacy: .public)")
       self?.sendEventInternal(event: event, userIdentity: userIdentity, domain: geoAdjustedDomain, callback: callback)
     }
   }
@@ -91,7 +91,7 @@ fileprivate extension ATTNAPI {
       return
     }
 
-    Loggers.event.trace("Building Event URL: \(url)")
+    Loggers.event.debug("Building Event URL: \(url)")
 
     var urlRequest = URLRequest(url: url)
     urlRequest.httpMethod = "POST"
@@ -102,7 +102,7 @@ fileprivate extension ATTNAPI {
       } else if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode > 400 {
         Loggers.event.error("Error sending the event. Incorrect status code: '\(httpResponse.statusCode)'")
       } else {
-        Loggers.event.trace("Successfully sent event of type '\(request.eventNameAbbreviation)'")
+        Loggers.event.debug("Successfully sent event of type '\(request.eventNameAbbreviation)'")
       }
 
       callback?(data, url, response, error)
@@ -117,7 +117,7 @@ fileprivate extension ATTNAPI {
       return
     }
 
-    Loggers.event.trace("Building Identity Event URL: \(url)")
+    Loggers.event.debug("Building Identity Event URL: \(url)")
 
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
@@ -128,7 +128,7 @@ fileprivate extension ATTNAPI {
       } else if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode > 400 {
         Loggers.event.error("Error sending the event. Incorrect status code: '\(httpResponse.statusCode)'")
       } else {
-        Loggers.event.trace("Successfully sent user identity event")
+        Loggers.event.debug("Successfully sent user identity event")
       }
 
       callback?(data, url, response, error)
@@ -175,11 +175,11 @@ extension ATTNAPI {
       return
     }
 
-    Loggers.network.trace("Getting the geoAdjustedDomain for domain '\(domain)'...")
+    Loggers.network.debug("Getting the geoAdjustedDomain for domain '\(domain)'...")
 
     let urlString = String(format: RequestConstants.dtagUrlFormat, domain)
     guard let url = URL(string: urlString) else {
-      Loggers.network.trace("Invalid URL format for domain '\(domain)'")
+      Loggers.network.debug("Invalid URL format for domain '\(domain)'")
       completionHandler(nil, NSError(domain: "com.attentive.API", code: NSURLErrorBadURL, userInfo: nil))
       return
     }

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -44,6 +44,7 @@ final class ATTNAPI: ATTNAPIProtocol {
     getGeoAdjustedDomain(domain: domain) { [weak self] geoAdjustedDomain, error in
       if let error = error {
         Loggers.network.error("Error sending user identity: \(error.localizedDescription)")
+        return
       }
 
       guard let geoAdjustedDomain = geoAdjustedDomain else { return }
@@ -90,16 +91,18 @@ fileprivate extension ATTNAPI {
       return
     }
 
+    Loggers.event.trace("Building Event URL: \(url)")
+
     var urlRequest = URLRequest(url: url)
     urlRequest.httpMethod = "POST"
 
     let task = urlSession.dataTask(with: urlRequest) { data, response, error in
       if let error = error {
-        Loggers.network.error("Error sending for event '\(request.eventNameAbbreviation)'. Error: '\(error.localizedDescription)'")
+        Loggers.event.error("Error sending for event '\(request.eventNameAbbreviation)'. Error: '\(error.localizedDescription)'")
       } else if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode > 400 {
-        Loggers.network.error("Error sending the event. Incorrect status code: '\(httpResponse.statusCode)'")
+        Loggers.event.error("Error sending the event. Incorrect status code: '\(httpResponse.statusCode)'")
       } else {
-        Loggers.network.trace("Successfully sent event of type '\(request.eventNameAbbreviation)'")
+        Loggers.event.trace("Successfully sent event of type '\(request.eventNameAbbreviation)'")
       }
 
       callback?(data, url, response, error)
@@ -114,16 +117,18 @@ fileprivate extension ATTNAPI {
       return
     }
 
+    Loggers.event.trace("Building Identity Event URL: \(url)")
+
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
 
     let task = urlSession.dataTask(with: request) { data, response, error in
       if let error = error {
-        Loggers.network.error("Error sending user identity. Error: '\(error.localizedDescription)'")
+        Loggers.event.error("Error sending user identity. Error: '\(error.localizedDescription)'")
       } else if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode > 400 {
-        Loggers.network.error("Error sending the event. Incorrect status code: '\(httpResponse.statusCode)'")
+        Loggers.event.error("Error sending the event. Incorrect status code: '\(httpResponse.statusCode)'")
       } else {
-        Loggers.network.trace("Successfully sent user identity event")
+        Loggers.event.trace("Successfully sent user identity event")
       }
 
       callback?(data, url, response, error)

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -187,7 +187,7 @@ extension ATTNAPI {
     let request = URLRequest(url: url)
     let task = urlSession.dataTask(with: request) { [weak self] data, response, error in
       if let error = error {
-        Loggers.network.error("Error getting the geo-adjusted domain. Error: '\(error.localizedDescription)'")
+        Loggers.network.error("Error getting the geo-adjusted domain for \(domain). Error: '\(error.localizedDescription)'")
         completionHandler(nil, error)
         return
       }
@@ -199,7 +199,7 @@ extension ATTNAPI {
       }
 
       guard httpResponse.statusCode == 200, let data = data else {
-        Loggers.network.error("Error getting the geo-adjusted domain. Incorrect status code: '\(httpResponse.statusCode)'")
+        Loggers.network.error("Error getting the geo-adjusted domain for \(domain). Incorrect status code: '\(httpResponse.statusCode)'")
         completionHandler(nil, NSError(domain: "com.attentive.API", code: NSURLErrorBadServerResponse, userInfo: nil))
         return
       }

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -43,8 +43,7 @@ final class ATTNAPI: ATTNAPIProtocol {
   func send(userIdentity: ATTNUserIdentity, callback: ATTNAPICallback?) {
     getGeoAdjustedDomain(domain: domain) { [weak self] geoAdjustedDomain, error in
       if let error = error {
-        NSLog("Error sending user identity: '%@'", error.localizedDescription)
-        return
+        Loggers.network.error("Error sending user identity: \(error.localizedDescription)")
       }
 
       guard let geoAdjustedDomain = geoAdjustedDomain else { return }
@@ -59,11 +58,12 @@ final class ATTNAPI: ATTNAPIProtocol {
   func send(event: ATTNEvent, userIdentity: ATTNUserIdentity, callback: ATTNAPICallback?) {
     getGeoAdjustedDomain(domain: domain) { [weak self] geoAdjustedDomain, error in
       if let error = error {
-        NSLog("Error sending user identity: '%@'", error.localizedDescription)
+        Loggers.network.error("Error sending event: \(error.localizedDescription)")
         return
       }
 
       guard let geoAdjustedDomain = geoAdjustedDomain else { return }
+      Loggers.network.trace("Successfully returned geoAdjustedDomain: \(geoAdjustedDomain, privacy: .public)")
       self?.sendEventInternal(event: event, userIdentity: userIdentity, domain: geoAdjustedDomain, callback: callback)
     }
   }
@@ -86,7 +86,7 @@ fileprivate extension ATTNAPI {
 
   func sendEventInternalForRequest(request: ATTNEventRequest, userIdentity: ATTNUserIdentity, domain: String, callback: ATTNAPICallback?) {
     guard let url = eventUrlProvider.buildUrl(for: request, userIdentity: userIdentity, domain: domain) else {
-      NSLog("Invalid URL constructed for event request.")
+      Loggers.event.error("Invalid URL constructed for event request.")
       return
     }
 
@@ -94,17 +94,13 @@ fileprivate extension ATTNAPI {
     urlRequest.httpMethod = "POST"
 
     let task = urlSession.dataTask(with: urlRequest) { data, response, error in
-      let message: String
-
       if let error = error {
-        message = "Error sending for event '\(request.eventNameAbbreviation)'. Error: '\(error.localizedDescription)'"
+        Loggers.network.error("Error sending for event '\(request.eventNameAbbreviation)'. Error: '\(error.localizedDescription)'")
       } else if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode > 400 {
-        message = "Error sending the event. Incorrect status code: '\(httpResponse.statusCode)'"
+        Loggers.network.error("Error sending the event. Incorrect status code: '\(httpResponse.statusCode)'")
       } else {
-        message = "Successfully sent event of type '\(request.eventNameAbbreviation)'"
+        Loggers.network.trace("Successfully sent event of type '\(request.eventNameAbbreviation)'")
       }
-
-      NSLog("%@", message)
 
       callback?(data, url, response, error)
     }
@@ -114,7 +110,7 @@ fileprivate extension ATTNAPI {
 
   func sendUserIdentityInternal(userIdentity: ATTNUserIdentity, domain: String, callback: ATTNAPICallback?) {
     guard let url = eventUrlProvider.buildUrl(for: userIdentity, domain: domain) else {
-      NSLog("Invalid URL constructed for user identity.")
+      Loggers.event.error("Invalid URL constructed for user identity.")
       return
     }
 
@@ -122,17 +118,13 @@ fileprivate extension ATTNAPI {
     request.httpMethod = "POST"
 
     let task = urlSession.dataTask(with: request) { data, response, error in
-      let message: String
-
       if let error = error {
-        message = "Error sending user identity. Error: '\(error.localizedDescription)'"
+        Loggers.network.error("Error sending user identity. Error: '\(error.localizedDescription)'")
       } else if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode > 400 {
-        message = "Error sending the event. Incorrect status code: '\(httpResponse.statusCode)'"
+        Loggers.network.error("Error sending the event. Incorrect status code: '\(httpResponse.statusCode)'")
       } else {
-        message = "Successfully sent user identity event"
+        Loggers.network.trace("Successfully sent user identity event")
       }
-
-      NSLog("%@", message)
 
       callback?(data, url, response, error)
     }
@@ -146,26 +138,26 @@ fileprivate extension ATTNAPI {
       let matchesCount = regex.numberOfMatches(in: tag, options: [], range: NSRange(location: 0, length: tag.utf16.count))
 
       guard matchesCount >= 1 else {
-        NSLog("No Attentive domain found in the tag")
+        Loggers.creative.debug("No Attentive domain found in the tag")
         return nil
       }
 
       guard let match = regex.firstMatch(in: tag, options: [], range: NSRange(location: 0, length: tag.utf16.count)) else {
-        NSLog("No Attentive domain regex match object returned.")
+        Loggers.creative.debug("No Attentive domain regex match object returned.")
         return nil
       }
 
       let domainRange = match.range(at: 1)
       guard domainRange.location != NSNotFound, let range = Range(domainRange, in: tag) else {
-        NSLog("No match found for Attentive domain in the tag.")
+        Loggers.creative.debug("No match found for Attentive domain in the tag.")
         return nil
       }
 
       let regionalizedDomain = String(tag[range])
-      NSLog("Identified regionalized attentive domain: %@", regionalizedDomain)
+      Loggers.creative.debug("Identified regionalized attentive domain: \(regionalizedDomain)")
       return regionalizedDomain
     } catch {
-      NSLog("Error building the domain regex. Error: '%@'", error.localizedDescription)
+      Loggers.creative.debug("Error building the domain regex. Error: '\(error.localizedDescription)'")
       return nil
     }
   }
@@ -178,11 +170,11 @@ extension ATTNAPI {
       return
     }
 
-    NSLog("Getting the geoAdjustedDomain for domain '%@'...", domain)
+    Loggers.network.trace("Getting the geoAdjustedDomain for domain '\(domain)'...")
 
     let urlString = String(format: RequestConstants.dtagUrlFormat, domain)
     guard let url = URL(string: urlString) else {
-      NSLog("Invalid URL format for domain '%@'", domain)
+      Loggers.network.trace("Invalid URL format for domain '\(domain)'")
       completionHandler(nil, NSError(domain: "com.attentive.API", code: NSURLErrorBadURL, userInfo: nil))
       return
     }
@@ -190,19 +182,19 @@ extension ATTNAPI {
     let request = URLRequest(url: url)
     let task = urlSession.dataTask(with: request) { [weak self] data, response, error in
       if let error = error {
-        NSLog("Error getting the geo-adjusted domain. Error: '%@'", error.localizedDescription)
+        Loggers.network.error("Error getting the geo-adjusted domain. Error: '\(error.localizedDescription)'")
         completionHandler(nil, error)
         return
       }
 
       guard let httpResponse = response as? HTTPURLResponse else {
-        NSLog("Invalid response received.")
+        Loggers.network.error("Invalid response received.")
         completionHandler(nil, NSError(domain: "com.attentive.API", code: NSURLErrorUnknown, userInfo: nil))
         return
       }
 
       guard httpResponse.statusCode == 200, let data = data else {
-        NSLog("Error getting the geo-adjusted domain. Incorrect status code: '%ld'", httpResponse.statusCode)
+        Loggers.network.error("Error getting the geo-adjusted domain. Incorrect status code: '\(httpResponse.statusCode)'")
         completionHandler(nil, NSError(domain: "com.attentive.API", code: NSURLErrorBadServerResponse, userInfo: nil))
         return
       }
@@ -211,6 +203,7 @@ extension ATTNAPI {
       guard let geoAdjustedDomain = ATTNAPI.extractDomainFromTag(dataString ?? "") else { return }
 
       if geoAdjustedDomain.isEmpty {
+        Loggers.network.error("Invalid empty geo-adjusted domain")
         let error = NSError(domain: "com.attentive.API", code: NSURLErrorBadServerResponse, userInfo: nil)
         completionHandler(nil, error)
         return

--- a/Sources/ATTNParameterValidation.swift
+++ b/Sources/ATTNParameterValidation.swift
@@ -18,13 +18,13 @@ struct ATTNParameterValidation {
 
   static func verifyNotNil(_ inputValue: NSObject?, inputName: String) {
     guard isNil(inputValue) else { return }
-    NSLog("Input was nil; %@ should be non-nil", inputName)
+    Loggers.event.debug("Input was nil; \(inputName) should be non-nil")
   }
 
   static func verifyStringOrNil(_ inputValue: NSObject?, inputName: String) {
     guard isNil(inputValue) else { return }
     guard !isString(inputValue) || isEmpty(inputName) else { return }
-    NSLog("Identifier %@ should be a non-empty NSString", inputName)
+    Loggers.event.debug("Identifier \(inputName) should be a non-empty NSString")
   }
 
   static func verify1DStringDictionaryOrNil(_ inputValue: NSDictionary?, inputName: String) {

--- a/Sources/ATTNUserAgentBuilder.swift
+++ b/Sources/ATTNUserAgentBuilder.swift
@@ -20,7 +20,7 @@ class ATTNUserAgentBuilder: ATTNUserAgentBuilderProtocol {
 
   func buildUserAgent() -> String {
     // We replace the spaces with dashes for the app name because spaces in a User-Agent represent a new "product", so app names that have spaces are harder to parse if we don't replace spaces with dashes
-    String(
+    let userAgent = String(
       format: "%@/%@.%@ (%@; %@ %@) %@/%@",
       appInfo.getFormattedAppName(),
       appInfo.getAppVersion(),
@@ -31,5 +31,9 @@ class ATTNUserAgentBuilder: ATTNUserAgentBuilderProtocol {
       appInfo.getSdkName(),
       appInfo.getSdkVersion()
     )
+
+    Loggers.event.debug("Created User Agent: \(userAgent)")
+
+    return userAgent
   }
 }

--- a/Sources/ATTNVisitorService.swift
+++ b/Sources/ATTNVisitorService.swift
@@ -23,12 +23,17 @@ struct ATTNVisitorService {
       return createNewVisitorId()
     }
 
+    Loggers.event.info("Obtained existing visitor id: \(existingVisitorId, privacy: .public)")
+
     return existingVisitorId
   }
 
   func createNewVisitorId() -> String {
     let newVisitorId = generateVisitorId()
     persistentStorage.save(newVisitorId as NSObject, forKey: Constants.visitorIdKey)
+
+    Loggers.event.info("Generated new visitor id: \(newVisitorId, privacy: .public)")
+
     return newVisitorId
   }
 

--- a/Sources/ATTNVisitorService.swift
+++ b/Sources/ATTNVisitorService.swift
@@ -23,7 +23,7 @@ struct ATTNVisitorService {
       return createNewVisitorId()
     }
 
-    Loggers.event.info("Obtained existing visitor id: \(existingVisitorId, privacy: .public)")
+    Loggers.event.info("Obtained existing visitor id: \(existingVisitorId)")
 
     return existingVisitorId
   }
@@ -32,7 +32,7 @@ struct ATTNVisitorService {
     let newVisitorId = generateVisitorId()
     persistentStorage.save(newVisitorId as NSObject, forKey: Constants.visitorIdKey)
 
-    Loggers.event.info("Generated new visitor id: \(newVisitorId, privacy: .public)")
+    Loggers.event.info("Generated new visitor id: \(newVisitorId)")
 
     return newVisitorId
   }

--- a/Sources/Helpers/ATTNJsonUtils.swift
+++ b/Sources/Helpers/ATTNJsonUtils.swift
@@ -18,7 +18,7 @@ struct ATTNJsonUtils: ATTNJsonUtilsProtocol {
     do {
       let jsonData = try JSONSerialization.data(withJSONObject: object, options: [])
       guard let jsonString = String(data: jsonData, encoding: .utf8) else {
-        NSLog("Could not encode JSON data to a string.")
+        Loggers.event.error("Could not encode JSON data to a string.")
         return nil
       }
       return jsonString

--- a/Sources/Helpers/ATTNJsonUtils.swift
+++ b/Sources/Helpers/ATTNJsonUtils.swift
@@ -8,17 +8,17 @@
 import Foundation
 
 protocol ATTNJsonUtilsProtocol {
-  static func convertObjectToJson(_ object: Any) throws -> String?
+  static func convertObjectToJson(_ object: Any, file: String, function: String) throws -> String?
 }
 
 struct ATTNJsonUtils: ATTNJsonUtilsProtocol {
   private init() { }
 
-  static func convertObjectToJson(_ object: Any) throws -> String? {
+  static func convertObjectToJson(_ object: Any, file: String = #file, function: String = #function) throws -> String? {
     do {
       let jsonData = try JSONSerialization.data(withJSONObject: object, options: [])
       guard let jsonString = String(data: jsonData, encoding: .utf8) else {
-        Loggers.event.error("Could not encode JSON data to a string.")
+        Loggers.event.error("Could not encode JSON data to a string. Function:\(function), File:\(file)")
         return nil
       }
       return jsonString

--- a/Sources/Helpers/Extension/ATTNAddToCartEvent+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNAddToCartEvent+Extension.swift
@@ -12,7 +12,7 @@ extension ATTNAddToCartEvent: ATTNEventRequestProvider {
     var eventRequests = [ATTNEventRequest]()
 
     if items.isEmpty {
-      Loggers.event.error("No items found in the AddToCart event.")
+      Loggers.event.debug("No items found in the AddToCart event.")
       return []
     }
 

--- a/Sources/Helpers/Extension/ATTNAddToCartEvent+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNAddToCartEvent+Extension.swift
@@ -12,7 +12,7 @@ extension ATTNAddToCartEvent: ATTNEventRequestProvider {
     var eventRequests = [ATTNEventRequest]()
 
     if items.isEmpty {
-      NSLog("No items found in the AddToCart event.")
+      Loggers.event.error("No items found in the AddToCart event.")
       return []
     }
 

--- a/Sources/Helpers/Extension/ATTNEvent+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNEvent+Extension.swift
@@ -11,7 +11,7 @@ import Foundation
 extension ATTNEvent {
   func convertEventToRequests() -> [ATTNEventRequest] {
     guard let provider = self as? ATTNEventRequestProvider else {
-      NSLog("ERROR: Unknown event type: \(type(of: self))")
+      Loggers.event.error("ERROR: Unknown event type: \(type(of: self))")
       return []
     }
 

--- a/Sources/Helpers/Extension/ATTNEvent+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNEvent+Extension.swift
@@ -11,7 +11,7 @@ import Foundation
 extension ATTNEvent {
   func convertEventToRequests() -> [ATTNEventRequest] {
     guard let provider = self as? ATTNEventRequestProvider else {
-      Loggers.event.error("ERROR: Unknown event type: \(type(of: self))")
+      Loggers.event.error("Unknown event type: \(type(of: self)). It can not be converted to EventRequest.")
       return []
     }
 

--- a/Sources/Helpers/Extension/ATTNEvent+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNEvent+Extension.swift
@@ -11,7 +11,7 @@ import Foundation
 extension ATTNEvent {
   func convertEventToRequests() -> [ATTNEventRequest] {
     guard let provider = self as? ATTNEventRequestProvider else {
-      Loggers.event.error("Unknown event type: \(type(of: self)). It can not be converted to EventRequest.")
+      Loggers.event.debug("Unknown event type: \(type(of: self)). It can not be converted to EventRequest.")
       return []
     }
 

--- a/Sources/Helpers/Extension/ATTNProductViewEvent+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNProductViewEvent+Extension.swift
@@ -12,7 +12,7 @@ extension ATTNProductViewEvent: ATTNEventRequestProvider {
     var eventRequests = [ATTNEventRequest]()
 
     if items.isEmpty {
-      NSLog("No items found in the ProductView event.")
+      Loggers.event.error("No items found in the ProductView event.")
       return []
     }
 

--- a/Sources/Helpers/Extension/ATTNProductViewEvent+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNProductViewEvent+Extension.swift
@@ -12,7 +12,7 @@ extension ATTNProductViewEvent: ATTNEventRequestProvider {
     var eventRequests = [ATTNEventRequest]()
 
     if items.isEmpty {
-      Loggers.event.error("No items found in the ProductView event.")
+      Loggers.event.debug("No items found in the ProductView event.")
       return []
     }
 

--- a/Sources/Helpers/Extension/ATTNPurchaseEvent+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNPurchaseEvent+Extension.swift
@@ -12,7 +12,7 @@ extension ATTNPurchaseEvent: ATTNEventRequestProvider {
     var eventRequests = [ATTNEventRequest]()
 
     guard !items.isEmpty else {
-      NSLog("No items found in the purchase event.")
+      Loggers.event.debug("No items found in the purchase event.")
       return []
     }
 

--- a/Sources/Helpers/Extension/ATTNSDK+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNSDK+Extension.swift
@@ -15,6 +15,7 @@ extension ATTNSDK {
   func initializeSkipFatigueOnCreatives() {
     if let skipFatigueValue = ProcessInfo.processInfo.environment[ATTNConstants.skipFatigueEnvKey] {
       self.skipFatigueOnCreative = skipFatigueValue.booleanValue
+      Loggers.creative.info("SKIP_FATIGUE_ON_CREATIVE: \(skipFatigueValue)")
     } else {
       self.skipFatigueOnCreative = false
     }

--- a/Sources/Helpers/Extension/ATTNUserIdentity+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNUserIdentity+Extension.swift
@@ -30,7 +30,7 @@ extension ATTNUserIdentity {
     do {
       return try ATTNJsonUtils.convertObjectToJson(ids) ?? "[]"
     } catch {
-      NSLog("Could not serialize the external vendor ids. Returning an empty array. Error: '\(error.localizedDescription)'")
+      Loggers.event.error("Could not serialize the external vendor ids. Returning an empty array. Error: '\(error.localizedDescription)'")
       return "[]"
     }
   }
@@ -56,7 +56,7 @@ extension ATTNUserIdentity {
     do {
       return try ATTNJsonUtils.convertObjectToJson(metadata) ?? "{}"
     } catch {
-      NSLog("Could not serialize the external vendor ids. Returning an empty blob. Error: '\(error.localizedDescription)'")
+      Loggers.event.error("Could not serialize the external vendor ids. Returning an empty blob. Error: '\(error.localizedDescription)'")
       return "{}"
     }
   }

--- a/Sources/Helpers/Logger.swift
+++ b/Sources/Helpers/Logger.swift
@@ -1,0 +1,17 @@
+//
+//  Logger.swift
+//  attentive-ios-sdk-framework
+//
+//  Created by Vladimir - Work on 2024-06-25.
+//
+
+import Foundation
+import os
+
+enum Loggers {
+  private static var subsystem: String { Bundle.main.bundleIdentifier ?? "com.attentive.attentive-ios-sdk-local" }
+
+  static var network = os.Logger(subsystem: subsystem, category: "network")
+  static var event = os.Logger(subsystem: subsystem, category: "event")
+  static var creative = os.Logger(subsystem: subsystem, category: "creative")
+}

--- a/Sources/Helpers/Logger.swift
+++ b/Sources/Helpers/Logger.swift
@@ -11,7 +11,7 @@ import os
 enum Loggers {
   private static var subsystem: String { Bundle.main.bundleIdentifier ?? "com.attentive.attentive-ios-sdk-local" }
 
-  static var network = os.Logger(subsystem: subsystem, category: "network")
-  static var event = os.Logger(subsystem: subsystem, category: "event")
-  static var creative = os.Logger(subsystem: subsystem, category: "creative")
+  static var network = Logger(subsystem: subsystem, category: "network")
+  static var event = Logger(subsystem: subsystem, category: "event")
+  static var creative = Logger(subsystem: subsystem, category: "creative")
 }

--- a/Sources/Public/ATTNEventTracker.swift
+++ b/Sources/Public/ATTNEventTracker.swift
@@ -20,6 +20,7 @@ public final class ATTNEventTracker: NSObject {
   @objc(setupWithSdk:)
   public static func setup(with sdk: ATTNSDK) {
     _sharedInstance = ATTNEventTracker(sdk: sdk)
+    Loggers.event.debug("ATTNEventTracker was initialized with SDK")
   }
 
   @available(swift, deprecated: 0.6, message: "Please use record(event: ATTNEvent) instead.")

--- a/Sources/Public/Events/ATTNCustomEvent.swift
+++ b/Sources/Public/Events/ATTNCustomEvent.swift
@@ -17,7 +17,7 @@ public final class ATTNCustomEvent: NSObject, ATTNEvent {
     ATTNParameterValidation.verifyNotNil(type as NSObject, inputName: "type")
     ATTNParameterValidation.verifyStringOrNil(type as NSObject, inputName: "type")
     if let invalidCharInType = ATTNCustomEvent.findInvalidCharacter(in: type) {
-      print("Invalid character \(invalidCharInType) in CustomEvent type \(type)")
+      Loggers.event.debug("Invalid character \(invalidCharInType) in CustomEvent type \(type)")
       return nil
     }
 

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -55,7 +55,7 @@ public final class ATTNSDK: NSObject {
   @objc public var skipFatigueOnCreative: Bool = false
 
   public init(domain: String, mode: ATTNSDKMode) {
-    Loggers.creative.trace("Init ATTNSDKFramework v\(ATTNConstants.sdkVersion), Mode: \(mode.rawValue), Domain: \(domain)")
+    Loggers.creative.debug("Init ATTNSDKFramework v\(ATTNConstants.sdkVersion), Mode: \(mode.rawValue), Domain: \(domain)")
 
     self.domain = domain
     self.mode = mode
@@ -119,9 +119,9 @@ public final class ATTNSDK: NSObject {
     guard self.domain != domain else { return }
     self.domain = domain
     api.update(domain: domain)
-    Loggers.creative.trace("Updated SDK with new domain: \(domain)")
+    Loggers.creative.debug("Updated SDK with new domain: \(domain)")
     api.send(userIdentity: userIdentity)
-    Loggers.creative.trace("Retrigger Identity Event with new domain '\(domain)'")
+    Loggers.creative.debug("Retrigger Identity Event with new domain '\(domain)'")
   }
 }
 
@@ -136,7 +136,7 @@ fileprivate extension ATTNSDK {
     webView = nil
     ATTNSDK.isCreativeOpen = false
     triggerHandler?(ATTNCreativeTriggerStatus.closed)
-    Loggers.creative.trace("Successfully closed creative")
+    Loggers.creative.debug("Successfully closed creative")
   }
 
   func launchCreative(
@@ -147,19 +147,19 @@ fileprivate extension ATTNSDK {
     parentView = view
     triggerHandler = handler
 
-    Loggers.creative.trace("Called showWebView in creativeSDK with domain: \(self.domain, privacy: .public)")
+    Loggers.creative.debug("Called showWebView in creativeSDK with domain: \(self.domain, privacy: .public)")
 
     guard !ATTNSDK.isCreativeOpen else {
-      Loggers.creative.trace("Attempted to trigger creative, but creative is currently open. Taking no action")
+      Loggers.creative.debug("Attempted to trigger creative, but creative is currently open. Taking no action")
       return
     }
 
     guard #available(iOS 14, *) else {
-      Loggers.creative.trace("Not showing the Attentive creative because the iOS version is too old.")
+      Loggers.creative.debug("Not showing the Attentive creative because the iOS version is too old.")
       triggerHandler?(ATTNCreativeTriggerStatus.notOpened)
       return
     }
-    Loggers.creative.trace("The iOS version is new enough, continuing to show the Attentive creative.")
+    Loggers.creative.debug("The iOS version is new enough, continuing to show the Attentive creative.")
 
     let creativePageUrl = urlBuilder.buildCompanyCreativeUrl(
       configuration: ATTNCreativeUrlConfig(
@@ -171,10 +171,10 @@ fileprivate extension ATTNSDK {
       )
     )
 
-    Loggers.creative.trace("Requesting creative page url: \(creativePageUrl)" )
+    Loggers.creative.debug("Requesting creative page url: \(creativePageUrl)" )
 
     guard let url = URL(string: creativePageUrl) else {
-      Loggers.creative.trace("URL could not be created.")
+      Loggers.creative.debug("URL could not be created.")
       return
     }
 
@@ -207,15 +207,15 @@ fileprivate extension ATTNSDK {
 extension ATTNSDK: WKScriptMessageHandler {
   public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
     let messageBody = message.body as? String ?? ""
-    Loggers.creative.trace("Web event message: \(messageBody). isCreativeOpen: \(ATTNSDK.isCreativeOpen ? "YES" : "NO")")
+    Loggers.creative.debug("Web event message: \(messageBody). isCreativeOpen: \(ATTNSDK.isCreativeOpen ? "YES" : "NO")")
 
     if messageBody == "CLOSE" {
       closeCreative()
     } else if messageBody == "IMPRESSION" {
-      Loggers.creative.trace("Creative opened and generated impression event")
+      Loggers.creative.debug("Creative opened and generated impression event")
       ATTNSDK.isCreativeOpen = true
     } else if messageBody == String(format: "%@ true", Constants.visibilityEvent), ATTNSDK.isCreativeOpen {
-      Loggers.creative.trace("Nav away from creative, closing")
+      Loggers.creative.debug("Nav away from creative, closing")
       closeCreative()
     }
   }
@@ -254,14 +254,14 @@ extension ATTNSDK: WKNavigationDelegate {
     ) { [weak self] result in
       guard let self = self else { return }
       guard case let .success(statusAny) = result else {
-        Loggers.creative.trace("No status returned from JS. Not showing WebView.")
+        Loggers.creative.debug("No status returned from JS. Not showing WebView.")
         self.triggerHandler?(ATTNCreativeTriggerStatus.notOpened)
         return
       }
 
       switch ScriptStatus.getRawValue(from: statusAny) {
       case .success:
-        Loggers.creative.trace("Found creative iframe, showing WebView.")
+        Loggers.creative.debug("Found creative iframe, showing WebView.")
         if self.mode == .production {
           self.parentView?.addSubview(webView)
         }

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -55,7 +55,8 @@ public final class ATTNSDK: NSObject {
   @objc public var skipFatigueOnCreative: Bool = false
 
   public init(domain: String, mode: ATTNSDKMode) {
-    Loggers.creative.trace("Init ATTNSDKFramework v\(ATTNConstants.sdkVersion). Mode: \(mode.rawValue)")
+    Loggers.creative.trace("Init ATTNSDKFramework v\(ATTNConstants.sdkVersion), Mode: \(mode.rawValue), Domain: \(domain)")
+
     self.domain = domain
     self.mode = mode
 
@@ -84,6 +85,7 @@ public final class ATTNSDK: NSObject {
   public func identify(_ userIdentifiers: [String: Any]) {
     userIdentity.mergeIdentifiers(userIdentifiers)
     api.send(userIdentity: userIdentity)
+    Loggers.event.debug("Send User Identifiers: \(userIdentifiers)")
   }
 
   @objc(trigger:)
@@ -109,6 +111,7 @@ public final class ATTNSDK: NSObject {
   @objc(clearUser)
   public func clearUser() {
     userIdentity.clearUser()
+    Loggers.creative.debug("Clear user. New visitor id: \(self.userIdentity.visitorId, privacy: .public)")
   }
 
   @objc(updateDomain:)
@@ -116,7 +119,9 @@ public final class ATTNSDK: NSObject {
     guard self.domain != domain else { return }
     self.domain = domain
     api.update(domain: domain)
+    Loggers.creative.trace("Updated SDK with new domain: \(domain)")
     api.send(userIdentity: userIdentity)
+    Loggers.creative.trace("Retrigger Identity Event with new domain '\(domain)'")
   }
 }
 

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -55,7 +55,7 @@ public final class ATTNSDK: NSObject {
   @objc public var skipFatigueOnCreative: Bool = false
 
   public init(domain: String, mode: ATTNSDKMode) {
-    Loggers.creative.trace("Init attentive_ios_sdk v\(ATTNConstants.sdkVersion)")
+    Loggers.creative.trace("Init ATTNSDKFramework v\(ATTNConstants.sdkVersion). Mode: \(mode.rawValue)")
     self.domain = domain
     self.mode = mode
 

--- a/Sources/URLProviders/ATTNCreativeUrlProvider.swift
+++ b/Sources/URLProviders/ATTNCreativeUrlProvider.swift
@@ -70,6 +70,7 @@ struct ATTNCreativeUrlProvider: ATTNCreativeUrlProviding {
 
     if configuration.skipFatigue {
       queryItems.append(URLQueryItem(name: "skipFatigue", value: configuration.skipFatigue.stringValue))
+      Loggers.creative.info("Skip Fatigue is enabled. Keep in mind it should be disable for production.")
     }
 
     if let creativeId = configuration.creativeId {

--- a/Sources/URLProviders/ATTNCreativeUrlProvider.swift
+++ b/Sources/URLProviders/ATTNCreativeUrlProvider.swift
@@ -89,7 +89,7 @@ fileprivate extension ATTNCreativeUrlProvider {
       let jsonData = try JSONSerialization.data(withJSONObject: customIdentifiers, options: [])
       return String(data: jsonData, encoding: .utf8)
     } catch {
-      NSLog("ERROR: Could not parse custom identifiers to json %@", error.localizedDescription)
+      Loggers.creative.error("Could not parse custom identifiers to json \(error.localizedDescription)")
     }
     return "{}"
   }

--- a/attentive-ios-sdk.podspec
+++ b/attentive-ios-sdk.podspec
@@ -28,7 +28,7 @@ The Attentive IOS SDK provides the functionality to render Attentive signup unit
   s.source           = { :git => 'https://github.com/attentive-mobile/attentive-ios-sdk.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '14.0'
 
   s.source_files = 'Sources/**/*.swift', 'Objc/**/*'
 

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		FB90EF0B2C109CB4004DFC4A /* ATTNAPIITTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB90EF0A2C109CB4004DFC4A /* ATTNAPIITTests.swift */; };
 		FB90EF0D2C10A7F7004DFC4A /* NSURLSessionDataTaskMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB90EF0C2C10A7F7004DFC4A /* NSURLSessionDataTaskMock.swift */; };
 		FB90EF0F2C10A81E004DFC4A /* NSURLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB90EF0E2C10A81E004DFC4A /* NSURLSessionMock.swift */; };
+		FB91BE602C2B4C6200E5A9B8 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB91BE5F2C2B4C6200E5A9B8 /* Logger.swift */; };
 		FBA9FA062C0A77AB00C65024 /* ATTNAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA9F9E42C0A77AB00C65024 /* ATTNAPI.swift */; };
 		FBA9FA072C0A77AB00C65024 /* ATTNEventRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA9F9E52C0A77AB00C65024 /* ATTNEventRequest.swift */; };
 		FBA9FA082C0A77AB00C65024 /* Dictionary+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA9F9E72C0A77AB00C65024 /* Dictionary+Extension.swift */; };
@@ -154,6 +155,7 @@
 		FB90EF0A2C109CB4004DFC4A /* ATTNAPIITTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNAPIITTests.swift; sourceTree = "<group>"; };
 		FB90EF0C2C10A7F7004DFC4A /* NSURLSessionDataTaskMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSURLSessionDataTaskMock.swift; sourceTree = "<group>"; };
 		FB90EF0E2C10A81E004DFC4A /* NSURLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSURLSessionMock.swift; sourceTree = "<group>"; };
+		FB91BE5F2C2B4C6200E5A9B8 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		FBA9F9E42C0A77AB00C65024 /* ATTNAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ATTNAPI.swift; sourceTree = "<group>"; };
 		FBA9F9E52C0A77AB00C65024 /* ATTNEventRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ATTNEventRequest.swift; sourceTree = "<group>"; };
 		FBA9F9E72C0A77AB00C65024 /* Dictionary+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extension.swift"; sourceTree = "<group>"; };
@@ -339,6 +341,7 @@
 				FB35C18F2C0E5057009FA048 /* Protocols */,
 				FBA9F9E82C0A77AB00C65024 /* Extension */,
 				FB35C1842C0E35E7009FA048 /* ATTNJsonUtils.swift */,
+				FB91BE5F2C2B4C6200E5A9B8 /* Logger.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -639,6 +642,7 @@
 				FBA9FA1B2C0A77AB00C65024 /* ATTNSDKMode.swift in Sources */,
 				FBF78AAE2C135ECD00596479 /* ATTNConstants.m in Sources */,
 				FBA9FA072C0A77AB00C65024 /* ATTNEventRequest.swift in Sources */,
+				FB91BE602C2B4C6200E5A9B8 /* Logger.swift in Sources */,
 				FB35C1932C0E524E009FA048 /* ATTNPurchaseEvent+Extension.swift in Sources */,
 				FB35C18D2C0E3FAA009FA048 /* ATTNUserIdentity+Extension.swift in Sources */,
 				FB35C1832C0E1FD7009FA048 /* URLSession+Extension.swift in Sources */,
@@ -850,7 +854,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
@@ -892,7 +896,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

[Jira Link](https://attentivemobile.atlassian.net/browse/APP-2881)

## What's new?
- Replaced NSLog with Logger.
  * Only errors will persist on the device.
- Creative three categories: `event, creative, network` for filtering the SDK Logs.
- Ways of filtering the SDK Logs.
   | Filter   | Values |
   | -------- | ------ |
   | Category | `[event, creative, network]` |
   | Library | `ATTNSDKFramework` |
   | Process | `The App Name` |
   | Log Type  | `[debug, info, error]` |

## Testing
- Xcode: Tested in simulators
- Console: Tested in simulators and one actual device. In the last case, the data is obfuscated. 

## Screenshots
### Xcode
![Screenshot 2024-06-26 at 2 52 05 PM](https://github.com/attentive-mobile/attentive-ios-sdk/assets/11541905/e0eaf0f8-d7af-43c5-ac66-6bb2a78f04fe)

### Console
![Screenshot 2024-06-26 at 2 58 57 PM](https://github.com/attentive-mobile/attentive-ios-sdk/assets/11541905/1bd799b3-90f8-46ae-b38d-d11e9bdf6447)
