### PR TITLE
MSDK-320: Support beta/prerelease versions in release-sdk automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ parameters:
   with_local_binary:
     type: string
     default: "true"
+  is_prerelease:
+    type: string
+    default: "false"
 
 # ========================
 # Executors
@@ -424,7 +427,7 @@ jobs:
           environment:
             RELEASE_VERSION: << pipeline.parameters.release_version >>
             RELEASE_NOTES: << pipeline.parameters.release_notes >>
-          command: bundle exec fastlane create_release version:"<< pipeline.parameters.release_version >>" release_notes:"${RELEASE_NOTES}"
+          command: bundle exec fastlane create_release version:"<< pipeline.parameters.release_version >>" release_notes:"${RELEASE_NOTES}" is_prerelease:<< pipeline.parameters.is_prerelease >>
 
       - notify-slack-on-release-success
       - notify-slack-on-failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -512,6 +512,9 @@ workflows:
           requires:
             - build-examples
             - assemble-xcframework
+          when:
+            not:
+              equal: ["true", << pipeline.parameters.is_prerelease >>]
 
       - release:
           context: *default_context
@@ -524,6 +527,9 @@ workflows:
           requires:
             - build-bonni-release
             - release
+          when:
+            not:
+              equal: ["true", << pipeline.parameters.is_prerelease >>]
 
   # Deploy to TestFlight workflow triggered via API (GitHub Actions)
   deploy-testflight:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       is_prerelease:
-        description: "Mark as prerelease (beta). Skips CocoaPods push and PR to main."
+        description: "Mark as prerelease (beta). Skips PR to main and TestFlight deploy."
         required: false
         type: boolean
         default: false
@@ -38,7 +38,7 @@ jobs:
             --arg notes "$RELEASE_NOTES" \
             --arg is_prerelease "${{ inputs.is_prerelease }}" \
             '{
-              branch: "main",
+              branch: "${{ github.ref_name }}",
               parameters: {
                 run_release: true,
                 release_version: $version,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g., 2.1.0)"
+        description: "Release version (e.g., 2.1.0 or 2.1.0-beta.1)"
         required: true
         type: string
+      is_prerelease:
+        description: "Mark as prerelease (beta). Skips CocoaPods push and PR to main."
+        required: false
+        type: boolean
+        default: false
       release_notes:
         description: "Release notes (optional — single line only, use gh CLI for multiline. Auto-generated from commits if blank)"
         required: false
@@ -18,8 +23,8 @@ jobs:
     steps:
       - name: Validate version format
         run: |
-          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Version must be in semver format (e.g., 2.1.0)"
+          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Version must be in semver format (e.g., 2.1.0 or 2.1.0-beta.1)"
             exit 1
           fi
 
@@ -31,12 +36,14 @@ jobs:
           payload=$(jq -n \
             --arg version "${{ inputs.version }}" \
             --arg notes "$RELEASE_NOTES" \
+            --arg is_prerelease "${{ inputs.is_prerelease }}" \
             '{
               branch: "main",
               parameters: {
                 run_release: true,
                 release_version: $version,
-                release_notes: $notes
+                release_notes: $notes,
+                is_prerelease: $is_prerelease
               }
             }')
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -660,10 +660,10 @@ platform :ios do
       UI.user_error!("Release failed and rolled back: #{e.message}")
     end
 
+    # 12. Open PR to main (skip for prereleases — beta version bumps should not target main)
     if is_prerelease
-      UI.important("Prerelease: skipping PR to main and CocoaPods push")
+      UI.important("Prerelease: skipping PR to main")
     else
-      # 12. Open PR to main
       create_pull_request(
         repo: repository_name,
         api_bearer: ENV["GITHUB_TOKEN"],
@@ -673,18 +673,18 @@ platform :ios do
         body: "Automated version bump to #{new_version}",
         team_reviewers: "team-mobile-sdk"
       )
+    end
 
-      # 13. Push to CocoaPods (SPM + GitHub release already work at this point)
-      podspecs = ["ATTNSDKFramework.podspec", "attentive-ios-sdk.podspec"]
-      podspecs.each do |spec|
-        begin
-          pod_push(
-            path: spec,
-            allow_warnings: true
-          )
-        rescue => e
-          UI.user_error!("CocoaPods push failed for #{spec}: #{e.message}\nSPM and GitHub release are live. Retry with: pod trunk push #{spec} --allow-warnings")
-        end
+    # 13. Push to CocoaPods (prerelease versions require explicit opt-in via pod version pinning)
+    podspecs = ["ATTNSDKFramework.podspec", "attentive-ios-sdk.podspec"]
+    podspecs.each do |spec|
+      begin
+        pod_push(
+          path: spec,
+          allow_warnings: true
+        )
+      rescue => e
+        UI.user_error!("CocoaPods push failed for #{spec}: #{e.message}\nSPM and GitHub release are live. Retry with: pod trunk push #{spec} --allow-warnings")
       end
     end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -139,7 +139,19 @@ platform :ios do
                    if new_pre.nil? && current_pre
                      true
                    elsif new_pre && current_pre
-                     new_pre > current_pre
+                     # Compare identifiers per semver: split on '.', compare numerics as integers
+                     new_ids = new_pre.split('.')
+                     current_ids = current_pre.split('.')
+                     cmp = new_ids.zip(current_ids).reduce(nil) do |result, (n, c)|
+                       next result if result && result != 0
+                       # A longer prerelease has higher precedence if all prior ids match
+                       next 1 if c.nil?
+                       both_numeric = n.match?(/^\d+$/) && c.match?(/^\d+$/)
+                       both_numeric ? n.to_i <=> c.to_i : n <=> c
+                     end
+                     # If all compared ids are equal, longer prerelease wins (e.g., beta.1.1 > beta.1)
+                     cmp = new_ids.length <=> current_ids.length if cmp.nil? || cmp == 0
+                     cmp > 0
                    else
                      false
                    end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -116,18 +116,38 @@ platform :ios do
     version
   end
 
-  desc "Bump version. Usage: fastlane bump_version version:2.1.0"
+  desc "Bump version. Usage: fastlane bump_version version:2.1.0 (or version:2.1.0-beta.1)"
   lane :bump_version do |options|
     version_file = abs_path(".version")
     current_version = File.read(version_file).strip
 
     UI.user_error!("version parameter is required. Usage: fastlane bump_version version:2.1.0") unless options[:version]
     new_version = options[:version].strip
-    UI.user_error!("❌ Invalid version format: #{new_version}. Expected X.Y.Z") unless new_version.match?(/^\d+\.\d+\.\d+$/)
+    UI.user_error!("❌ Invalid version format: #{new_version}. Expected X.Y.Z or X.Y.Z-prerelease") unless new_version.match?(/^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/)
 
-    current_parts = current_version.split('.').map(&:to_i)
-    new_parts = new_version.split('.').map(&:to_i)
-    UI.user_error!("❌ New version #{new_version} must be greater than current version #{current_version}") unless (new_parts <=> current_parts) == 1
+    current_base = current_version.split('-').first.split('.').map(&:to_i)
+    new_base = new_version.split('-').first.split('.').map(&:to_i)
+
+    version_ok = if (new_base <=> current_base) == 1
+                   true
+                 elsif (new_base <=> current_base) == 0
+                   # Same base version: allow if new has a higher prerelease than current
+                   # e.g., 2.0.14-beta.1 → 2.0.14-beta.2, or 2.0.14-beta.1 → 2.0.14
+                   current_pre = current_version.include?('-') ? current_version.split('-', 2).last : nil
+                   new_pre = new_version.include?('-') ? new_version.split('-', 2).last : nil
+                   # Release (no prerelease) > any prerelease of the same base version
+                   if new_pre.nil? && current_pre
+                     true
+                   elsif new_pre && current_pre
+                     new_pre > current_pre
+                   else
+                     false
+                   end
+                 else
+                   false
+                 end
+
+    UI.user_error!("❌ New version #{new_version} must be greater than current version #{current_version}") unless version_ok
 
     UI.message("📝 Bumping version: #{current_version} → #{new_version}")
 
@@ -543,7 +563,7 @@ platform :ios do
   # Distribution
   # ========================
 
-  desc "Create release: zip XCFramework, compute checksum, tag, GitHub release, CocoaPods, and open PR to main. Usage: fastlane create_release version:2.1.0"
+  desc "Create release: zip XCFramework, compute checksum, tag, GitHub release, CocoaPods, and open PR to main. Usage: fastlane create_release version:2.1.0 (or version:2.1.0-beta.1 is_prerelease:true)"
   lane :create_release do |options|
     UI.user_error!("Version parameter is required. Usage: fastlane create_release version:2.1.0") unless options[:version]
 
@@ -551,6 +571,7 @@ platform :ios do
     repository_name   = "attentive-mobile/attentive-ios-sdk"
     current_version   = get_version
     new_version       = options[:version].strip
+    is_prerelease     = options[:is_prerelease].to_s == "true"
     xcframework_path  = "#{FASTLANE_BUILD_OUTPUT_DIR}/ATTNSDKFramework.xcframework"
 
     # 1. Pre-flight checks
@@ -628,6 +649,7 @@ platform :ios do
         name: "#{new_version}",
         tag_name: "#{new_version}",
         description: release_notes,
+        is_prerelease: is_prerelease,
         upload_assets: [xcframework_zip_path]
       )
     rescue => e
@@ -638,31 +660,35 @@ platform :ios do
       UI.user_error!("Release failed and rolled back: #{e.message}")
     end
 
-    # 12. Open PR to main
-    create_pull_request(
-      repo: repository_name,
-      api_bearer: ENV["GITHUB_TOKEN"],
-      title: "[CI/fastlane] Bump version to #{new_version}",
-      head: version_bump,
-      base: "main",
-      body: "Automated version bump to #{new_version}",
-      team_reviewers: "team-mobile-sdk"
-    )
+    if is_prerelease
+      UI.important("Prerelease: skipping PR to main and CocoaPods push")
+    else
+      # 12. Open PR to main
+      create_pull_request(
+        repo: repository_name,
+        api_bearer: ENV["GITHUB_TOKEN"],
+        title: "[CI/fastlane] Bump version to #{new_version}",
+        head: version_bump,
+        base: "main",
+        body: "Automated version bump to #{new_version}",
+        team_reviewers: "team-mobile-sdk"
+      )
 
-    # 13. Push to CocoaPods (SPM + GitHub release already work at this point)
-    podspecs = ["ATTNSDKFramework.podspec", "attentive-ios-sdk.podspec"]
-    podspecs.each do |spec|
-      begin
-        pod_push(
-          path: spec,
-          allow_warnings: true
-        )
-      rescue => e
-        UI.user_error!("CocoaPods push failed for #{spec}: #{e.message}\nSPM and GitHub release are live. Retry with: pod trunk push #{spec} --allow-warnings")
+      # 13. Push to CocoaPods (SPM + GitHub release already work at this point)
+      podspecs = ["ATTNSDKFramework.podspec", "attentive-ios-sdk.podspec"]
+      podspecs.each do |spec|
+        begin
+          pod_push(
+            path: spec,
+            allow_warnings: true
+          )
+        rescue => e
+          UI.user_error!("CocoaPods push failed for #{spec}: #{e.message}\nSPM and GitHub release are live. Retry with: pod trunk push #{spec} --allow-warnings")
+        end
       end
     end
 
-    UI.success("Released #{new_version}. PR opened to main.")
+    UI.success("#{is_prerelease ? 'Prerelease' : 'Released'} #{new_version}.#{is_prerelease ? '' : ' PR opened to main.'}")
   end
 
   desc "Upload a new build to TestFlight"


### PR DESCRIPTION
## Summary
- Adds `is_prerelease` flag through the full release pipeline (GitHub Actions → CircleCI → Fastlane)
- For prerelease builds, the GitHub release is marked as prerelease, the PR-to-main and TestFlight deploy are skipped
- CocoaPods push still runs for prereleases since prerelease semver requires explicit opt-in via version pinning
- Updates `bump_version` to accept semver prerelease formats (e.g. `2.0.14-beta.1`) with semver-aware comparison
- Uses `github.ref_name` so CircleCI checks out whichever branch is selected in the GitHub Actions UI

## Test plan
- [ ] Trigger a dry-run release with `is_prerelease: true` and a beta version (e.g. `2.0.14-beta.1`) to verify the pipeline passes parameters end-to-end
- [ ] Verify `bump_version` accepts prerelease versions and rejects invalid formats
- [ ] Verify semver-aware prerelease comparison (e.g. `beta.10 > beta.9`)
- [ ] Verify `set_github_release` receives `is_prerelease: true` for beta releases
- [ ] Verify PR-to-main is skipped for prereleases
- [ ] Verify TestFlight deploy is skipped for prereleases
- [ ] Verify CocoaPods push still runs for prereleases
- [ ] Verify normal (non-prerelease) releases still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)