### PR TITLE
Security fixes to CircleCI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
       - run:
           name: Checkout code
           command: |
-            git -c "http.https://github.com/.extraheader=Authorization: basic $(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64)" \
+            git -c "http.https://github.com/.extraheader=Authorization: basic $(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 -w 0)" \
               clone --filter=blob:none \
               "https://github.com/attentive-mobile/attentive-ios-sdk.git" .
             git checkout "${CIRCLE_SHA1}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,8 +152,9 @@ jobs:
       - run:
           name: Checkout code
           command: |
-            git clone --filter=blob:none \
-              "https://x-access-token:${GITHUB_TOKEN}@github.com/attentive-mobile/attentive-ios-sdk.git" .
+            git -c "http.https://github.com/.extraheader=Authorization: basic $(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64)" \
+              clone --filter=blob:none \
+              "https://github.com/attentive-mobile/attentive-ios-sdk.git" .
             git checkout "${CIRCLE_SHA1}"
 
       # Setup Fastlane
@@ -304,7 +305,7 @@ jobs:
 
             - aws-cli/setup:
                 region: AWS_REGION
-                role_arn: 'arn:aws:iam::026393418737:role/circleci'
+                role_arn: "${AWS_ROLE_ARN}"
                 role_session_name: $CIRCLE_JOB-<< pipeline.number >>
 
             - setup-fastlane

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,7 +305,7 @@ jobs:
 
             - aws-cli/setup:
                 region: AWS_REGION
-                role_arn: "${AWS_ROLE_ARN}"
+                role_arn: $AWS_ROLE_ARN
                 role_session_name: $CIRCLE_JOB-<< pipeline.number >>
 
             - setup-fastlane


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [X] CI related changes

## What's new?

These are minor changes to address some security findings on the CircleCI pipeline:

1. Instead of passing the `GITHUB_TOKEN` in the clone URL, it passes it as an additional header.  This prevents the token from possibly showing up in log files or other places it should not be visible
2. Moved the CircleCI AWS role ARN to an environmental variable.  While hard coding it was super low risk, it does present a tiny chance of providing intel to malicious actors, and the fix is simple, so we might as well do it

