### PR TITLE
Fix release job git auth + SPM cache key checksum path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,6 +422,17 @@ jobs:
 
       - github-cli/setup
 
+      # The workspace was cloned in `checkout-and-setup` with a GitHub App token that
+      # expires in ~1 hour. By the time this job runs the persisted credential is
+      # likely stale, so write a fresh auth header into the local git config before
+      # any git push (e.g. Fastlane's `push_git_tags`).
+      - run:
+          name: Refresh git auth header with fresh GitHub App token
+          command: |
+            git config --local --replace-all \
+              "http.https://github.com/.extraheader" \
+              "Authorization: basic $(printf 'x-access-token:%s' "${GITHUB_TOKEN}" | base64 -w 0)"
+
       - run:
           name: Create release for SDK via Fastlane
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
       # Cache Swift Package Manager dependencies
       - restore_cache:
           keys:
-            - v1-spm-{{ checksum "Package.resolved" }}
+            - v1-spm-{{ checksum "attentive-ios-sdk.xcworkspace/xcshareddata/swiftpm/Package.resolved" }}
             - v1-spm-
 
       # Resolve dependencies via Fastlane
@@ -177,7 +177,7 @@ jobs:
           command: bundle exec fastlane setup
 
       - save_cache:
-          key: v1-spm-{{ checksum "Package.resolved" }}
+          key: v1-spm-{{ checksum "attentive-ios-sdk.xcworkspace/xcshareddata/swiftpm/Package.resolved" }}
           paths:
             - ~/.swiftpm
             - ~/Library/Developer/Xcode/DerivedData


### PR DESCRIPTION
## Summary

- **Fix release job 403 on `git push`**: `release` re-mints a GitHub App token via `attentive/app-based-github-token`, but the workspace inherited from `checkout-and-setup` still has the stale token in its local git config. Add a step that writes a fresh `http.https://github.com/.extraheader` entry before Fastlane runs, so `push_git_tags` (and any other authenticated git op) uses the new token. Failure seen in [pipeline 420](https://app.circleci.com/pipelines/github/attentive-mobile/attentive-ios-sdk/420/workflows/9da95be2-57ef-461b-8c4d-64f87a63c835).
- **Fix `Package.resolved` cache-key error**: `restore_cache`/`save_cache` in `checkout-and-setup` referenced `Package.resolved` at the repo root, which doesn't exist. The real path is `attentive-ios-sdk.xcworkspace/xcshareddata/swiftpm/Package.resolved`. This was causing `error computing cache key` warnings on every run.

## Test plan

- [ ] Pipeline's `checkout-and-setup` job no longer emits `error computing cache key` on `restore_cache`/`save_cache`.
- [ ] Trigger a release workflow (API-triggered) and confirm the `release` job:
  - [ ] Runs the new "Refresh git auth header with fresh GitHub App token" step successfully.
  - [ ] `push_git_tags` succeeds (no `Permission … denied to circleci-attentive` / 403).
  - [ ] Fastlane `create_release` completes through tag push → GitHub release → CocoaPods push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)