### PR TITLE
MSDK-271: Add swift-snapshot-testing dependency and base test infrastructure

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -143,3 +143,4 @@ excluded:
   - vendor
   - Vendor
   - .build
+  - fastlane/build

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -142,5 +142,4 @@ excluded:
   - Pods
   - vendor
   - Vendor
-  - Tests
   - .build

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -142,3 +142,5 @@ excluded:
   - Pods
   - vendor
   - Vendor
+  - Tests
+  - .build

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,41 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "05b6f05b55ff9e2dcdcc21ac78c6ba81ea624791",
+        "version" : "1.19.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "05b6f05b55ff9e2dcdcc21ac78c6ba81ea624791",
-        "version" : "1.19.1"
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
-        "version" : "602.0.0"
+        "revision" : "2b59c0c741e9184ab057fd22950b491076d42e91",
+        "version" : "603.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             name: "ATTNSDKFrameworkTests",
             dependencies: [
                 "ATTNSDKFramework",
-                .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+                .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
             ],
             path: "Tests"
         )

--- a/Package.swift
+++ b/Package.swift
@@ -9,11 +9,22 @@ let package = Package(
     products: [
         .library(name: "ATTNSDKFramework", targets: ["ATTNSDKFramework"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0")
+    ],
     targets: [
         .target(
             name: "ATTNSDKFramework",
             path: "Sources",
             resources: [.process("Resources")]
+        ),
+        .testTarget(
+            name: "ATTNSDKFrameworkTests",
+            dependencies: [
+                "ATTNSDKFramework",
+                .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
+            ],
+            path: "Tests"
         )
     ]
 )

--- a/Tests/TestCases/ATTNSnapshotTestCase.swift
+++ b/Tests/TestCases/ATTNSnapshotTestCase.swift
@@ -69,8 +69,7 @@ class ATTNSnapshotTestCase: XCTestCase {
     }
 
     private var recordMode: SnapshotTestingConfiguration.Record {
-        guard !Self.isCI else { return .never }
-        return isRecordingSnapshots ? .all : .missing
+        isRecordingSnapshots && !Self.isCI ? .all : .never
     }
 
     /// Asserts a snapshot of the given view controller for each provided device size.

--- a/Tests/TestCases/ATTNSnapshotTestCase.swift
+++ b/Tests/TestCases/ATTNSnapshotTestCase.swift
@@ -1,0 +1,97 @@
+//
+//  ATTNSnapshotTestCase.swift
+//  attentive-ios-sdk Tests
+//
+
+import XCTest
+import SnapshotTesting
+@testable import ATTNSDKFramework
+
+/// Base class for snapshot tests. Provides shared configuration for device sizes
+/// and a consistent `__Snapshots__` reference image directory.
+class ATTNSnapshotTestCase: XCTestCase {
+
+    /// Common device viewport sizes for snapshot testing.
+    enum DeviceSize: String, CaseIterable {
+        case iPhoneSE = "iPhone SE"
+        case iPhone16 = "iPhone 16"
+        case iPhone16ProMax = "iPhone 16 Pro Max"
+        case iPadMini = "iPad mini"
+
+        var config: ViewImageConfig {
+            switch self {
+            case .iPhoneSE: .iPhoneSe(.portrait)
+            case .iPhone16: Self.iPhone16Portrait
+            case .iPhone16ProMax: Self.iPhone16ProMaxPortrait
+            case .iPadMini: .iPadMini(.portrait)
+            }
+        }
+
+        // iPhone 16: 393x852 pt, 59pt top safe area, 34pt bottom safe area
+        private static let iPhone16Portrait = ViewImageConfig(
+            safeArea: UIEdgeInsets(top: 59, left: 0, bottom: 34, right: 0),
+            size: CGSize(width: 393, height: 852),
+            traits: UITraitCollection(
+                traitsFrom: [
+                    .init(forceTouchCapability: .unavailable),
+                    .init(layoutDirection: .leftToRight),
+                    .init(preferredContentSizeCategory: .medium),
+                    .init(userInterfaceIdiom: .phone),
+                    .init(horizontalSizeClass: .compact),
+                    .init(verticalSizeClass: .regular),
+                ]
+            )
+        )
+
+        // iPhone 16 Pro Max: 440x956 pt, 62pt top safe area, 34pt bottom safe area
+        private static let iPhone16ProMaxPortrait = ViewImageConfig(
+            safeArea: UIEdgeInsets(top: 62, left: 0, bottom: 34, right: 0),
+            size: CGSize(width: 440, height: 956),
+            traits: UITraitCollection(
+                traitsFrom: [
+                    .init(forceTouchCapability: .unavailable),
+                    .init(layoutDirection: .leftToRight),
+                    .init(preferredContentSizeCategory: .medium),
+                    .init(userInterfaceIdiom: .phone),
+                    .init(horizontalSizeClass: .compact),
+                    .init(verticalSizeClass: .regular),
+                ]
+            )
+        )
+    }
+
+    private static let isCI = ProcessInfo.processInfo.environment["CI"] != nil
+
+    /// Set `true` in a subclass or test to record new reference snapshots.
+    /// Ignored on CI — recording is never allowed in CI to prevent silent passes.
+    var isRecordingSnapshots: Bool {
+        false
+    }
+
+    private var recordMode: SnapshotTestingConfiguration.Record {
+        guard !Self.isCI else { return .never }
+        return isRecordingSnapshots ? .all : .missing
+    }
+
+    /// Asserts a snapshot of the given view controller for each provided device size.
+    /// Reference images are stored alongside the test file in a `__Snapshots__` directory.
+    func assertSnapshot(
+        of viewController: UIViewController,
+        deviceSizes: [DeviceSize] = [.iPhone16],
+        file: StaticString = #filePath,
+        testName: String = #function,
+        line: UInt = #line
+    ) {
+        for device in deviceSizes {
+            SnapshotTesting.assertSnapshot(
+                of: viewController,
+                as: .image(on: device.config),
+                named: device.rawValue,
+                record: recordMode,
+                file: file,
+                testName: testName,
+                line: line
+            )
+        }
+    }
+}

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		0A8BDC8C2F298C5D00138567 /* InboxMessageRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8BDC8B2F298C4800138567 /* InboxMessageRowView.swift */; };
 		0A8BDC8E2F29975400138567 /* Inbox+Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8BDC8D2F29974F00138567 /* Inbox+Strings.swift */; };
 		0A8BDC902F29B8EC00138567 /* InboxStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8BDC8F2F29B8E900138567 /* InboxStyle.swift */; };
+		0AE51BF12F7D8138004CC16E /* ATTNSnapshotTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE51BF02F7D8138004CC16E /* ATTNSnapshotTestCase.swift */; };
+		0AE51BF22F7D8200004CC16E /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 0AE51BF32F7D8200004CC16E /* SnapshotTesting */; };
 		58332EDD292EC25500B1ECF3 /* attentive-ios-sdk.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 58332EDC292EC25500B1ECF3 /* attentive-ios-sdk.podspec */; };
 		58332EE0292EC26000B1ECF3 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 58332EDE292EC26000B1ECF3 /* README.md */; };
 		58332EE1292EC26000B1ECF3 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 58332EDF292EC26000B1ECF3 /* LICENSE */; };
@@ -126,6 +128,7 @@
 		0A8BDC8B2F298C4800138567 /* InboxMessageRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageRowView.swift; sourceTree = "<group>"; };
 		0A8BDC8D2F29974F00138567 /* Inbox+Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox+Strings.swift"; sourceTree = "<group>"; };
 		0A8BDC8F2F29B8E900138567 /* InboxStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxStyle.swift; sourceTree = "<group>"; };
+		0AE51BF02F7D8138004CC16E /* ATTNSnapshotTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNSnapshotTestCase.swift; sourceTree = "<group>"; };
 		58332EC3292EC18800B1ECF3 /* ATTNSDKFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ATTNSDKFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		58332EDC292EC25500B1ECF3 /* attentive-ios-sdk.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "attentive-ios-sdk.podspec"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		58332EDE292EC26000B1ECF3 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -248,6 +251,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0AE51BF22F7D8200004CC16E /* SnapshotTesting in Frameworks */,
 				58D52E1D292EC52B00CF32DE /* ATTNSDKFramework.framework in Frameworks */,
 				58B01AC5294D44140001CEBF /* libOCMock.a in Frameworks */,
 			);
@@ -392,6 +396,7 @@
 		FB2983F22C0F75600039759C /* TestCases */ = {
 			isa = PBXGroup;
 			children = (
+				0AE51BF02F7D8138004CC16E /* ATTNSnapshotTestCase.swift */,
 				F952B5AC2EC2915000E0E69D /* ATTNEventTrackerV2Tests.swift */,
 				F952B5AD2EC2915000E0E69D /* ATTNEventURLProviderV2Tests.swift */,
 				F952B5AE2EC2915000E0E69D /* ATTNUserIdentityExtensionTests.swift */,
@@ -634,6 +639,9 @@
 				58D52E1F292EC52B00CF32DE /* PBXTargetDependency */,
 			);
 			name = "attentive-ios-sdk Tests";
+			packageProductDependencies = (
+				0AE51BF32F7D8200004CC16E /* SnapshotTesting */,
+			);
 			productName = "attentive-ios-sdk Tests";
 			productReference = 58D52E19292EC52B00CF32DE /* attentive-ios-sdk Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -666,6 +674,9 @@
 				Base,
 			);
 			mainGroup = 58332EB9292EC18800B1ECF3;
+			packageReferences = (
+				0AE51BF42F7D8200004CC16E /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
+			);
 			productRefGroup = 58332EC4292EC18800B1ECF3 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -805,6 +816,7 @@
 				FB2983F62C0F7CF10039759C /* ATTNUserIdentityTests.swift in Sources */,
 				FB86C0402C40669400E35580 /* ATTNProductViewEventTests.swift in Sources */,
 				FB2983F42C0F759D0039759C /* ATTNVisitorServiceTests.swift in Sources */,
+				0AE51BF12F7D8138004CC16E /* ATTNSnapshotTestCase.swift in Sources */,
 				FB2983FA2C0F80A30039759C /* ATTNPersistentStorageTests.swift in Sources */,
 				F9CED4652DEF74D200780536 /* ATTNRetryingNetworkClientTests.swift in Sources */,
 				FB080C722C1C755F00834BAA /* ATTNCreativeUrlProviderSpy.swift in Sources */,
@@ -833,6 +845,25 @@
 			targetProxy = 58D52E1E292EC52B00CF32DE /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		0AE51BF42F7D8200004CC16E /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.17.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		0AE51BF32F7D8200004CC16E /* SnapshotTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0AE51BF42F7D8200004CC16E /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
+			productName = SnapshotTesting;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCBuildConfiguration section */
 		58332EC8292EC18800B1ECF3 /* Debug */ = {

--- a/attentive-ios-sdk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/attentive-ios-sdk.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,42 @@
+{
+  "originHash" : "09b08963887ce6eac26952e8acb25256a8ec102f2b5528ae68a97fa296723712",
+  "pins" : [
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "2b59c0c741e9184ab057fd22950b491076d42e91",
+        "version" : "603.0.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
## Summary

- Added [swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing) as a test-only SPM dependency in `Package.swift` and as a package in the Xcode project
- Created `ATTNSnapshotTestCase` base class with shared configuration for device sizes (iPhone SE, iPhone 16, iPhone 16 Pro Max, iPad mini) and `__Snapshots__` reference image directory convention
- CI-safe: uses `record: .never` when `CI` env var is set, so missing snapshots fail instead of silently recording
- Excluded `.build` from SwiftLint to prevent lint errors on dependency sources

## Jira

[MSDK-271](https://attentivemobile.atlassian.net/browse/MSDK-271)

## Test plan

- [x] Existing unit tests pass (`bundle exec fastlane ios unit_test`)
- [ ] Verify Xcode GUI build succeeds with snapshot dependency resolved
- [ ] Subclass `ATTNSnapshotTestCase` and confirm snapshot recording works locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-271]: https://attentivemobile.atlassian.net/browse/MSDK-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ