### PR TITLE
MSDK-264: Fix noisy identifier validation logs and refine clearUser docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ sdk.clearUser()
 [sdk clearUser];
 ```
 
+> **Push token users:** If your app uses Attentive push notifications, `clearUser` will also detach the push token from the logged-out user on the server, so they no longer receive push notifications on this device. Make sure to call `clearUser()` on every logout path.
+
 ### Update user via email and/or phone
 
 Our SDK supports switching the identified user via email and/or phone (at least one identifier must be provided). Calling this method will clear all identifiers previously associated with the current user (the sdk will automatically call clearUser()), and associate the app with the new identifier(s) you provide. This ensures that all subsequent events and messages are attributed to the newly identified user.
@@ -158,7 +160,6 @@ Our SDK supports switching the identified user via email and/or phone (at least 
 #### Swift
 ```
 // Update user with both email and phone
-attentiveSdk.clearUser() // Must be called prior to calling updateUser()
 attentiveSdk.updateUser(email: "user@example.com", phone: "+15551234567") { result in
     switch result {
     case .success:
@@ -210,9 +211,10 @@ attentiveSdk?.identify([
 ```
 
 ### 3. User logs out  
-Call `clearUser()` to remove identifiers.  
+Call `clearUser()` to remove identifiers. If your app uses Attentive push notifications, this also detaches the push token from the logged-out user.
 
-``` user logs out
+```swift
+// user logs out
 attentiveSdk?.clearUser()
 ```
 

--- a/Sources/Public/ATTNUserIdentity.swift
+++ b/Sources/Public/ATTNUserIdentity.swift
@@ -51,15 +51,16 @@ public final class ATTNUserIdentity: NSObject {
 
 fileprivate extension ATTNUserIdentity {
     func validate(identifiers: [String: Any]) {
-        ATTNIdentifierType.allKeys.forEach { currentKey in
-            ATTNParameterValidation.verifyStringOrNil(
-                identifiers[currentKey] as? NSObject,
-                inputName: currentKey
-            )
+        for key in identifiers.keys {
+            if key == ATTNIdentifierType.customIdentifiers {
+                ATTNParameterValidation.verify1DStringDictionaryOrNil(
+                    identifiers[key] as? NSDictionary,
+                    inputName: key)
+            } else {
+                ATTNParameterValidation.verifyStringOrNil(
+                    identifiers[key] as? NSObject,
+                    inputName: key)
+            }
         }
-
-        ATTNParameterValidation.verify1DStringDictionaryOrNil(
-            identifiers[ATTNIdentifierType.customIdentifiers] as? NSDictionary,
-            inputName: ATTNIdentifierType.customIdentifiers)
     }
 }


### PR DESCRIPTION
## Summary
- **Identifier validation** now only checks keys the caller actually provided, eliminating spurious "should be a non-empty NSString" warnings for keys like `shopifyId`, `klaviyoId`, `clientUserId` that the caller never set
- **README** adds a push token callout to the `clearUser` section for apps using push notifications, removes stale `clearUser()` call from `updateUser` example, and fixes a malformed code fence

## Test plan
- [ ] Call `identify(["email": "test@example.com"])` and verify logs no longer contain warnings for `clientUserId`, `phone`, `shopifyId`, `klaviyoId`
- [ ] Call `identify` with all identifiers and verify validation still works for provided keys
- [ ] Verify passing an invalid value (e.g. `NSNull`) for a provided key still logs a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)