### PR TITLE
MSDK-329: surface SDK domain, visitor ID, and version in Bonni Settings

### DIFF
--- a/Bonni/AttentiveExample/SettingsViewController.swift
+++ b/Bonni/AttentiveExample/SettingsViewController.swift
@@ -51,6 +51,33 @@ class SettingsViewController: UIViewController {
         return label
     }()
 
+    private let domainLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "DegularDisplay-Regular", size: 16)
+        label.textColor = .darkGray
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let sdkVersionLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "DegularDisplay-Regular", size: 16)
+        label.textColor = .darkGray
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let visitorIdLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "DegularDisplay-Regular", size: 16)
+        label.textColor = .darkGray
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
     private let switchAccountButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("Switch User", for: .normal)
@@ -238,6 +265,14 @@ class SettingsViewController: UIViewController {
 
         setupUI()
         setupActions()
+        refreshSdkInfoLabels()
+    }
+
+    private func refreshSdkInfoLabels() {
+        let sdk = getAttentiveSdk()
+        domainLabel.text = "Domain: \(sdk.domain)"
+        visitorIdLabel.text = "Visitor ID: \(sdk.visitorId)"
+        sdkVersionLabel.text = "SDK: v\(ATTNSDK.sdkVersion)"
     }
 
     // MARK: - UI Setup
@@ -270,6 +305,8 @@ class SettingsViewController: UIViewController {
         ])
 
         stackView.addArrangedSubview(accountInfoLabel)
+        stackView.addArrangedSubview(domainLabel)
+        stackView.addArrangedSubview(visitorIdLabel)
         stackView.addArrangedSubview(switchAccountButton)
         stackView.addArrangedSubview(switchDomainButton)
         stackView.addArrangedSubview(logOutButton)
@@ -297,7 +334,7 @@ class SettingsViewController: UIViewController {
         stackView.addArrangedSubview(showPushPermissionButton)
         stackView.addArrangedSubview(sendLocalPushNotification)
         stackView.addArrangedSubview(sendCustomEventButton)
-        // TODO: Add back stackView.addArrangedSubview(identifyUserButton)
+        stackView.addArrangedSubview(identifyUserButton)
         stackView.addArrangedSubview(cartDeepLinkButton)
         stackView.addArrangedSubview(clearUserButton)
         stackView.addArrangedSubview(clearCookiesButton)
@@ -341,6 +378,7 @@ class SettingsViewController: UIViewController {
         stackView.addArrangedSubview(phoneRow)
         stackView.addArrangedSubview(currentEmailLabel)
         stackView.addArrangedSubview(currentPhoneLabel)
+        stackView.addArrangedSubview(sdkVersionLabel)
 
         // optional: match font to other buttons
         if let degular = UIFont(name: "DegularDisplay-Regular", size: 16) {
@@ -459,6 +497,7 @@ class SettingsViewController: UIViewController {
 
             let sdk = self.getAttentiveSdk()
             sdk.update(domain: newDomain)
+            self.refreshSdkInfoLabels()
             self.showToast(with: "Domain updated to “\(newDomain)”")
         })
 
@@ -516,7 +555,60 @@ class SettingsViewController: UIViewController {
     }
 
     @objc private func identifyUserTapped() {
-        // TODO: Identify the user & show results on debug view
+        let alert = UIAlertController(title: "Identify User",
+                                      message: "Leave fields blank to skip them.",
+                                      preferredStyle: .alert)
+
+        alert.addTextField { tf in
+            tf.placeholder = "Client User ID"
+            tf.autocapitalizationType = .none
+        }
+        alert.addTextField { tf in
+            tf.placeholder = "name@example.com"
+            tf.keyboardType = .emailAddress
+            tf.autocapitalizationType = .none
+        }
+        alert.addTextField { tf in
+            tf.placeholder = "+15551234567"
+            tf.keyboardType = .phonePad
+        }
+        alert.addTextField { tf in
+            tf.placeholder = "Shopify ID"
+            tf.autocapitalizationType = .none
+        }
+        alert.addTextField { tf in
+            tf.placeholder = "Klaviyo ID"
+            tf.autocapitalizationType = .none
+        }
+
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Identify", style: .default) { [weak self] _ in
+            guard let self else { return }
+            let keys = [
+                ATTNIdentifierType.clientUserId,
+                ATTNIdentifierType.email,
+                ATTNIdentifierType.phone,
+                ATTNIdentifierType.shopifyId,
+                ATTNIdentifierType.klaviyoId
+            ]
+            var identifiers: [String: Any] = [:]
+            for (index, key) in keys.enumerated() {
+                let value = alert.textFields?[index].text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                guard !value.isEmpty else { continue }
+                identifiers[key] = value
+            }
+
+            guard !identifiers.isEmpty else {
+                self.showToast(with: "No identifiers provided")
+                return
+            }
+
+            self.getAttentiveSdk().identify(identifiers)
+            let summary = identifiers.map { "\($0.key)=\($0.value)" }.sorted().joined(separator: ", ")
+            self.showToast(with: "Identified: \(summary)")
+        })
+
+        present(alert, animated: true)
     }
 
     @objc private func cartDeepLinkTapped() {
@@ -537,11 +629,13 @@ class SettingsViewController: UIViewController {
         currentEmailLabel.text = "Current email:"
         currentPhoneLabel.text = "Current phone:"
         accountInfoLabel.text = "Login Info: Guest"
+        refreshSdkInfoLabels()
         showToast(with: "Logged out — push token detached")
     }
 
     @objc private func clearUserTapped() {
         getAttentiveSdk().clearUser()
+        refreshSdkInfoLabels()
         showToast(with: "User cleared")
     }
 

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -58,9 +58,15 @@ public final class ATTNSDK: NSObject {
     private(set) var api: ATTNAPIProtocol
     private(set) var userIdentity: ATTNUserIdentity
 
-    internal var domain: String
+    @objc public internal(set) var domain: String
     private var mode: ATTNSDKMode
     private var webViewHandler: ATTNWebViewHandling?
+
+    /// The visitor ID for the current user. Rotates when `clearUser()` is called.
+    @objc public var visitorId: String { userIdentity.visitorId }
+
+    /// The marketing version of the SDK (e.g. `"2.0.13"`).
+    @objc public static var sdkVersion: String { ATTNConstants.sdkVersion }
 
     /// Determinates if fatigue rules evaluation will be skipped for Creative. Default value is false.
     @objc public var skipFatigueOnCreative: Bool = false


### PR DESCRIPTION
## PR Type
- [x] Feature

## What's new?
Implements [MSDK-329](https://attentivemobile.atlassian.net/browse/MSDK-329) parity items for the Bonni example app:

- Exposes `domain`, `visitorId`, and `sdkVersion` on the public `ATTNSDK` API.
- Adds `Domain` and `Visitor ID` labels to the top of the Settings screen, refreshing them after `Switch domain`, `Log Out`, and `Clear User`.
- Adds a `SDK: vX.Y.Z` label at the bottom of the Settings scroll view.
- Wires up the `Identify User` button (previously a `TODO` stub) with an alert covering `clientUserId`, `email`, `phone`, `shopifyId`, and `klaviyoId`.

The debug/console logs overlay item from the ticket is intentionally out of scope and will be tracked separately — it requires plumbing a log sink into `ATTNLogger`.

## Testing
- `xcodebuild` builds both the SDK framework and the Bonni example app.
- Verified in the iOS Simulator: top-of-Settings labels render the live SDK domain and visitor ID; SDK version label renders at the bottom of the scroll view (confirmed via the accessibility tree at y=1073).

## Screenshots
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-12 at 14 17 03" src="https://github.com/user-attachments/assets/8b601ad2-8d41-4ba9-9ce1-e757d0cb8670" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-329]: https://attentivemobile.atlassian.net/browse/MSDK-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ