### PR TITLE
NATV-18: Fixed display issue where user cannot interact with rest of the app even if creative is minimized

### DIFF
--- a/ExampleSwift/ExampleSwift.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ExampleSwift/ExampleSwift.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "62dc5f9606142e259275d938027b59c944959560f934dd2210d0e0cc4420a08d",
+  "pins" : [
+    {
+      "identity" : "attentive-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/attentive-mobile/attentive-ios-sdk",
+      "state" : {
+        "revision" : "6f6d281e63eee0e7a894524d5d461a74ab8837f0",
+        "version" : "1.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] Bugfix


[Jira Link](https://attentivemobile.atlassian.net/browse/NATV-18)

## What's new?
In production mode, users can interact with the rest of the app while creative is minimized to a bubble. Expanding and shrinking creative does not affect app usage.
In debug mode, allow web view to stay full screen to allow debug JSON output to be visible.
## Testing
Manual testing on a few simulators
## Screenshots

https://github.com/user-attachments/assets/77ded208-d64c-47a9-b8b8-e4b241121bc8

