### PR TITLE
MSDK-314: centralize hardcoded URLs, timeouts, and config values

### DIFF
--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -106,8 +106,9 @@ final class ATTNAPI: ATTNAPIProtocol {
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
+        request.timeoutInterval = ATTNSDKConfiguration.Timeout.defaultRequest
+        request.setValue(ATTNSDKConfiguration.Headers.applicationJSON, forHTTPHeaderField: ATTNSDKConfiguration.Headers.contentType)
+        request.setValue(ATTNSDKConfiguration.Headers.datadogSamplingPriorityKeep, forHTTPHeaderField: ATTNSDKConfiguration.Headers.datadogSamplingPriority)
         request.httpBody = try? JSONSerialization.data(withJSONObject: payload)
 
         Loggers.network.debug("POST /token payload: \(payload, privacy: .public)")
@@ -149,14 +150,15 @@ final class ATTNAPI: ATTNAPIProtocol {
                 "events": events
             ]
 
-            guard let url = URL(string: "https://mobile.attentivemobile.com/mtctrl") else {
+            guard let url = ATTNSDKConfiguration.Endpoint.Mobile.appEventsURL else {
                 Loggers.network.error("Invalid AppEvents URL")
                 return
             }
 
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.timeoutInterval = ATTNSDKConfiguration.Timeout.defaultRequest
+            request.setValue(ATTNSDKConfiguration.Headers.applicationJSON, forHTTPHeaderField: ATTNSDKConfiguration.Headers.contentType)
             request.httpBody = try? JSONSerialization.data(withJSONObject: payload)
 
             Loggers.network.debug("POST app open events payload: \(payload, privacy: .public)")
@@ -199,7 +201,7 @@ final class ATTNAPI: ATTNAPIProtocol {
             if let phone = phone { payload["phone"] = phone }
             if !pushToken.isEmpty { payload["pt"] = pushToken }
 
-            guard let url = URL(string: "https://mobile.attentivemobile.com/opt-in-subscriptions") else {
+            guard let url = ATTNSDKConfiguration.Endpoint.Mobile.optInURL else {
                 Loggers.network.error("Invalid opt-in subscriptions URL")
                 callback?(nil, nil, nil, ATTNError.badURL)
                 return
@@ -207,9 +209,9 @@ final class ATTNAPI: ATTNAPIProtocol {
 
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
-            request.timeoutInterval = 15
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
+            request.timeoutInterval = ATTNSDKConfiguration.Timeout.defaultRequest
+            request.setValue(ATTNSDKConfiguration.Headers.applicationJSON, forHTTPHeaderField: ATTNSDKConfiguration.Headers.contentType)
+            request.setValue(ATTNSDKConfiguration.Headers.datadogSamplingPriorityKeep, forHTTPHeaderField: ATTNSDKConfiguration.Headers.datadogSamplingPriority)
             request.httpBody = try? JSONSerialization.data(withJSONObject: payload, options: [])
 
             Loggers.network.debug("POST /opt-in-subscriptions payload: \(payload, privacy: .public)")
@@ -261,7 +263,7 @@ final class ATTNAPI: ATTNAPIProtocol {
             if let phone = phone { payload["phone"] = phone }
             if !pushToken.isEmpty { payload["pt"] = pushToken }
 
-            guard let url = URL(string: "https://mobile.attentivemobile.com/opt-out-subscriptions") else {
+            guard let url = ATTNSDKConfiguration.Endpoint.Mobile.optOutURL else {
                 Loggers.network.error("Invalid opt-out subscriptions URL")
                 callback?(nil, nil, nil, ATTNError.badURL)
                 return
@@ -269,9 +271,9 @@ final class ATTNAPI: ATTNAPIProtocol {
 
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
-            request.timeoutInterval = 15
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
+            request.timeoutInterval = ATTNSDKConfiguration.Timeout.defaultRequest
+            request.setValue(ATTNSDKConfiguration.Headers.applicationJSON, forHTTPHeaderField: ATTNSDKConfiguration.Headers.contentType)
+            request.setValue(ATTNSDKConfiguration.Headers.datadogSamplingPriorityKeep, forHTTPHeaderField: ATTNSDKConfiguration.Headers.datadogSamplingPriority)
             request.httpBody = try? JSONSerialization.data(withJSONObject: payload, options: [])
 
             Loggers.network.debug("POST /opt-out-subscriptions payload: \(payload, privacy: .public)")
@@ -343,7 +345,7 @@ final class ATTNAPI: ATTNAPIProtocol {
         ]
         if !pushToken.isEmpty { payload["pt"] = pushToken }
 
-        guard let url = URL(string: "https://mobile.attentivemobile.com:443/user-update") else {
+        guard let url = ATTNSDKConfiguration.Endpoint.Mobile.userUpdateURL else {
             Loggers.network.error("\(operationContext, privacy: .public): invalid URL")
             callback?(nil, nil, nil, ATTNError.badURL)
             return
@@ -351,9 +353,9 @@ final class ATTNAPI: ATTNAPIProtocol {
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.timeoutInterval = 15
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
+        request.timeoutInterval = ATTNSDKConfiguration.Timeout.defaultRequest
+        request.setValue(ATTNSDKConfiguration.Headers.applicationJSON, forHTTPHeaderField: ATTNSDKConfiguration.Headers.contentType)
+        request.setValue(ATTNSDKConfiguration.Headers.datadogSamplingPriorityKeep, forHTTPHeaderField: ATTNSDKConfiguration.Headers.datadogSamplingPriority)
         request.httpBody = try? JSONSerialization.data(withJSONObject: payload, options: [])
 
         Loggers.network.debug("\(operationContext, privacy: .public): POST /user-update payload: \(payload, privacy: .public)")
@@ -398,6 +400,7 @@ fileprivate extension ATTNAPI {
 
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
+        urlRequest.timeoutInterval = ATTNSDKConfiguration.Timeout.defaultRequest
 
         let task = urlSession.dataTask(with: urlRequest) { data, response, error in
             if let error = error {
@@ -424,6 +427,7 @@ fileprivate extension ATTNAPI {
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
+        request.timeoutInterval = ATTNSDKConfiguration.Timeout.defaultRequest
 
         let task = urlSession.dataTask(with: request) { data, response, error in
             if let error = error {
@@ -445,7 +449,7 @@ fileprivate extension ATTNAPI {
 extension ATTNAPI {
     static func isInvalidDomain(_ domain: String) -> Bool {
         let normalized = domain.lowercased()
-        return normalized.contains("attn.tv") || normalized.contains("/") || normalized.contains(":")
+        return ATTNSDKConfiguration.Endpoint.invalidDomainSubstrings.contains { normalized.contains($0) }
     }
 
 
@@ -473,8 +477,9 @@ extension ATTNAPI {
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("application/x-www-form-urlencoded; charset=utf-8", forHTTPHeaderField: "Content-Type")
-        request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
+        request.timeoutInterval = ATTNSDKConfiguration.Timeout.defaultRequest
+        request.setValue(ATTNSDKConfiguration.Headers.formURLEncoded, forHTTPHeaderField: ATTNSDKConfiguration.Headers.contentType)
+        request.setValue(ATTNSDKConfiguration.Headers.datadogSamplingPriorityKeep, forHTTPHeaderField: ATTNSDKConfiguration.Headers.datadogSamplingPriority)
 
         do {
             // Encode the event to JSON with explicit null values

--- a/Sources/ATTNRetryingNetworkClient.swift
+++ b/Sources/ATTNRetryingNetworkClient.swift
@@ -19,10 +19,10 @@ struct ATTNRetryConfiguration {
     let maxCumulativeDelay: TimeInterval
 
     init(
-        initialDelay: TimeInterval = 1.0,
-        maxRetries: Int = 5,
-        jitterRange: ClosedRange<Double> = -0.5...0.5,
-        maxCumulativeDelay: TimeInterval = 300.0 // 5 minutes
+        initialDelay: TimeInterval = ATTNSDKConfiguration.Retry.initialDelay,
+        maxRetries: Int = ATTNSDKConfiguration.Retry.maxRetries,
+        jitterRange: ClosedRange<Double> = ATTNSDKConfiguration.Retry.jitterRange,
+        maxCumulativeDelay: TimeInterval = ATTNSDKConfiguration.Retry.maxCumulativeDelay
     ) {
         self.initialDelay = initialDelay
         self.maxRetries = maxRetries

--- a/Sources/ATTNSDKConfiguration.swift
+++ b/Sources/ATTNSDKConfiguration.swift
@@ -1,0 +1,108 @@
+//
+//  ATTNSDKConfiguration.swift
+//  attentive-ios-sdk-framework
+//
+
+import Foundation
+
+/// Single source of truth for network endpoints, timeouts, retry policy, and
+/// persistent-storage keys used by the SDK. Any new endpoint, header, or
+/// default value should be added here instead of being inlined at the call site.
+internal enum ATTNSDKConfiguration {
+
+    // MARK: - Endpoints
+
+    /// Scheme/host/path/port for every SDK endpoint. When adding a new endpoint,
+    /// extend this enum rather than building a URL from a string literal.
+    enum Endpoint {
+        static let scheme = "https"
+
+        /// `events.attentivemobile.com` — legacy event pipeline (`/e`) and new
+        /// typed event pipeline (`/mobile`).
+        enum Events {
+            static let host = "events.attentivemobile.com"
+            static let legacyPath = "/e"
+            static let newEventPath = "/mobile"
+        }
+
+        /// `mobile.attentivemobile.com` — push token, marketing control,
+        /// opt-in/opt-out, and user-update endpoints.
+        enum Mobile {
+            static let host = "mobile.attentivemobile.com"
+            static let port = 443
+            static let pushTokenPath = "/token"
+            static let appEventsPath = "/mtctrl"
+            static let optInPath = "/opt-in-subscriptions"
+            static let optOutPath = "/opt-out-subscriptions"
+            static let userUpdatePath = "/user-update"
+
+            static let appEventsURL: URL? = url(path: appEventsPath)
+            static let optInURL: URL? = url(path: optInPath)
+            static let optOutURL: URL? = url(path: optOutPath)
+            static let userUpdateURL: URL? = url(path: userUpdatePath, includePort: true)
+
+            private static func url(path: String, includePort: Bool = false) -> URL? {
+                var components = URLComponents()
+                components.scheme = Endpoint.scheme
+                components.host = host
+                components.path = path
+                if includePort { components.port = port }
+                return components.url
+            }
+        }
+
+        /// `creatives.attn.tv` — hosts the creative web experience rendered in
+        /// a web view.
+        enum Creatives {
+            static let host = "creatives.attn.tv"
+            static let path = "/mobile-apps/index.html"
+        }
+
+        /// A customer domain configured on the SDK is considered invalid when
+        /// it contains any of these substrings — the SDK expects the bare
+        /// customer domain, not a URL.
+        static let invalidDomainSubstrings = ["attn.tv", "/", ":"]
+    }
+
+    // MARK: - Timeouts
+
+    /// Default request timeout applied to SDK network requests. Endpoints
+    /// should pass this into their `URLRequest.timeoutInterval` rather than
+    /// picking an ad-hoc value.
+    enum Timeout {
+        static let defaultRequest: TimeInterval = 15
+    }
+
+    // MARK: - Retry policy
+
+    /// Defaults consumed by `ATTNRetryingNetworkClient`.
+    enum Retry {
+        static let initialDelay: TimeInterval = 1.0
+        static let maxRetries = 5
+        static let jitterRange: ClosedRange<Double> = -0.5...0.5
+        static let maxCumulativeDelay: TimeInterval = 300.0
+    }
+
+    // MARK: - HTTP headers
+
+    enum Headers {
+        static let contentType = "Content-Type"
+        static let datadogSamplingPriority = "x-datadog-sampling-priority"
+
+        static let applicationJSON = "application/json"
+        static let formURLEncoded = "application/x-www-form-urlencoded; charset=utf-8"
+
+        /// Datadog sampling decision — `"1"` tells the collector to keep this
+        /// trace; `"0"` would drop it. SDK endpoints always keep.
+        static let datadogSamplingPriorityKeep = "1"
+    }
+
+    // MARK: - UserDefaults keys
+
+    /// Raw `UserDefaults` keys. Use `ATTNPersistentStorage` for new keys —
+    /// these exist because the values are read/written outside that wrapper.
+    enum UserDefaultsKey {
+        static let deviceToken = "attentiveDeviceToken"
+        static let lastAuthStatus = "attentiveLastAuthStatus"
+    }
+}

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -561,9 +561,9 @@ public final class ATTNSDK: NSObject {
         let trimmedPushToken = currentPushToken.trimmingCharacters(in: .whitespacesAndNewlines)
         let pushToken = !trimmedPushToken.isEmpty
         ? trimmedPushToken
-        : (UserDefaults.standard.string(forKey: "attentiveDeviceToken") ?? "")
+        : (UserDefaults.standard.string(forKey: ATTNSDKConfiguration.UserDefaultsKey.deviceToken) ?? "")
         guard !pushToken.isEmpty else {
-            Loggers.event.error("updateUser: aborted — missing push token - Tried in-memory token: '\(trimmedPushToken, privacy: .public)', Tried UserDefaults: '\(UserDefaults.standard.string(forKey: "attentiveDeviceToken") ?? "nil", privacy: .public)', Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
+            Loggers.event.error("updateUser: aborted — missing push token - Tried in-memory token: '\(trimmedPushToken, privacy: .public)', Tried UserDefaults: '\(UserDefaults.standard.string(forKey: ATTNSDKConfiguration.UserDefaultsKey.deviceToken) ?? "nil", privacy: .public)', Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
             callback?(nil, nil, nil, ATTNSDKError.missingPushToken)
             return
         }
@@ -642,13 +642,13 @@ public final class ATTNSDK: NSObject {
             let settings = await center.notificationSettings()
             let currentStatus = settings.authorizationStatus
 
-            let lastStatus = UserDefaults.standard.integer(forKey: "attentiveLastAuthStatus")
-                            UserDefaults.standard.set(currentStatus.rawValue, forKey: "attentiveLastAuthStatus")
+            let lastStatus = UserDefaults.standard.integer(forKey: ATTNSDKConfiguration.UserDefaultsKey.lastAuthStatus)
+                            UserDefaults.standard.set(currentStatus.rawValue, forKey: ATTNSDKConfiguration.UserDefaultsKey.lastAuthStatus)
 
                             if lastStatus != UNAuthorizationStatus.authorized.rawValue &&
                                  currentStatus == .authorized {
                                     Loggers.event.debug("Push permission became authorized. Clearing cached token and forcing APNs re-registration.")
-                                    UserDefaults.standard.removeObject(forKey: "attentiveDeviceToken")
+                                    UserDefaults.standard.removeObject(forKey: ATTNSDKConfiguration.UserDefaultsKey.deviceToken)
                                     self.pushTokenStore.token = ""
                                     await MainActor.run {
                                             UIApplication.shared.registerForRemoteNotifications()
@@ -663,7 +663,7 @@ public final class ATTNSDK: NSObject {
                 await MainActor.run {
                     if self.currentPushToken.isEmpty {
                         Loggers.event.debug("Authorization granted after denial — forcing APNs re-registration.")
-                        UserDefaults.standard.removeObject(forKey: "attentiveDeviceToken")
+                        UserDefaults.standard.removeObject(forKey: ATTNSDKConfiguration.UserDefaultsKey.deviceToken)
                             }
                     Loggers.event.debug("Notification permission authorized. Registering for remote notifications.")
                     UIApplication.shared.registerForRemoteNotifications()
@@ -875,7 +875,7 @@ fileprivate extension ATTNSDK {
 
 // MARK: - PushToken storage
 private final class PushTokenStore {
-    private let key = "attentiveDeviceToken"
+    private let key = ATTNSDKConfiguration.UserDefaultsKey.deviceToken
     private let queue = DispatchQueue(label: "com.attentive.sdk.PushTokenStore", qos: .userInitiated)
     private var inMemory: String?
 

--- a/Sources/URLProviders/ATTNCreativeUrlProvider.swift
+++ b/Sources/URLProviders/ATTNCreativeUrlProvider.swift
@@ -12,12 +12,6 @@ protocol ATTNCreativeUrlProviding {
 }
 
 struct ATTNCreativeUrlProvider: ATTNCreativeUrlProviding {
-    private enum Constants {
-        static var scheme: String { "https" }
-        static var host: String { "creatives.attn.tv" }
-        static var path: String { "/mobile-apps/index.html" }
-    }
-
     private let appInfo: ATTNAppInfoProtocol
 
     init(appInfo: ATTNAppInfoProtocol = ATTNAppInfo()) {
@@ -26,9 +20,9 @@ struct ATTNCreativeUrlProvider: ATTNCreativeUrlProviding {
 
     func buildCompanyCreativeUrl(configuration: ATTNCreativeUrlConfig) -> String {
         var components = URLComponents()
-        components.scheme = Constants.scheme
-        components.host = Constants.host
-        components.path = Constants.path
+        components.scheme = ATTNSDKConfiguration.Endpoint.scheme
+        components.host = ATTNSDKConfiguration.Endpoint.Creatives.host
+        components.path = ATTNSDKConfiguration.Endpoint.Creatives.path
 
         var queryItems = [
             URLQueryItem(name: "domain", value: configuration.domain)

--- a/Sources/URLProviders/ATTNEventURLProvider.swift
+++ b/Sources/URLProviders/ATTNEventURLProvider.swift
@@ -15,17 +15,6 @@ protocol ATTNEventURLProviding {
 }
 
 struct ATTNEventURLProvider: ATTNEventURLProviding {
-    private enum Constants {
-        static var scheme: String { "https" }
-        static var host: String { "events.attentivemobile.com" }
-        static var path: String { "/e" }
-        static var newEventPath: String { "/mobile" }
-
-        static var pushHost: String { "mobile.attentivemobile.com" }
-        static var pushPath: String { "/token" }
-        static var pushPort: Int { 443 }
-    }
-
     func buildUrl(for userIdentity: ATTNUserIdentity, domain: String) -> URL? {
         var urlComponents = getUrlComponent()
 
@@ -72,38 +61,37 @@ struct ATTNEventURLProvider: ATTNEventURLProviding {
     }
 
     func buildPushTokenUrl(for userIdentity: ATTNUserIdentity, domain: String) -> URL? {
-        var components = getUrlComponent(
-            host: Constants.pushHost,
-            path: Constants.pushPath,
-            port: Constants.pushPort
-        )
-        return components.url
+        getUrlComponent(
+            host: ATTNSDKConfiguration.Endpoint.Mobile.host,
+            path: ATTNSDKConfiguration.Endpoint.Mobile.pushTokenPath,
+            port: ATTNSDKConfiguration.Endpoint.Mobile.port
+        ).url
     }
 }
 
 extension ATTNEventURLProvider {
     private func getUrlComponent() -> URLComponents {
-        var urlComponent = URLComponents()
-        urlComponent.scheme = Constants.scheme
-        urlComponent.host = Constants.host
-        urlComponent.path = Constants.path
-        return urlComponent
+        getUrlComponent(
+            host: ATTNSDKConfiguration.Endpoint.Events.host,
+            path: ATTNSDKConfiguration.Endpoint.Events.legacyPath,
+            port: nil
+        )
     }
 
     private func getNewEventEndpointUrlComponent() -> URLComponents {
-        var urlComponent = URLComponents()
-        urlComponent.scheme = Constants.scheme
-        urlComponent.host = Constants.host
-        urlComponent.path = Constants.newEventPath
-        return urlComponent
+        getUrlComponent(
+            host: ATTNSDKConfiguration.Endpoint.Events.host,
+            path: ATTNSDKConfiguration.Endpoint.Events.newEventPath,
+            port: nil
+        )
     }
 
     private func getUrlComponent(host: String, path: String, port: Int?) -> URLComponents {
-        var c = URLComponents()
-        c.scheme = Constants.scheme
-        c.host   = host
-        c.path   = path
-        c.port   = port
-        return c
+        var components = URLComponents()
+        components.scheme = ATTNSDKConfiguration.Endpoint.scheme
+        components.host = host
+        components.path = path
+        components.port = port
+        return components
     }
 }

--- a/Tests/TestCases/ATTNSDKTests.swift
+++ b/Tests/TestCases/ATTNSDKTests.swift
@@ -19,7 +19,7 @@ final class ATTNSDKTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        UserDefaults.standard.removeObject(forKey: "attentiveDeviceToken")
+        UserDefaults.standard.removeObject(forKey: ATTNSDKConfiguration.UserDefaultsKey.deviceToken)
         creativeUrlProviderSpy = ATTNCreativeUrlProviderSpy()
         apiSpy = ATTNAPISpy(domain: testDomain)
         sut = ATTNSDK(api: apiSpy, urlBuilder: creativeUrlProviderSpy)
@@ -31,7 +31,7 @@ final class ATTNSDKTests: XCTestCase {
         ATTNEventTracker.destroy()
 
         ProcessInfo.restoreOriginalEnvironment()
-        UserDefaults.standard.removeObject(forKey: "attentiveDeviceToken")
+        UserDefaults.standard.removeObject(forKey: ATTNSDKConfiguration.UserDefaultsKey.deviceToken)
 
         creativeUrlProviderSpy = nil
         sut = nil

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		FB35C1792C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1782C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift */; };
 		FB35C17B2C0E0353009FA048 /* ATTNIdentifierType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */; };
 		FB35C17D2C0E039E009FA048 /* ATTNConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C17C2C0E039E009FA048 /* ATTNConstants.swift */; };
+		FB314CFA0001000000000001 /* ATTNSDKConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB314CFA0002000000000002 /* ATTNSDKConfiguration.swift */; };
 		FB35C1832C0E1FD7009FA048 /* URLSession+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1822C0E1FD7009FA048 /* URLSession+Extension.swift */; };
 		FB35C1852C0E35E7009FA048 /* ATTNJsonUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1842C0E35E7009FA048 /* ATTNJsonUtils.swift */; };
 		FB35C1872C0E3929009FA048 /* ATTNEventTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1862C0E3929009FA048 /* ATTNEventTypes.swift */; };
@@ -163,6 +164,7 @@
 		FB35C1782C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNCreativeTriggerStatus.swift; sourceTree = "<group>"; };
 		FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNIdentifierType.swift; sourceTree = "<group>"; };
 		FB35C17C2C0E039E009FA048 /* ATTNConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNConstants.swift; sourceTree = "<group>"; };
+		FB314CFA0002000000000002 /* ATTNSDKConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNSDKConfiguration.swift; sourceTree = "<group>"; };
 		FB35C1822C0E1FD7009FA048 /* URLSession+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Extension.swift"; sourceTree = "<group>"; };
 		FB35C1842C0E35E7009FA048 /* ATTNJsonUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNJsonUtils.swift; sourceTree = "<group>"; };
 		FB35C1862C0E3929009FA048 /* ATTNEventTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNEventTypes.swift; sourceTree = "<group>"; };
@@ -522,6 +524,7 @@
 				FBA9F9EE2C0A77AB00C65024 /* ATTNUserAgentBuilder.swift */,
 				FBA9F9EF2C0A77AB00C65024 /* ATTNVisitorService.swift */,
 				FB35C17C2C0E039E009FA048 /* ATTNConstants.swift */,
+				FB314CFA0002000000000002 /* ATTNSDKConfiguration.swift */,
 				FB4E3FE42C36F7BF004B8FF0 /* ATTNWebViewHandling.swift */,
 				FB4E3FE62C372C54004B8FF0 /* ATTNWebViewProviding.swift */,
 				F939F2452D64DF75002CC012 /* ATTNCreativeStateManager.swift */,
@@ -735,6 +738,7 @@
 				FB65536C2C1B74A9008DB3B1 /* ATTNAPIProtocol.swift in Sources */,
 				FB84E3032C3F30FF0011936B /* ATTNDeeplinkHandling.swift in Sources */,
 				FB35C17D2C0E039E009FA048 /* ATTNConstants.swift in Sources */,
+				FB314CFA0001000000000001 /* ATTNSDKConfiguration.swift in Sources */,
 				F96E25382DD69244005AE2E3 /* ATTNLaunchManager.swift in Sources */,
 				FB56D4DC2C208D6100AF7530 /* Boolean+Extension.swift in Sources */,
 				FBA9FA082C0A77AB00C65024 /* Dictionary+Extension.swift in Sources */,


### PR DESCRIPTION
## Summary
- Adds `ATTNSDKConfiguration` as a single source of truth for network endpoints, request timeouts, retry policy, HTTP headers, and `UserDefaults` keys.
- Replaces hardcoded URLs (`mobile.attentivemobile.com/*`, `events.attentivemobile.com`, `creatives.attn.tv`) and inline timeout/header/key literals across `ATTNAPI`, URL providers, `ATTNSDK`, `ATTNRetryingNetworkClient`, and tests.
- Applies a consistent 15s timeout to event, identity, push-token, and `/mobile` endpoints that previously had none — AI/assistants copying the nearest example now inherit sensible defaults instead of drift.

Jira: [MSDK-314](https://attentivemobile.atlassian.net/browse/MSDK-314)

## Test plan
- [x] `xcodebuild` build on iOS Simulator — succeeds
- [x] Full test suite — 171/171 passing
- [x] Manual smoke: event, identity, opt-in/out, user-update, push-token still hit the expected endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-314]: https://attentivemobile.atlassian.net/browse/MSDK-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ