### PR TITLE
Adjusted web view hit area to be a rectangle at lower left corner of the screen

### DIFF
--- a/ATTNSDKFramework.podspec
+++ b/ATTNSDKFramework.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ATTNSDKFramework'
-  s.version          = '1.0.0'
+  s.version          = '1.0.2-beta.9'
   s.summary          = 'Attentive IOS SDK'
 
 # This description is used to generate tags and improve search results.

--- a/attentive-ios-sdk.podspec
+++ b/attentive-ios-sdk.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'attentive-ios-sdk'
-  s.version          = '1.0.0'
+  s.version          = '1.0.2-beta.9'
   s.summary          = 'Attentive IOS SDK'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other

[Jira Link](https://jira/x)

## What's new?
When the web view creative is a bubble, web view hit area only receives user touches if it's within a rectangular area at the lower left corner of the screen (60% of screen width, 25% of screen height to accommodate different creative sizes and positioning).
 
## Testing
Manually tested with various creatives on different screen sizes to ensure that the hit area is correctly positioned and sized.

