### PR TITLE
MSDK-264: Detach push token from user on clearUser

### DIFF
--- a/Bonni/AttentiveExample/SettingsViewController.swift
+++ b/Bonni/AttentiveExample/SettingsViewController.swift
@@ -388,7 +388,6 @@ class SettingsViewController: UIViewController {
             self.currentEmailLabel.text = "Current email: \(self.currentEmail ?? "")"
             self.currentPhoneLabel.text = "Current phone: \(self.currentPhone ?? "")"
 
-            self.getAttentiveSdk().clearUser()
             self.getAttentiveSdk().updateUser(
                 email: self.currentEmail,
                 phone: self.currentPhone

--- a/Bonni/AttentiveExample/SettingsViewController.swift
+++ b/Bonni/AttentiveExample/SettingsViewController.swift
@@ -65,6 +65,14 @@ class SettingsViewController: UIViewController {
         return button
     }()
 
+    private let logOutButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Log Out", for: .normal)
+        button.setTitleColor(.systemRed, for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
     // MARK: - Test Events Section
 
     private let showCreativeButton: UIButton = {
@@ -250,6 +258,7 @@ class SettingsViewController: UIViewController {
         stackView.addArrangedSubview(accountInfoLabel)
         stackView.addArrangedSubview(switchAccountButton)
         stackView.addArrangedSubview(switchDomainButton)
+        stackView.addArrangedSubview(logOutButton)
 
         let divider = UIView()
         divider.backgroundColor = .lightGray
@@ -272,6 +281,7 @@ class SettingsViewController: UIViewController {
             let allButtons: [UIButton] = [
                 switchAccountButton,
                 switchDomainButton,
+                logOutButton,
                 showCreativeButton,
                 showPushPermissionButton,
                 sendLocalPushNotification,
@@ -320,6 +330,7 @@ class SettingsViewController: UIViewController {
     private func setupActions() {
         switchAccountButton.addTarget(self, action: #selector(switchAccountTapped), for: .touchUpInside)
         switchDomainButton.addTarget(self, action: #selector(switchDomainTapped), for: .touchUpInside)
+        logOutButton.addTarget(self, action: #selector(logOutTapped), for: .touchUpInside)
         showCreativeButton.addTarget(self, action: #selector(showCreativeTapped), for: .touchUpInside)
         showPushPermissionButton.addTarget(self, action: #selector(showPushPermissionTapped), for: .touchUpInside)
         sendLocalPushNotification.addTarget(self, action: #selector(sendLocalPushNotificationTapped), for: .touchUpInside)
@@ -493,8 +504,19 @@ class SettingsViewController: UIViewController {
         showToast(with: success ? "Deep link handled: bonni://cart" : "Deep link failed")
     }
 
+    @objc private func logOutTapped() {
+        getAttentiveSdk().clearUser()
+        currentEmail = nil
+        currentPhone = nil
+        currentEmailLabel.text = "Current email:"
+        currentPhoneLabel.text = "Current phone:"
+        accountInfoLabel.text = "Login Info: Guest"
+        showToast(with: "Logged out — push token detached")
+    }
+
     @objc private func clearUserTapped() {
-        // TODO: Clear the user
+        getAttentiveSdk().clearUser()
+        showToast(with: "User cleared")
     }
 
     @objc private func clearCookiesTapped() {

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ sdk.identify([
 ```
 ### Clearing user data
 
-If the user "logs out" of your application, you can call `clearUser` to remove all current identifiers.
+When the user logs out of your application, call `clearUser` to remove all current identifiers **and** detach the push token from the logged-out user. This ensures the previous user no longer receives push notifications on this device.
 
 #### Swift
 ```swift
@@ -151,6 +151,8 @@ sdk.clearUser()
 [sdk clearUser];
 ```
 
+> **Note:** `clearUser` requires a push token to have been registered (via `registerDeviceToken`) in order to detach it server-side. If no push token is available, identifiers are still cleared locally.
+
 ### Update user via email and/or phone
 
 Our SDK supports switching the identified user via email and/or phone (at least one identifier must be provided). Calling this method will clear all identifiers previously associated with the current user (the sdk will automatically call clearUser()), and associate the app with the new identifier(s) you provide. This ensures that all subsequent events and messages are attributed to the newly identified user.
@@ -158,7 +160,6 @@ Our SDK supports switching the identified user via email and/or phone (at least 
 #### Swift
 ```
 // Update user with both email and phone
-attentiveSdk.clearUser() // Must be called prior to calling updateUser()
 attentiveSdk.updateUser(email: "user@example.com", phone: "+15551234567") { result in
     switch result {
     case .success:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ sdk.identify([
 ```
 ### Clearing user data
 
-When the user logs out of your application, call `clearUser` to remove all current identifiers **and** detach the push token from the logged-out user. This ensures the previous user no longer receives push notifications on this device.
+If the user "logs out" of your application, you can call `clearUser` to remove all current identifiers.
 
 #### Swift
 ```swift
@@ -151,11 +151,11 @@ sdk.clearUser()
 [sdk clearUser];
 ```
 
-> **Note:** `clearUser` requires a push token to have been registered (via `registerDeviceToken`) in order to detach it server-side. If no push token is available, identifiers are still cleared locally.
+> **Push token users:** If your app uses Attentive push notifications, `clearUser` will also detach the push token from the logged-out user on the server, so they no longer receive push notifications on this device. Make sure to call `clearUser()` on every logout path.
 
 ### Update user via email and/or phone
 
-Our SDK supports switching the identified user via email and/or phone (at least one identifier must be provided). Calling this method will clear all identifiers previously associated with the current user (the sdk will automatically call clearUser()), and associate the app with the new identifier(s) you provide. This ensures that all subsequent events and messages are attributed to the newly identified user.
+Our SDK supports switching the identified user via email and/or phone (at least one identifier must be provided). Calling this method will automatically clear all identifiers previously associated with the current user, and associate the current user with the new identifier(s) you provide. This ensures that all subsequent events and messages are attributed to the newly identified user.
 
 #### Swift
 ```
@@ -211,9 +211,10 @@ attentiveSdk?.identify([
 ```
 
 ### 3. User logs out  
-Call `clearUser()` to remove identifiers.  
+Call `clearUser()` to remove identifiers. If your app uses Attentive push notifications, this also detaches the push token from the logged-out user.
 
-``` user logs out
+```swift
+// user logs out
 attentiveSdk?.clearUser()
 ```
 

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -299,14 +299,32 @@ final class ATTNAPI: ATTNAPIProtocol {
 
     // MARK: - Update User
 
+    // Internal note for maintainers and AI assistants:
+    // ------------------------------------------------
+    // This method is the single network call behind two public SDK operations:
+    //
+    //   1. **updateUser(email:phone:callback:)** — the user is switching identity.
+    //      Called with a real email/phone and operationContext = "updateUser".
+    //
+    //   2. **clearUser()** — the user is logging out.
+    //      Called with nil email/phone and operationContext = "clearUser".
+    //      Sending an empty metadata dict ("m": {}) tells the server to detach
+    //      the push token from the current user without associating it to a new
+    //      email/phone. This is an internal implementation detail — SDK consumers
+    //      should only see "clearUser" in logs, never "updateUser".
+    //
+    // The `operationContext` parameter controls how every log line is labelled so
+    // that developer-facing console output always reflects the public API the
+    // consumer actually called, not the underlying network mechanism.
     func updateUser(
         pushToken: String,
         userIdentity: ATTNUserIdentity,
         email: String? = nil,
         phone: String? = nil,
+        operationContext: String = "updateUser",
         callback: ATTNAPICallback? = nil
     ) {
-        Loggers.network.debug("Updating user - Visitor ID: \(userIdentity.visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public)")
+        Loggers.network.debug("\(operationContext, privacy: .public): sending request - Visitor ID: \(userIdentity.visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public)")
 
         var meta: [String: Any] = [:]
         if let email = email?.trimmingCharacters(in: .whitespacesAndNewlines), !email.isEmpty {
@@ -326,7 +344,7 @@ final class ATTNAPI: ATTNAPIProtocol {
         if !pushToken.isEmpty { payload["pt"] = pushToken }
 
         guard let url = URL(string: "https://mobile.attentivemobile.com:443/user-update") else {
-            Loggers.network.error("Invalid Update User URL")
+            Loggers.network.error("\(operationContext, privacy: .public): invalid URL")
             callback?(nil, nil, nil, ATTNError.badURL)
             return
         }
@@ -338,17 +356,17 @@ final class ATTNAPI: ATTNAPIProtocol {
         request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
         request.httpBody = try? JSONSerialization.data(withJSONObject: payload, options: [])
 
-        Loggers.network.debug("POST /update_user payload: \(payload, privacy: .public)")
+        Loggers.network.debug("\(operationContext, privacy: .public): POST /user-update payload: \(payload, privacy: .public)")
 
         let task = self.urlSession.dataTask(with: request) { data, response, error in
             if let error = error {
-                Loggers.network.error("Update User error: \(error.localizedDescription, privacy: .public)")
+                Loggers.network.error("\(operationContext, privacy: .public): network error - \(error.localizedDescription, privacy: .public)")
             } else if let http = response as? HTTPURLResponse {
-                Loggers.network.debug("----- Update User Result -----")
+                Loggers.network.debug("----- \(operationContext, privacy: .public) Result -----")
                 Loggers.network.debug("Status Code: \(http.statusCode, privacy: .public)")
                 Loggers.network.debug("Headers: \(http.allHeaderFields, privacy: .public)")
                 if http.statusCode >= 400 {
-                    Loggers.network.error("UpdateUser API returned status \(http.statusCode, privacy: .public)")
+                    Loggers.network.error("\(operationContext, privacy: .public): API returned status \(http.statusCode, privacy: .public)")
                 }
             }
             if let data = data, let bodyStr = String(data: data, encoding: .utf8) {

--- a/Sources/API/ATTNAPIProtocol.swift
+++ b/Sources/API/ATTNAPIProtocol.swift
@@ -56,11 +56,22 @@ protocol ATTNAPIProtocol {
     )
 
     // MARK: - Update User
+    //
+    // Shared endpoint for both `clearUser()` and `updateUser(email:phone:)`.
+    //
+    // - When called from clearUser:  email=nil, phone=nil, operationContext="clearUser"
+    //   → Tells the server to detach the push token from the current user (logout flow).
+    //
+    // - When called from updateUser: email/phone provided, operationContext="updateUser"
+    //   → Tells the server to re-identify the device under a new user.
+    //
+    // `operationContext` is used exclusively for logging — it has no effect on the API payload.
     func updateUser(
         pushToken: String,
         userIdentity: ATTNUserIdentity,
         email: String?,
         phone: String?,
+        operationContext: String,
         callback: ATTNAPICallback?
     )
 }

--- a/Sources/Public/ATTNUserIdentity.swift
+++ b/Sources/Public/ATTNUserIdentity.swift
@@ -51,15 +51,16 @@ public final class ATTNUserIdentity: NSObject {
 
 fileprivate extension ATTNUserIdentity {
     func validate(identifiers: [String: Any]) {
-        ATTNIdentifierType.allKeys.forEach { currentKey in
-            ATTNParameterValidation.verifyStringOrNil(
-                identifiers[currentKey] as? NSObject,
-                inputName: currentKey
-            )
+        for key in identifiers.keys {
+            if key == ATTNIdentifierType.customIdentifiers {
+                ATTNParameterValidation.verify1DStringDictionaryOrNil(
+                    identifiers[key] as? NSDictionary,
+                    inputName: key)
+            } else {
+                ATTNParameterValidation.verifyStringOrNil(
+                    identifiers[key] as? NSObject,
+                    inputName: key)
+            }
         }
-
-        ATTNParameterValidation.verify1DStringDictionaryOrNil(
-            identifiers[ATTNIdentifierType.customIdentifiers] as? NSDictionary,
-            inputName: ATTNIdentifierType.customIdentifiers)
     }
 }

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -167,6 +167,27 @@ public final class ATTNSDK: NSObject {
 
     @objc(clearUser)
     public func clearUser() {
+        clearUserIdentifiers()
+
+        // Detach push token from the logged-out user by calling updateUser with empty identifiers
+        let pushToken = currentPushToken
+        guard !pushToken.isEmpty else {
+            Loggers.event.debug("clearUser: skipping push token detach — no push token available")
+            return
+        }
+
+        Loggers.event.debug("clearUser: detaching push token from previous user - Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
+        api.updateUser(
+            pushToken: pushToken,
+            userIdentity: userIdentity,
+            email: nil,
+            phone: nil,
+            callback: nil
+        )
+    }
+
+    /// Clears user identifiers and generates a new visitor ID without making any network calls.
+    private func clearUserIdentifiers() {
         let oldVisitorId = userIdentity.visitorId
         userIdentity.clearUser()
         Loggers.creative.debug("User cleared successfully - Old Visitor ID: \(oldVisitorId, privacy: .public), New Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
@@ -512,7 +533,7 @@ public final class ATTNSDK: NSObject {
             return
         }
         Loggers.event.debug("Updating user with push token: \(pushToken, privacy: .public)")
-        clearUser()
+        clearUserIdentifiers()
         api.updateUser(
             pushToken: pushToken,
             userIdentity: userIdentity,

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -165,11 +165,29 @@ public final class ATTNSDK: NSObject {
         launchCreative(parentView: view, creativeId: creativeId, handler: handler)
     }
 
+    /// Clears all user identifiers and detaches the push token from the current user.
+    ///
+    /// Call this when the user logs out. The SDK will:
+    /// 1. Reset all local identifiers (email, phone, etc.) and generate a new anonymous visitor ID.
+    /// 2. If a push token is registered, tell the server to detach it from the previous user so
+    ///    they stop receiving push notifications on this device.
+    ///
+    /// After `clearUser()` returns, the device is in an anonymous state. The next call to
+    /// `identify(_:)` or `updateUser(email:phone:callback:)` will associate the device with a
+    /// new user.
+    ///
+    /// - Note: If no push token has been registered (via `registerDeviceToken`), the server-side
+    ///   detach is skipped — identifiers are still cleared locally.
+    ///
+    /// Internal implementation detail (for maintainers / AI assistants):
+    /// Under the hood this calls the same `/user-update` endpoint as `updateUser`, but with
+    /// empty email and phone. The `operationContext: "clearUser"` parameter ensures all logs
+    /// are labelled "clearUser" so SDK consumers never see "updateUser" in their console when
+    /// they only called `clearUser()`.
     @objc(clearUser)
     public func clearUser() {
         clearUserIdentifiers()
 
-        // Detach push token from the logged-out user by calling updateUser with empty identifiers
         let pushToken = currentPushToken
         guard !pushToken.isEmpty else {
             Loggers.event.debug("clearUser: skipping push token detach — no push token available")
@@ -182,11 +200,16 @@ public final class ATTNSDK: NSObject {
             userIdentity: userIdentity,
             email: nil,
             phone: nil,
+            operationContext: "clearUser",
             callback: nil
         )
     }
 
-    /// Clears user identifiers and generates a new visitor ID without making any network calls.
+    /// Clears user identifiers and generates a new visitor ID. **Local only — no network call.**
+    ///
+    /// Both `clearUser()` and `updateUser(email:phone:callback:)` call this as their first step.
+    /// The new visitor ID is used in any subsequent API call so the server treats the device as
+    /// a fresh anonymous user.
     private func clearUserIdentifiers() {
         let oldVisitorId = userIdentity.visitorId
         userIdentity.clearUser()
@@ -518,27 +541,40 @@ public final class ATTNSDK: NSObject {
         optOutMarketingSubscription(email: nil, phone: phone, callback: callback)
     }
 
+    /// Switches the current user identity by associating the device with new email and/or phone identifiers.
+    ///
+    /// This method:
+    /// 1. Clears all existing identifiers and generates a new anonymous visitor ID (same as `clearUser()`).
+    /// 2. Sends the new email/phone to the server, which re-identifies the device under the new user.
+    ///
+    /// At least one of `email` or `phone` must be provided.
+    ///
+    /// - Parameters:
+    ///   - email: The new user's email address (optional if phone is provided).
+    ///   - phone: The new user's phone number in E.164 format (optional if email is provided).
+    ///   - callback: Called when the server responds. `nil` is acceptable.
     @objc(updateUserWithEmail:phone:callback:)
     public func updateUser(email: String? = nil,
                                                  phone: String? = nil,
                                                  callback: ATTNAPICallback? = nil) {
-        Loggers.event.debug("Attempting to update user - Current Visitor ID: \(self.userIdentity.visitorId, privacy: .public), Email: \(email ?? "nil", privacy: .public), Phone: \(phone ?? "nil", privacy: .public)")
+        Loggers.event.debug("updateUser: switching user identity - Current Visitor ID: \(self.userIdentity.visitorId, privacy: .public), Email: \(email ?? "nil", privacy: .public), Phone: \(phone ?? "nil", privacy: .public)")
         let trimmedPushToken = currentPushToken.trimmingCharacters(in: .whitespacesAndNewlines)
         let pushToken = !trimmedPushToken.isEmpty
         ? trimmedPushToken
         : (UserDefaults.standard.string(forKey: "attentiveDeviceToken") ?? "")
         guard !pushToken.isEmpty else {
-            Loggers.event.error("updateUser aborted: missing push token - Tried in-memory token: '\(trimmedPushToken, privacy: .public)', Tried UserDefaults: '\(UserDefaults.standard.string(forKey: "attentiveDeviceToken") ?? "nil", privacy: .public)', Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
+            Loggers.event.error("updateUser: aborted — missing push token - Tried in-memory token: '\(trimmedPushToken, privacy: .public)', Tried UserDefaults: '\(UserDefaults.standard.string(forKey: "attentiveDeviceToken") ?? "nil", privacy: .public)', Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
             callback?(nil, nil, nil, ATTNSDKError.missingPushToken)
             return
         }
-        Loggers.event.debug("Updating user with push token: \(pushToken, privacy: .public)")
+        Loggers.event.debug("updateUser: proceeding with push token: \(pushToken, privacy: .public)")
         clearUserIdentifiers()
         api.updateUser(
             pushToken: pushToken,
             userIdentity: userIdentity,
             email: email,
             phone: phone,
+            operationContext: "updateUser",
             callback: callback
         )
     }

--- a/Tests/Doubles/Spies/ATTNAPISpy.swift
+++ b/Tests/Doubles/Spies/ATTNAPISpy.swift
@@ -129,17 +129,21 @@ final class ATTNAPISpy: ATTNAPIProtocol {
     }
 
     // MARK: - Update User
+    private(set) var lastOperationContext: String?
+
     func updateUser(
         pushToken: String,
         userIdentity: ATTNUserIdentity,
         email: String?,
         phone: String?,
+        operationContext: String,
         callback: ATTNAPICallback?
     ) {
         updateUserWasCalled = true
         updateUserCallCount += 1
         lastUpdateUserEmail = email
         lastUpdateUserPhone = phone
+        lastOperationContext = operationContext
         callback?(nil, nil, nil, nil)
     }
 }

--- a/Tests/Doubles/Spies/ATTNAPISpy.swift
+++ b/Tests/Doubles/Spies/ATTNAPISpy.swift
@@ -130,6 +130,7 @@ final class ATTNAPISpy: ATTNAPIProtocol {
 
     // MARK: - Update User
     private(set) var lastOperationContext: String?
+    private(set) var lastUpdateUserPushToken: String?
 
     func updateUser(
         pushToken: String,
@@ -141,6 +142,7 @@ final class ATTNAPISpy: ATTNAPIProtocol {
     ) {
         updateUserWasCalled = true
         updateUserCallCount += 1
+        lastUpdateUserPushToken = pushToken
         lastUpdateUserEmail = email
         lastUpdateUserPhone = phone
         lastOperationContext = operationContext

--- a/Tests/Doubles/Spies/ATTNAPISpy.swift
+++ b/Tests/Doubles/Spies/ATTNAPISpy.swift
@@ -22,6 +22,7 @@ final class ATTNAPISpy: ATTNAPIProtocol {
     private(set) var sendOptInWasCalled = false
     private(set) var sendOptOutWasCalled = false
     private(set) var updateUserWasCalled = false
+    private(set) var updateUserCallCount = 0
 
     // MARK: - Last-params (optional, handy for assertions)
     private(set) var lastPushToken: String?
@@ -136,6 +137,7 @@ final class ATTNAPISpy: ATTNAPIProtocol {
         callback: ATTNAPICallback?
     ) {
         updateUserWasCalled = true
+        updateUserCallCount += 1
         lastUpdateUserEmail = email
         lastUpdateUserPhone = phone
         callback?(nil, nil, nil, nil)

--- a/Tests/TestCases/ATTNSDKTests.swift
+++ b/Tests/TestCases/ATTNSDKTests.swift
@@ -381,6 +381,8 @@ final class ATTNSDKTests: XCTestCase {
         XCTAssertTrue(apiSpy.updateUserWasCalled, "clearUser should call updateUser to detach push token")
         XCTAssertNil(apiSpy.lastUpdateUserEmail, "clearUser should pass nil email to detach push token")
         XCTAssertNil(apiSpy.lastUpdateUserPhone, "clearUser should pass nil phone to detach push token")
+        XCTAssertEqual(apiSpy.lastOperationContext, "clearUser")
+        XCTAssertEqual(apiSpy.lastUpdateUserPushToken, "010203")
     }
 
     func testClearUser_withoutPushToken_doesNotCallUpdateUser() {
@@ -410,6 +412,7 @@ final class ATTNSDKTests: XCTestCase {
         XCTAssertEqual(apiSpy.updateUserCallCount, 1, "updateUser should call api.updateUser exactly once, not twice")
         XCTAssertEqual(apiSpy.lastUpdateUserEmail, "new@example.com")
         XCTAssertEqual(apiSpy.lastUpdateUserPhone, "+15551234567")
+        XCTAssertEqual(apiSpy.lastOperationContext, "updateUser")
     }
 
     private func waitForCondition(_ condition: @escaping () -> Bool, timeout: TimeInterval = 0.25) -> Bool {

--- a/Tests/TestCases/ATTNSDKTests.swift
+++ b/Tests/TestCases/ATTNSDKTests.swift
@@ -368,6 +368,50 @@ final class ATTNSDKTests: XCTestCase {
         XCTAssertEqual(apiSpy.lastOptOutPhone, "+15551234567")
     }
 
+    // MARK: - clearUser tests
+
+    func testClearUser_withPushToken_callsUpdateUserWithNilEmailAndPhone() {
+        let deviceToken = Data([0x01, 0x02, 0x03])
+        sut.registerDeviceToken(deviceToken, authorizationStatus: .authorized)
+
+        XCTAssertFalse(apiSpy.updateUserWasCalled)
+
+        sut.clearUser()
+
+        XCTAssertTrue(apiSpy.updateUserWasCalled, "clearUser should call updateUser to detach push token")
+        XCTAssertNil(apiSpy.lastUpdateUserEmail, "clearUser should pass nil email to detach push token")
+        XCTAssertNil(apiSpy.lastUpdateUserPhone, "clearUser should pass nil phone to detach push token")
+    }
+
+    func testClearUser_withoutPushToken_doesNotCallUpdateUser() {
+        sut.clearUser()
+
+        XCTAssertFalse(apiSpy.updateUserWasCalled, "clearUser should not call updateUser without a push token")
+    }
+
+    func testClearUser_resetsIdentifiers() {
+        sut.identify([ATTNIdentifierType.email: "user@example.com"])
+
+        sut.clearUser()
+
+        XCTAssertEqual(sut.getUserIdentity().identifiers.count, 0, "clearUser should reset all identifiers")
+    }
+
+    // MARK: - updateUser tests
+
+    func testUpdateUser_callsUpdateUserExactlyOnce() {
+        let deviceToken = Data([0x01, 0x02, 0x03])
+        sut.registerDeviceToken(deviceToken, authorizationStatus: .authorized)
+
+        XCTAssertEqual(apiSpy.updateUserCallCount, 0, "updateUser should not have been called yet")
+
+        sut.updateUser(email: "new@example.com", phone: "+15551234567")
+
+        XCTAssertEqual(apiSpy.updateUserCallCount, 1, "updateUser should call api.updateUser exactly once, not twice")
+        XCTAssertEqual(apiSpy.lastUpdateUserEmail, "new@example.com")
+        XCTAssertEqual(apiSpy.lastUpdateUserPhone, "+15551234567")
+    }
+
     private func waitForCondition(_ condition: @escaping () -> Bool, timeout: TimeInterval = 0.25) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [x] Tests
- [ ] Other

[MSDK-264](https://attentivemobile.atlassian.net/browse/MSDK-264)

## What's new?

`clearUser()` now detaches the push token from the logged-out user by calling the `updateUser` API with empty email/phone identifiers. This ensures the previous user no longer receives push notifications on this device after logout.

**Implementation details:**
- Extracted `clearUserIdentifiers()` as a private helper to avoid a redundant API call when `updateUser()` internally clears identifiers
- If no push token is available, `clearUser()` gracefully skips the server-side detach and still clears identifiers locally
- Added `operationContext` parameter to `updateUser()` so log messages display the correct public API name (`clearUser` vs `updateUser`) since both share the same `/user-update` endpoint
- Fixed noisy identifier validation — `validate()` now only checks keys actually provided by the caller instead of iterating all possible identifier keys
- Updated README to document the push token detach behavior for users who have push notifications enabled

## Testing

- `testClearUser_withPushToken_callsUpdateUserWithNilEmailAndPhone` — verifies API is called with nil email/phone to detach token
- `testClearUser_withoutPushToken_doesNotCallUpdateUser` — verifies graceful no-op without a token
- `testClearUser_resetsIdentifiers` — verifies identifiers are still cleared
- `testUpdateUser_callsUpdateUserExactlyOnce` — verifies no double API call from the refactored code path

Screenshots from attentive UI: see [slack thread](https://attentivemobile.slack.com/archives/C087XAP637X/p1776356914678239)
All 171 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-264]: https://attentivemobile.atlassian.net/browse/MSDK-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ