### PR TITLE
MSDK-337: Fix Bonni app v2 endpoint events

### DIFF
--- a/Bonni/AttentiveExample/AppDelegate.swift
+++ b/Bonni/AttentiveExample/AppDelegate.swift
@@ -35,6 +35,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Initialize the ATTNEventTracker. This must be done before the ATTNEventTracker can be used to send any events. It only has to be done once per applicaiton lifecycle.
         ATTNEventTracker.setup(with: sdk)
 
+        sdk.useV2Endpoint = UserDefaults.standard.bool(forKey: "attentiveUseV2Endpoint")
+
         // Register the current user with the Attentive SDK by calling the `identify` method. Each identifier is optional, but the more identifiers you provide the better the Attentive SDK will function.
         // Every time any identifiers are added/changed, call the SDK's "identify" method
         // sdk.identify(AppDelegate.createUserIdentifiers())

--- a/Bonni/AttentiveExample/ProductCollectionViewCell.swift
+++ b/Bonni/AttentiveExample/ProductCollectionViewCell.swift
@@ -145,6 +145,7 @@ class ProductCollectionViewCell: UICollectionViewCell {
         }()
 
         productImageView.image = UIImage(named: product.name ?? "Protective Superscreen")
+        productImageView.contentMode = .scaleAspectFill
 
         addToCartButton.addTarget(self, action: #selector(addToCartTapped), for: .touchUpInside)
     }

--- a/Bonni/AttentiveExample/ProductDetailViewController.swift
+++ b/Bonni/AttentiveExample/ProductDetailViewController.swift
@@ -140,7 +140,10 @@ class ProductDetailViewController: UIViewController {
     
     // MARK: - Actions
     @objc private func addToCartTapped() {
+        let addToCartEvent = ATTNAddToCartEvent(items: [product])
+        ATTNEventTracker.sharedInstance()?.record(event: addToCartEvent)
         delegate?.productDetailViewController(self, didAddToCart: product)
+        showToast(with: "Add To Cart event sent")
     }
     
     @objc private func addToCartV2Tapped() {

--- a/Bonni/AttentiveExample/ProductDetailViewController.swift
+++ b/Bonni/AttentiveExample/ProductDetailViewController.swift
@@ -78,7 +78,12 @@ class ProductDetailViewController: UIViewController {
         setupUI()
         configureProduct()
     }
-    
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        showToast(with: "Product View event sent")
+    }
+
     // MARK: - Setup UI
     
     private func setupUI() {
@@ -114,7 +119,9 @@ class ProductDetailViewController: UIViewController {
     
     private func configureProduct() {
         productNameLabel.text = product.name ?? "Unknown Product"
-        if let imageUrl = product.productImage, let url = URL(string: imageUrl) {
+        if let name = product.name, let localImage = UIImage(named: name) {
+            productImageView.image = localImage
+        } else if let imageUrl = product.productImage, let url = URL(string: imageUrl) {
             loadImage(from: url)
         } else {
             productImageView.image = UIImage(systemName: "photo")

--- a/Bonni/AttentiveExample/ProductViewController.swift
+++ b/Bonni/AttentiveExample/ProductViewController.swift
@@ -228,8 +228,5 @@ extension ProductViewController: ProductCollectionViewCellDelegate {
 extension ProductViewController: ProductDetailViewControllerDelegate {
     func productDetailViewController(_ controller: ProductDetailViewController, didAddToCart product: ATTNItem) {
         viewModel.addProductToCart(product)
-        let addToCartEvent = ATTNAddToCartEvent(items: [product])
-        ATTNEventTracker.sharedInstance()?.record(event: addToCartEvent)
-        showToast(with: "Add To Cart event sent")
     }
 }

--- a/Bonni/AttentiveExample/ProductViewController.swift
+++ b/Bonni/AttentiveExample/ProductViewController.swift
@@ -202,9 +202,19 @@ class ProductViewController: UIViewController, UICollectionViewDataSource, UICol
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return 10
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
         return 10
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let product = viewModel.products[indexPath.item]
+        let productViewEvent = ATTNProductViewEvent(items: [product])
+        ATTNEventTracker.sharedInstance()?.record(event: productViewEvent)
+
+        let detailVC = ProductDetailViewController(product: product)
+        detailVC.delegate = self
+        navigationController?.pushViewController(detailVC, animated: true)
     }
 }
 
@@ -221,7 +231,6 @@ extension ProductViewController: ProductCollectionViewCellDelegate {
     func didTapProductImage(product: ATTNItem) {
         let productViewEvent = ATTNProductViewEvent(items: [product])
         ATTNEventTracker.sharedInstance()?.record(event: productViewEvent)
-        showToast(with: "Product View event sent")
 
         let detailVC = ProductDetailViewController(product: product)
         detailVC.delegate = self

--- a/Bonni/AttentiveExample/ProductViewController.swift
+++ b/Bonni/AttentiveExample/ProductViewController.swift
@@ -219,6 +219,10 @@ extension ProductViewController: ProductCollectionViewCellDelegate {
     }
     
     func didTapProductImage(product: ATTNItem) {
+        let productViewEvent = ATTNProductViewEvent(items: [product])
+        ATTNEventTracker.sharedInstance()?.record(event: productViewEvent)
+        showToast(with: "Product View event sent")
+
         let detailVC = ProductDetailViewController(product: product)
         detailVC.delegate = self
         navigationController?.pushViewController(detailVC, animated: true)

--- a/Bonni/AttentiveExample/SettingsViewController.swift
+++ b/Bonni/AttentiveExample/SettingsViewController.swift
@@ -547,6 +547,7 @@ class SettingsViewController: UIViewController {
 
     @objc private func v2ToggleChanged(_ sender: UISwitch) {
         getAttentiveSdk().useV2Endpoint = sender.isOn
+        UserDefaults.standard.set(sender.isOn, forKey: "attentiveUseV2Endpoint")
         showToast(with: sender.isOn ? "All events → /mobile (v2)" : "All events → /e (v1)")
     }
 

--- a/Bonni/AttentiveExample/SettingsViewController.swift
+++ b/Bonni/AttentiveExample/SettingsViewController.swift
@@ -131,6 +131,20 @@ class SettingsViewController: UIViewController {
         return button
     }()
 
+    private let v2EndpointToggle: UISwitch = {
+        let toggle = UISwitch()
+        toggle.translatesAutoresizingMaskIntoConstraints = false
+        return toggle
+    }()
+
+    private let v2EndpointLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Use V2 (/mobile) for all events"
+        label.font = UIFont(name: "DegularDisplay-Regular", size: 16)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
     private let copyDeviceTokenButton: UIButton = {
         let copyButton = UIButton(type: .system)
         copyButton.setTitle("Copy Device Token", for: .normal)
@@ -265,6 +279,19 @@ class SettingsViewController: UIViewController {
         divider.translatesAutoresizingMaskIntoConstraints = false
         divider.heightAnchor.constraint(equalToConstant: 1).isActive = true
         stackView.addArrangedSubview(divider)
+
+        let v2Row = UIStackView(arrangedSubviews: [v2EndpointLabel, v2EndpointToggle])
+        v2Row.axis = .horizontal
+        v2Row.spacing = 8
+        v2EndpointToggle.isOn = getAttentiveSdk().useV2Endpoint
+        v2EndpointToggle.addTarget(self, action: #selector(v2ToggleChanged), for: .valueChanged)
+        stackView.addArrangedSubview(v2Row)
+
+        let divider2 = UIView()
+        divider2.backgroundColor = .lightGray
+        divider2.translatesAutoresizingMaskIntoConstraints = false
+        divider2.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        stackView.addArrangedSubview(divider2)
 
         stackView.addArrangedSubview(showCreativeButton)
         stackView.addArrangedSubview(showPushPermissionButton)
@@ -516,6 +543,11 @@ class SettingsViewController: UIViewController {
     @objc private func clearUserTapped() {
         getAttentiveSdk().clearUser()
         showToast(with: "User cleared")
+    }
+
+    @objc private func v2ToggleChanged(_ sender: UISwitch) {
+        getAttentiveSdk().useV2Endpoint = sender.isOn
+        showToast(with: sender.isOn ? "All events → /mobile (v2)" : "All events → /e (v1)")
     }
 
     @objc private func clearCookiesTapped() {

--- a/Sources/API/ATTNEventTypes.swift
+++ b/Sources/API/ATTNEventTypes.swift
@@ -178,9 +178,11 @@ public struct ATTNPurchaseMetadata: Codable {
 /// Metadata for "MobileCustomEvent" events.
 public struct ATTNMobileCustomEventMetadata: Codable {
     public let eventType: String = "MobileCustomEvent"
+    public let type: String?
     public let customProperties: [String: String]?
 
-    public init(customProperties: [String: String]? = nil) {
+    public init(type: String? = nil, customProperties: [String: String]? = nil) {
+        self.type = type
         self.customProperties = customProperties
     }
 }

--- a/Sources/Helpers/Extension/ATTNSDK+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNSDK+Extension.swift
@@ -9,15 +9,19 @@ import Foundation
 
 extension ATTNSDK {
     func send(event: ATTNEvent) {
-        if useV2Endpoint, let v2Event = convertLegacyEventToV2(event) {
-            recordV2EventData(v2Event)
+        if useV2Endpoint {
+            sendLegacyEventAsV2(event)
             return
         }
         api.send(event: event, userIdentity: userIdentity)
     }
 
-    private func convertLegacyEventToV2(_ event: ATTNEvent) -> ATTNEventData? {
+    private func sendLegacyEventAsV2(_ event: ATTNEvent) {
         if let purchase = event as? ATTNPurchaseEvent {
+            guard !purchase.items.isEmpty else {
+                Loggers.event.debug("No items found in the purchase event, skipping v2 send.")
+                return
+            }
             let products = purchase.items.map { item in
                 ATTNProduct(
                     productId: item.productId,
@@ -34,59 +38,63 @@ extension ATTNSDK {
             let orderTotal = products.reduce(0.0) {
                 $0 + (Double($1.price) ?? 0) * Double($1.quantity)
             }
-            return .purchase(
+            sendPurchaseEvent(
                 orderId: purchase.order.orderId,
                 currency: currency,
                 orderTotal: String(format: "%.2f", orderTotal),
                 cart: cart,
                 products: products
             )
+            return
         }
 
-        if let addToCart = event as? ATTNAddToCartEvent, let item = addToCart.items.first {
-            let product = ATTNProduct(
-                productId: item.productId,
-                variantId: item.productVariantId,
-                name: item.name ?? "",
-                imageUrl: item.productImage,
-                categories: item.category.map { [$0] },
-                price: item.price.price.stringValue,
-                quantity: item.quantity
-            )
-            return .addToCart(product: product, currency: item.price.currency)
+        if let addToCart = event as? ATTNAddToCartEvent {
+            guard !addToCart.items.isEmpty else {
+                Loggers.event.debug("No items found in the AddToCart event, skipping v2 send.")
+                return
+            }
+            for item in addToCart.items {
+                let product = ATTNProduct(
+                    productId: item.productId,
+                    variantId: item.productVariantId,
+                    name: item.name ?? "",
+                    imageUrl: item.productImage,
+                    categories: item.category.map { [$0] },
+                    price: item.price.price.stringValue,
+                    quantity: item.quantity
+                )
+                sendAddToCartEvent(product: product, currency: item.price.currency)
+            }
+            return
         }
 
-        if let productView = event as? ATTNProductViewEvent, let item = productView.items.first {
-            let product = ATTNProduct(
-                productId: item.productId,
-                variantId: item.productVariantId,
-                name: item.name ?? "",
-                imageUrl: item.productImage,
-                categories: item.category.map { [$0] },
-                price: item.price.price.stringValue,
-                quantity: item.quantity
-            )
-            return .productView(product: product, currency: item.price.currency)
+        if let productView = event as? ATTNProductViewEvent {
+            guard !productView.items.isEmpty else {
+                Loggers.event.debug("No items found in the ProductView event, skipping v2 send.")
+                return
+            }
+            for item in productView.items {
+                let product = ATTNProduct(
+                    productId: item.productId,
+                    variantId: item.productVariantId,
+                    name: item.name ?? "",
+                    imageUrl: item.productImage,
+                    categories: item.category.map { [$0] },
+                    price: item.price.price.stringValue,
+                    quantity: item.quantity
+                )
+                sendProductViewEvent(product: product, currency: item.price.currency)
+            }
+            return
         }
 
         if let customEvent = event as? ATTNCustomEvent {
-            return .customEvent(customProperties: customEvent.properties)
+            sendCustomEvent(type: customEvent.type, customProperties: customEvent.properties)
+            return
         }
 
-        return nil
-    }
-
-    private func recordV2EventData(_ eventData: ATTNEventData) {
-        switch eventData {
-        case let .addToCart(product, currency):
-            sendAddToCartEvent(product: product, currency: currency)
-        case let .productView(product, currency):
-            sendProductViewEvent(product: product, currency: currency)
-        case let .purchase(orderId, currency, orderTotal, cart, products):
-            sendPurchaseEvent(orderId: orderId, currency: currency, orderTotal: orderTotal, cart: cart, products: products)
-        case let .customEvent(customProperties):
-            sendCustomEvent(customProperties: customProperties)
-        }
+        Loggers.event.debug("Unsupported event type for v2 conversion, falling back to legacy.")
+        api.send(event: event, userIdentity: userIdentity)
     }
 
     func initializeSkipFatigueOnCreatives() {
@@ -127,8 +135,8 @@ extension ATTNSDK {
         sendNewEventInternal(eventType: .purchase, metadata: metadata)
     }
 
-    func sendCustomEvent(customProperties: [String: String]?) {
-        let metadata = ATTNMobileCustomEventMetadata(customProperties: customProperties)
+    func sendCustomEvent(type: String? = nil, customProperties: [String: String]?) {
+        let metadata = ATTNMobileCustomEventMetadata(type: type, customProperties: customProperties)
         sendNewEventInternal(eventType: .mobileCustomEvent, metadata: metadata)
     }
 

--- a/Sources/Helpers/Extension/ATTNSDK+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNSDK+Extension.swift
@@ -9,7 +9,84 @@ import Foundation
 
 extension ATTNSDK {
     func send(event: ATTNEvent) {
+        if useV2Endpoint, let v2Event = convertLegacyEventToV2(event) {
+            recordV2EventData(v2Event)
+            return
+        }
         api.send(event: event, userIdentity: userIdentity)
+    }
+
+    private func convertLegacyEventToV2(_ event: ATTNEvent) -> ATTNEventData? {
+        if let purchase = event as? ATTNPurchaseEvent {
+            let products = purchase.items.map { item in
+                ATTNProduct(
+                    productId: item.productId,
+                    variantId: item.productVariantId,
+                    name: item.name ?? "",
+                    imageUrl: item.productImage,
+                    categories: item.category.map { [$0] },
+                    price: item.price.price.stringValue,
+                    quantity: item.quantity
+                )
+            }
+            let cart = ATTNCartPayload(from: purchase.cart)
+            let currency = purchase.items.first?.price.currency ?? "USD"
+            let orderTotal = products.reduce(0.0) {
+                $0 + (Double($1.price) ?? 0) * Double($1.quantity)
+            }
+            return .purchase(
+                orderId: purchase.order.orderId,
+                currency: currency,
+                orderTotal: String(format: "%.2f", orderTotal),
+                cart: cart,
+                products: products
+            )
+        }
+
+        if let addToCart = event as? ATTNAddToCartEvent, let item = addToCart.items.first {
+            let product = ATTNProduct(
+                productId: item.productId,
+                variantId: item.productVariantId,
+                name: item.name ?? "",
+                imageUrl: item.productImage,
+                categories: item.category.map { [$0] },
+                price: item.price.price.stringValue,
+                quantity: item.quantity
+            )
+            return .addToCart(product: product, currency: item.price.currency)
+        }
+
+        if let productView = event as? ATTNProductViewEvent, let item = productView.items.first {
+            let product = ATTNProduct(
+                productId: item.productId,
+                variantId: item.productVariantId,
+                name: item.name ?? "",
+                imageUrl: item.productImage,
+                categories: item.category.map { [$0] },
+                price: item.price.price.stringValue,
+                quantity: item.quantity
+            )
+            return .productView(product: product, currency: item.price.currency)
+        }
+
+        if let customEvent = event as? ATTNCustomEvent {
+            return .customEvent(customProperties: customEvent.properties)
+        }
+
+        return nil
+    }
+
+    private func recordV2EventData(_ eventData: ATTNEventData) {
+        switch eventData {
+        case let .addToCart(product, currency):
+            sendAddToCartEvent(product: product, currency: currency)
+        case let .productView(product, currency):
+            sendProductViewEvent(product: product, currency: currency)
+        case let .purchase(orderId, currency, orderTotal, cart, products):
+            sendPurchaseEvent(orderId: orderId, currency: currency, orderTotal: orderTotal, cart: cart, products: products)
+        case let .customEvent(customProperties):
+            sendCustomEvent(customProperties: customProperties)
+        }
     }
 
     func initializeSkipFatigueOnCreatives() {

--- a/Sources/Helpers/Extension/ATTNSDK+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNSDK+Extension.swift
@@ -22,26 +22,17 @@ extension ATTNSDK {
                 Loggers.event.debug("No items found in the purchase event, skipping v2 send.")
                 return
             }
-            let products = purchase.items.map { item in
-                ATTNProduct(
-                    productId: item.productId,
-                    variantId: item.productVariantId,
-                    name: item.name ?? "",
-                    imageUrl: item.productImage,
-                    categories: item.category.map { [$0] },
-                    price: item.price.price.stringValue,
-                    quantity: item.quantity
-                )
-            }
+            let products = purchase.items.map { product(from: $0) }
             let cart = ATTNCartPayload(from: purchase.cart)
-            let currency = purchase.items.first?.price.currency ?? "USD"
-            let orderTotal = products.reduce(0.0) {
-                $0 + (Double($1.price) ?? 0) * Double($1.quantity)
+            let currency = purchase.items[0].price.currency
+            let orderTotal = purchase.items.reduce(NSDecimalNumber.zero) { total, item in
+                let quantity = NSDecimalNumber(value: item.quantity)
+                return total.adding(item.price.price.multiplying(by: quantity))
             }
             sendPurchaseEvent(
                 orderId: purchase.order.orderId,
                 currency: currency,
-                orderTotal: String(format: "%.2f", orderTotal),
+                orderTotal: orderTotal.stringValue,
                 cart: cart,
                 products: products
             )
@@ -54,16 +45,7 @@ extension ATTNSDK {
                 return
             }
             for item in addToCart.items {
-                let product = ATTNProduct(
-                    productId: item.productId,
-                    variantId: item.productVariantId,
-                    name: item.name ?? "",
-                    imageUrl: item.productImage,
-                    categories: item.category.map { [$0] },
-                    price: item.price.price.stringValue,
-                    quantity: item.quantity
-                )
-                sendAddToCartEvent(product: product, currency: item.price.currency)
+                sendAddToCartEvent(product: product(from: item), currency: item.price.currency)
             }
             return
         }
@@ -74,16 +56,7 @@ extension ATTNSDK {
                 return
             }
             for item in productView.items {
-                let product = ATTNProduct(
-                    productId: item.productId,
-                    variantId: item.productVariantId,
-                    name: item.name ?? "",
-                    imageUrl: item.productImage,
-                    categories: item.category.map { [$0] },
-                    price: item.price.price.stringValue,
-                    quantity: item.quantity
-                )
-                sendProductViewEvent(product: product, currency: item.price.currency)
+                sendProductViewEvent(product: product(from: item), currency: item.price.currency)
             }
             return
         }
@@ -95,6 +68,18 @@ extension ATTNSDK {
 
         Loggers.event.debug("Unsupported event type for v2 conversion, falling back to legacy.")
         api.send(event: event, userIdentity: userIdentity)
+    }
+
+    private func product(from item: ATTNItem) -> ATTNProduct {
+        ATTNProduct(
+            productId: item.productId,
+            variantId: item.productVariantId,
+            name: item.name ?? "",
+            imageUrl: item.productImage,
+            categories: item.category.map { [$0] },
+            price: item.price.price.stringValue,
+            quantity: item.quantity
+        )
     }
 
     func initializeSkipFatigueOnCreatives() {

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -65,6 +65,9 @@ public final class ATTNSDK: NSObject {
     /// Determinates if fatigue rules evaluation will be skipped for Creative. Default value is false.
     @objc public var skipFatigueOnCreative: Bool = false
 
+    /// Routes legacy `record(event:)` calls through the v2 `/mobile` endpoint instead of `/e`.
+    @objc public var useV2Endpoint: Bool = false
+
     public init(domain: String, mode: ATTNSDKMode) {
         Loggers.creative.debug("Initializing ATTNSDK v\(ATTNConstants.sdkVersion, privacy: .public), Mode: \(mode.rawValue, privacy: .public), Domain: \(domain, privacy: .public)")
 

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -572,6 +572,10 @@ public final class ATTNSDK: NSObject {
         }
         Loggers.event.debug("updateUser: proceeding with push token: \(pushToken, privacy: .public)")
         clearUserIdentifiers()
+        var newIdentifiers: [String: Any] = [:]
+        if let email = email { newIdentifiers[ATTNIdentifierType.email] = email }
+        if let phone = phone { newIdentifiers[ATTNIdentifierType.phone] = phone }
+        userIdentity.mergeIdentifiers(newIdentifiers)
         api.updateUser(
             pushToken: pushToken,
             userIdentity: userIdentity,

--- a/Tests/Doubles/Spies/ATTNAPISpy.swift
+++ b/Tests/Doubles/Spies/ATTNAPISpy.swift
@@ -17,6 +17,7 @@ final class ATTNAPISpy: ATTNAPIProtocol {
     private(set) var sendNewEventWasCalled = false
     private(set) var sendNewEventCallCount = 0
     private(set) var lastEventRequest: ATTNEventRequest?
+    private(set) var lastEventMetadata: Any?
     private(set) var updateDomainWasCalled = false
     private(set) var domainWasSet = false
     private(set) var sendPushTokenWasCalled = false
@@ -74,6 +75,7 @@ final class ATTNAPISpy: ATTNAPIProtocol {
         sendNewEventWasCalled = true
         sendNewEventCallCount += 1
         lastEventRequest = eventRequest
+        lastEventMetadata = event.eventMetadata
         callback?(nil, nil, nil, nil)
     }
 

--- a/Tests/Doubles/Spies/ATTNAPISpy.swift
+++ b/Tests/Doubles/Spies/ATTNAPISpy.swift
@@ -15,6 +15,8 @@ final class ATTNAPISpy: ATTNAPIProtocol {
     private(set) var sendEventWasCalled = false
     private(set) var sendEventCallbackWasCalled = false
     private(set) var sendNewEventWasCalled = false
+    private(set) var sendNewEventCallCount = 0
+    private(set) var lastEventRequest: ATTNEventRequest?
     private(set) var updateDomainWasCalled = false
     private(set) var domainWasSet = false
     private(set) var sendPushTokenWasCalled = false
@@ -70,6 +72,8 @@ final class ATTNAPISpy: ATTNAPIProtocol {
         callback: ATTNAPICallback?
     ) {
         sendNewEventWasCalled = true
+        sendNewEventCallCount += 1
+        lastEventRequest = eventRequest
         callback?(nil, nil, nil, nil)
     }
 

--- a/Tests/TestCases/ATTNSDKTests.swift
+++ b/Tests/TestCases/ATTNSDKTests.swift
@@ -415,6 +415,138 @@ final class ATTNSDKTests: XCTestCase {
         XCTAssertEqual(apiSpy.lastOperationContext, "updateUser")
     }
 
+    func testUpdateUser_storesIdentifiersLocally() {
+        let deviceToken = Data([0x01, 0x02, 0x03])
+        sut.registerDeviceToken(deviceToken, authorizationStatus: .authorized)
+
+        sut.updateUser(email: "new@example.com", phone: "+15551234567")
+
+        let identifiers = sut.getUserIdentity().identifiers
+        XCTAssertEqual(identifiers[ATTNIdentifierType.email] as? String, "new@example.com",
+                       "updateUser should store email locally on userIdentity")
+        XCTAssertEqual(identifiers[ATTNIdentifierType.phone] as? String, "+15551234567",
+                       "updateUser should store phone locally on userIdentity")
+    }
+
+    // MARK: - sendLegacyEventAsV2 Tests
+
+    func testSendEvent_v2Enabled_purchase_sendNewEvent() {
+        sut.useV2Endpoint = true
+        let item = ATTNItem(productId: "p1", productVariantId: "v1", price: ATTNPrice(price: NSDecimalNumber(string: "9.99"), currency: "USD"))
+        item.quantity = 2
+        let order = ATTNOrder(orderId: "order-1")
+        let event = ATTNPurchaseEvent(items: [item], order: order)
+
+        sut.send(event: event)
+
+        XCTAssertTrue(apiSpy.sendNewEventWasCalled)
+        XCTAssertFalse(apiSpy.sendEventWasCalled)
+        XCTAssertEqual(apiSpy.lastEventRequest?.eventNameAbbreviation, ATTNEventTypes.purchase)
+    }
+
+    func testSendEvent_v2Enabled_purchaseMultipleItems_computesCorrectTotal() {
+        sut.useV2Endpoint = true
+        let item1 = ATTNItem(productId: "p1", productVariantId: "v1", price: ATTNPrice(price: NSDecimalNumber(string: "10.00"), currency: "USD"))
+        item1.quantity = 2
+        let item2 = ATTNItem(productId: "p2", productVariantId: "v2", price: ATTNPrice(price: NSDecimalNumber(string: "5.50"), currency: "USD"))
+        item2.quantity = 3
+        let order = ATTNOrder(orderId: "order-2")
+        let event = ATTNPurchaseEvent(items: [item1, item2], order: order)
+
+        sut.send(event: event)
+
+        XCTAssertTrue(apiSpy.sendNewEventWasCalled)
+        XCTAssertEqual(apiSpy.sendNewEventCallCount, 1)
+    }
+
+    func testSendEvent_v2Enabled_addToCart_sendsPerItem() {
+        sut.useV2Endpoint = true
+        let item1 = ATTNItem(productId: "p1", productVariantId: "v1", price: ATTNPrice(price: NSDecimalNumber(string: "10.00"), currency: "USD"))
+        let item2 = ATTNItem(productId: "p2", productVariantId: "v2", price: ATTNPrice(price: NSDecimalNumber(string: "20.00"), currency: "EUR"))
+        let event = ATTNAddToCartEvent(items: [item1, item2])
+
+        sut.send(event: event)
+
+        XCTAssertTrue(apiSpy.sendNewEventWasCalled)
+        XCTAssertEqual(apiSpy.sendNewEventCallCount, 2)
+        XCTAssertEqual(apiSpy.lastEventRequest?.eventNameAbbreviation, ATTNEventTypes.addToCart)
+    }
+
+    func testSendEvent_v2Enabled_productView_sendsPerItem() {
+        sut.useV2Endpoint = true
+        let item1 = ATTNItem(productId: "p1", productVariantId: "v1", price: ATTNPrice(price: NSDecimalNumber(string: "15.00"), currency: "GBP"))
+        let item2 = ATTNItem(productId: "p2", productVariantId: "v2", price: ATTNPrice(price: NSDecimalNumber(string: "25.00"), currency: "GBP"))
+        let event = ATTNProductViewEvent(items: [item1, item2])
+
+        sut.send(event: event)
+
+        XCTAssertTrue(apiSpy.sendNewEventWasCalled)
+        XCTAssertEqual(apiSpy.sendNewEventCallCount, 2)
+        XCTAssertEqual(apiSpy.lastEventRequest?.eventNameAbbreviation, ATTNEventTypes.productView)
+    }
+
+    func testSendEvent_v2Enabled_customEvent_sendsWithType() {
+        sut.useV2Endpoint = true
+        let event = ATTNCustomEvent(type: "Signup", properties: ["source": "banner"])!
+
+        sut.send(event: event)
+
+        XCTAssertTrue(apiSpy.sendNewEventWasCalled)
+        XCTAssertEqual(apiSpy.lastEventRequest?.eventNameAbbreviation, ATTNEventTypes.customEvent)
+    }
+
+    func testSendEvent_v2Enabled_unsupportedEvent_fallsBackToLegacy() {
+        sut.useV2Endpoint = true
+        let event = ATTNInfoEvent()
+
+        sut.send(event: event)
+
+        XCTAssertFalse(apiSpy.sendNewEventWasCalled)
+        XCTAssertTrue(apiSpy.sendEventWasCalled)
+    }
+
+    func testSendEvent_v2Enabled_emptyPurchaseItems_doesNotSend() {
+        sut.useV2Endpoint = true
+        let order = ATTNOrder(orderId: "order-empty")
+        let event = ATTNPurchaseEvent(items: [], order: order)
+
+        sut.send(event: event)
+
+        XCTAssertFalse(apiSpy.sendNewEventWasCalled)
+        XCTAssertFalse(apiSpy.sendEventWasCalled)
+    }
+
+    func testSendEvent_v2Enabled_emptyAddToCartItems_doesNotSend() {
+        sut.useV2Endpoint = true
+        let event = ATTNAddToCartEvent(items: [])
+
+        sut.send(event: event)
+
+        XCTAssertFalse(apiSpy.sendNewEventWasCalled)
+        XCTAssertFalse(apiSpy.sendEventWasCalled)
+    }
+
+    func testSendEvent_v2Enabled_emptyProductViewItems_doesNotSend() {
+        sut.useV2Endpoint = true
+        let event = ATTNProductViewEvent(items: [])
+
+        sut.send(event: event)
+
+        XCTAssertFalse(apiSpy.sendNewEventWasCalled)
+        XCTAssertFalse(apiSpy.sendEventWasCalled)
+    }
+
+    func testSendEvent_v2Disabled_usesLegacyPath() {
+        sut.useV2Endpoint = false
+        let item = ATTNItem(productId: "p1", productVariantId: "v1", price: ATTNPrice(price: NSDecimalNumber(string: "10.00"), currency: "USD"))
+        let event = ATTNAddToCartEvent(items: [item])
+
+        sut.send(event: event)
+
+        XCTAssertTrue(apiSpy.sendEventWasCalled)
+        XCTAssertFalse(apiSpy.sendNewEventWasCalled)
+    }
+
     private func waitForCondition(_ condition: @escaping () -> Bool, timeout: TimeInterval = 0.25) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {

--- a/Tests/TestCases/ATTNSDKTests.swift
+++ b/Tests/TestCases/ATTNSDKTests.swift
@@ -457,6 +457,8 @@ final class ATTNSDKTests: XCTestCase {
 
         XCTAssertTrue(apiSpy.sendNewEventWasCalled)
         XCTAssertEqual(apiSpy.sendNewEventCallCount, 1)
+        let metadata = apiSpy.lastEventMetadata as? ATTNPurchaseMetadata
+        XCTAssertEqual(metadata?.orderTotal, "36.5")
     }
 
     func testSendEvent_v2Enabled_addToCart_sendsPerItem() {


### PR DESCRIPTION
## Summary

- **Fix duplicate events:** V2 buttons (Add to Cart, Place Order) in the Bonni app were firing both a `/mobile` (v2) and `/e` (v1) event. Moved legacy event sending out of the delegate callback so each button owns its own event path.
- **App-wide v1/v2 toggle:** Added `useV2Endpoint` property on `ATTNSDK` that automatically converts legacy `record(event:)` calls to v2 format and routes them through `/mobile`. Supports Purchase, AddToCart, ProductView, and CustomEvent; unsupported types (e.g. InfoEvent) fall through to `/e`.
- **ProductView on product tap:** Tapping a product cell in the grid now fires a ProductView event, routed by the toggle.
- **Settings toggle with persistence:** Added a toggle switch in Bonni's Settings screen to flip between v1/v2 at runtime, persisted via UserDefaults across app launches.

Jira: [MSDK-337](https://attentivemobile.atlassian.net/browse/MSDK-337)

## Test plan

- [x] Verified via Datadog logs that V2 buttons send only `/mobile` events (no duplicate `/e` events)
- [x] Verified via Datadog logs that with toggle ON, legacy `record(event:)` calls route through `/mobile`
- [x] Verified identity (`t=i`) events still go through `/e` as expected
- [ ] Toggle ON → tap product → verify ProductView goes to `/mobile`
- [ ] Toggle OFF → tap product → verify ProductView goes to `/e`
- [ ] Toggle ON → Place Order (legacy button) → verify Purchase goes to `/mobile`
- [ ] Kill and relaunch app → verify toggle state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-337]: https://attentivemobile.atlassian.net/browse/MSDK-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ