### PR TITLE
MSDK-329: in-app SDK debug log overlay for Bonni

### DIFF
--- a/Bonni/AttentiveExample/AppDelegate.swift
+++ b/Bonni/AttentiveExample/AppDelegate.swift
@@ -18,6 +18,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     public var productListViewModel: ProductListViewModel?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Capture SDK logs into the in-app debug overlay. Must be set before SDK init
+        // so initialization logs are retained.
+        ATTNSDK.isLogCaptureEnabled = true
         initializeAttentiveSdk()
         UNUserNotificationCenter.current().delegate = self
         // Show push permission prompt

--- a/Bonni/AttentiveExample/DebugLogOverlay.swift
+++ b/Bonni/AttentiveExample/DebugLogOverlay.swift
@@ -1,0 +1,268 @@
+//
+//  DebugLogOverlay.swift
+//  AttentiveExample
+//
+//  Created by Umair Sharif on 5/12/26.
+//
+
+import UIKit
+import ATTNSDKFramework
+
+/// A floating window that renders SDK log entries on top of any screen. Useful for
+/// inspecting logs in TestFlight/release builds without attaching a debugger.
+///
+/// - Tap the floating "LOGS" button to show/hide the panel.
+/// - Drag the LOGS button or the panel's title bar to reposition them.
+final class DebugLogOverlay {
+    static let shared = DebugLogOverlay()
+
+    private var window: OverlayWindow?
+    private var streamTask: Task<Void, Never>?
+
+    private init() {}
+
+    func install(on windowScene: UIWindowScene) {
+        guard window == nil else { return }
+        let window = OverlayWindow(windowScene: windowScene)
+        window.windowLevel = .alert + 1
+        window.isHidden = false
+        window.rootViewController = OverlayContainerViewController()
+        self.window = window
+
+        let containerVC = window.rootViewController as? OverlayContainerViewController
+        containerVC?.panel.replace(with: ATTNSDK.recentLogs())
+
+        let containerRef = containerVC
+        streamTask = Task {
+            for await entry in ATTNSDK.logStream {
+                await MainActor.run {
+                    containerRef?.panel.append(entry)
+                }
+            }
+        }
+    }
+}
+
+/// A window that ignores taps on its empty regions, so the underlying app keeps
+/// receiving touches everywhere except on the LOGS button and the floating panel.
+private final class OverlayWindow: UIWindow {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let view = super.hitTest(point, with: event)
+        if view === rootViewController?.view { return nil }
+        return view
+    }
+}
+
+private final class OverlayContainerViewController: UIViewController {
+    let panel = DebugLogPanelView(frame: CGRect(x: 16, y: 80, width: 320, height: 240))
+    private let toggleButton = UIButton(type: .system)
+    private var didPositionToggle = false
+
+    override func loadView() {
+        let root = UIView()
+        root.backgroundColor = .clear
+        view = root
+
+        toggleButton.frame = CGRect(x: 0, y: 0, width: 60, height: 44)
+        toggleButton.setTitle("LOGS", for: .normal)
+        toggleButton.titleLabel?.font = .systemFont(ofSize: 12, weight: .bold)
+        toggleButton.setTitleColor(.white, for: .normal)
+        toggleButton.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+        toggleButton.layer.cornerRadius = 22
+        toggleButton.layer.borderColor = UIColor.white.withAlphaComponent(0.5).cgColor
+        toggleButton.layer.borderWidth = 1
+        toggleButton.addTarget(self, action: #selector(togglePanel), for: .touchUpInside)
+        toggleButton.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(handleDrag(_:))))
+        root.addSubview(toggleButton)
+
+        panel.isHidden = true
+        root.addSubview(panel)
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        // Preserve user-dragged position across rotations.
+        guard !didPositionToggle else { return }
+        didPositionToggle = true
+        let bounds = view.bounds
+        let safeBottom = view.safeAreaInsets.bottom
+        toggleButton.frame.origin = CGPoint(x: bounds.width - 76, y: bounds.height - safeBottom - 144)
+    }
+
+    @objc private func togglePanel() {
+        let willShow = panel.isHidden
+        panel.isHidden = !willShow
+        if willShow { panel.flushPending() }
+    }
+
+    @objc private func handleDrag(_ gesture: UIPanGestureRecognizer) {
+        guard let target = gesture.view, let parent = target.superview else { return }
+        let translation = gesture.translation(in: parent)
+        target.center = CGPoint(x: target.center.x + translation.x, y: target.center.y + translation.y)
+        gesture.setTranslation(.zero, in: parent)
+    }
+}
+
+/// Compact, draggable floating log panel. The title bar is the drag handle.
+private final class DebugLogPanelView: UIView {
+    private let textView: UITextView = {
+        let tv = UITextView()
+        tv.font = .monospacedSystemFont(ofSize: 10, weight: .regular)
+        tv.isEditable = false
+        tv.backgroundColor = .clear
+        tv.textColor = .white
+        tv.alwaysBounceVertical = true
+        tv.translatesAutoresizingMaskIntoConstraints = false
+        return tv
+    }()
+
+    private let titleBar: UIView = {
+        let v = UIView()
+        v.backgroundColor = UIColor.white.withAlphaComponent(0.1)
+        v.translatesAutoresizingMaskIntoConstraints = false
+        return v
+    }()
+
+    private let titleLabel: UILabel = {
+        let l = UILabel()
+        l.text = "SDK Logs"
+        l.textColor = .white
+        l.font = .systemFont(ofSize: 11, weight: .semibold)
+        l.translatesAutoresizingMaskIntoConstraints = false
+        return l
+    }()
+
+    private let clearButton: UIButton = {
+        let b = UIButton(type: .system)
+        b.setTitle("Clear", for: .normal)
+        b.setTitleColor(.white, for: .normal)
+        b.titleLabel?.font = .systemFont(ofSize: 11, weight: .semibold)
+        b.translatesAutoresizingMaskIntoConstraints = false
+        return b
+    }()
+
+    private static let timestampFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss.SSS"
+        return f
+    }()
+
+    /// Lines pending append when the panel is hidden. Flushed in one batch on show.
+    private var pendingLines: [String] = []
+    private var lineCount = 0
+    private static let maxLines = 1000
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = UIColor.black.withAlphaComponent(0.85)
+        layer.cornerRadius = 8
+        layer.borderColor = UIColor.white.withAlphaComponent(0.4).cgColor
+        layer.borderWidth = 1
+        clipsToBounds = true
+
+        addSubview(titleBar)
+        titleBar.addSubview(titleLabel)
+        titleBar.addSubview(clearButton)
+        addSubview(textView)
+
+        clearButton.addTarget(self, action: #selector(clearTapped), for: .touchUpInside)
+        titleBar.addGestureRecognizer(UIPanGestureRecognizer(target: self, action: #selector(handleDrag(_:))))
+        titleBar.isUserInteractionEnabled = true
+
+        NSLayoutConstraint.activate([
+            titleBar.topAnchor.constraint(equalTo: topAnchor),
+            titleBar.leadingAnchor.constraint(equalTo: leadingAnchor),
+            titleBar.trailingAnchor.constraint(equalTo: trailingAnchor),
+            titleBar.heightAnchor.constraint(equalToConstant: 28),
+
+            titleLabel.leadingAnchor.constraint(equalTo: titleBar.leadingAnchor, constant: 10),
+            titleLabel.centerYAnchor.constraint(equalTo: titleBar.centerYAnchor),
+
+            clearButton.trailingAnchor.constraint(equalTo: titleBar.trailingAnchor, constant: -10),
+            clearButton.centerYAnchor.constraint(equalTo: titleBar.centerYAnchor),
+
+            textView.topAnchor.constraint(equalTo: titleBar.bottomAnchor),
+            textView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
+            textView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -6),
+            textView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -6)
+        ])
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+
+    func append(_ entry: ATTNLogEntry) {
+        let line = formatLine(entry)
+        guard !isHidden else {
+            pendingLines.append(line)
+            if pendingLines.count > Self.maxLines {
+                pendingLines.removeFirst(pendingLines.count - Self.maxLines)
+            }
+            return
+        }
+        appendVisibleLine(line)
+    }
+
+    func replace(with entries: [ATTNLogEntry]) {
+        let text = entries.map(formatLine).joined(separator: "\n")
+        textView.text = text
+        lineCount = entries.count
+        scrollToBottom()
+    }
+
+    /// Apply any entries received while hidden. Called by the container on show.
+    func flushPending() {
+        guard !pendingLines.isEmpty else { return }
+        let chunk = pendingLines.joined(separator: "\n")
+        pendingLines.removeAll(keepingCapacity: true)
+        appendVisibleLine(chunk)
+    }
+
+    private func appendVisibleLine(_ line: String) {
+        let prefix = textView.text.isEmpty ? "" : "\n"
+        textView.textStorage.append(NSAttributedString(
+            string: prefix + line,
+            attributes: [
+                .font: textView.font ?? UIFont.monospacedSystemFont(ofSize: 10, weight: .regular),
+                .foregroundColor: textView.textColor ?? UIColor.white
+            ]
+        ))
+        lineCount += 1
+        trimIfNeeded()
+        scrollToBottom()
+    }
+
+    private func trimIfNeeded() {
+        guard lineCount > Self.maxLines else { return }
+        let text = textView.text ?? ""
+        var dropCount = lineCount - Self.maxLines
+        var idx = text.startIndex
+        while dropCount > 0, let nl = text[idx...].firstIndex(of: "\n") {
+            idx = text.index(after: nl)
+            dropCount -= 1
+        }
+        textView.text = String(text[idx...])
+        lineCount = Self.maxLines
+    }
+
+    private func scrollToBottom() {
+        let nsLength = (textView.text as NSString).length
+        textView.scrollRangeToVisible(NSRange(location: max(0, nsLength - 1), length: 1))
+    }
+
+    private func formatLine(_ entry: ATTNLogEntry) -> String {
+        entry.formatted(timestamp: Self.timestampFormatter.string(from: entry.date))
+    }
+
+    @objc private func clearTapped() {
+        textView.text = ""
+        pendingLines.removeAll(keepingCapacity: true)
+        lineCount = 0
+    }
+
+    @objc private func handleDrag(_ gesture: UIPanGestureRecognizer) {
+        guard let parent = superview else { return }
+        let translation = gesture.translation(in: parent)
+        center = CGPoint(x: center.x + translation.x, y: center.y + translation.y)
+        gesture.setTranslation(.zero, in: parent)
+    }
+}

--- a/Bonni/AttentiveExample/DebugLogOverlay.swift
+++ b/Bonni/AttentiveExample/DebugLogOverlay.swift
@@ -153,9 +153,14 @@ private final class DebugLogPanelView: UIView {
         return f
     }()
 
-    /// Lines pending append when the panel is hidden. Flushed in one batch on show.
-    private var pendingLines: [String] = []
-    private var lineCount = 0
+    /// Source of truth: all retained lines, capped at `maxLines`.
+    private var lines: [String] = []
+    /// Count of lines from the front of `lines` that are already in `textStorage`.
+    /// Lines past this index are pending and will be appended by `flushPending`.
+    private var renderedCount = 0
+    /// Number of leading rendered lines in `textStorage` that are now stale and
+    /// must be spliced out on the next flush. Accumulates while the panel is hidden.
+    private var pendingSplice = 0
     private static let maxLines = 1000
 
     override init(frame: CGRect) {
@@ -197,57 +202,74 @@ private final class DebugLogPanelView: UIView {
     required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
 
     func append(_ entry: ATTNLogEntry) {
-        let line = formatLine(entry)
-        guard !isHidden else {
-            pendingLines.append(line)
-            if pendingLines.count > Self.maxLines {
-                pendingLines.removeFirst(pendingLines.count - Self.maxLines)
-            }
-            return
-        }
-        appendVisibleLine(line)
+        appendLine(formatLine(entry))
     }
 
     func replace(with entries: [ATTNLogEntry]) {
-        let text = entries.map(formatLine).joined(separator: "\n")
-        textView.text = text
-        lineCount = entries.count
-        scrollToBottom()
-    }
-
-    /// Apply any entries received while hidden. Called by the container on show.
-    func flushPending() {
-        guard !pendingLines.isEmpty else { return }
-        let chunk = pendingLines.joined(separator: "\n")
-        pendingLines.removeAll(keepingCapacity: true)
-        appendVisibleLine(chunk)
-    }
-
-    private func appendVisibleLine(_ line: String) {
-        let prefix = textView.text.isEmpty ? "" : "\n"
-        textView.textStorage.append(NSAttributedString(
-            string: prefix + line,
-            attributes: [
-                .font: textView.font ?? UIFont.monospacedSystemFont(ofSize: 10, weight: .regular),
-                .foregroundColor: textView.textColor ?? UIColor.white
-            ]
-        ))
-        lineCount += 1
-        trimIfNeeded()
-        scrollToBottom()
-    }
-
-    private func trimIfNeeded() {
-        guard lineCount > Self.maxLines else { return }
-        let text = textView.text ?? ""
-        var dropCount = lineCount - Self.maxLines
-        var idx = text.startIndex
-        while dropCount > 0, let nl = text[idx...].firstIndex(of: "\n") {
-            idx = text.index(after: nl)
-            dropCount -= 1
+        lines = entries.map(formatLine)
+        if lines.count > Self.maxLines {
+            lines.removeFirst(lines.count - Self.maxLines)
         }
-        textView.text = String(text[idx...])
-        lineCount = Self.maxLines
+        renderedCount = 0
+        pendingSplice = 0
+        textView.textStorage.setAttributedString(NSAttributedString())
+        if !isHidden { flushPending() }
+    }
+
+    /// Reconciles `textView.textStorage` with `lines`. Splices any pending leading
+    /// lines out, then appends new tail entries. Cheap when nothing is pending.
+    func flushPending() {
+        if pendingSplice > 0 {
+            spliceLeadingLines(pendingSplice)
+            pendingSplice = 0
+        }
+        guard renderedCount < lines.count else { return }
+        let pending = lines[renderedCount...]
+        let prefix = renderedCount == 0 ? "" : "\n"
+        textView.textStorage.append(
+            NSAttributedString(string: prefix + pending.joined(separator: "\n"), attributes: lineAttributes)
+        )
+        renderedCount = lines.count
+        scrollToBottom()
+    }
+
+    /// Pushes a single line into the array, trims if needed, and updates `textStorage`
+    /// only if the panel is visible. While hidden, work is deferred to `flushPending`.
+    private func appendLine(_ line: String) {
+        lines.append(line)
+        if lines.count > Self.maxLines {
+            let drop = lines.count - Self.maxLines
+            lines.removeFirst(drop)
+            // Of the dropped lines, this many were already in textStorage and need
+            // to be spliced out (now or later, depending on visibility).
+            let renderedDrop = min(drop, renderedCount)
+            renderedCount -= renderedDrop
+            if isHidden {
+                pendingSplice += renderedDrop
+            } else if renderedDrop > 0 {
+                spliceLeadingLines(renderedDrop)
+            }
+        }
+        if !isHidden { flushPending() }
+    }
+
+    /// Removes the first `count` newline-terminated lines from the text view's storage
+    /// in place, preserving attributes on the remaining text.
+    private func spliceLeadingLines(_ count: Int) {
+        let storage = textView.textStorage
+        let plain = storage.string as NSString
+        var location = 0
+        for _ in 0..<count where location < plain.length {
+            let nlRange = plain.range(of: "\n", options: [], range: NSRange(location: location, length: plain.length - location))
+            guard nlRange.location != NSNotFound else {
+                location = plain.length
+                break
+            }
+            location = nlRange.location + nlRange.length
+        }
+        if location > 0 {
+            storage.replaceCharacters(in: NSRange(location: 0, length: location), with: "")
+        }
     }
 
     private func scrollToBottom() {
@@ -259,10 +281,18 @@ private final class DebugLogPanelView: UIView {
         entry.formatted(timestamp: Self.timestampFormatter.string(from: entry.date))
     }
 
+    private var lineAttributes: [NSAttributedString.Key: Any] {
+        [
+            .font: textView.font ?? UIFont.monospacedSystemFont(ofSize: 10, weight: .regular),
+            .foregroundColor: textView.textColor ?? UIColor.white
+        ]
+    }
+
     @objc private func clearTapped() {
-        textView.text = ""
-        pendingLines.removeAll(keepingCapacity: true)
-        lineCount = 0
+        lines.removeAll(keepingCapacity: true)
+        renderedCount = 0
+        pendingSplice = 0
+        textView.textStorage.setAttributedString(NSAttributedString())
     }
 
     @objc private func handleDrag(_ gesture: UIPanGestureRecognizer) {

--- a/Bonni/AttentiveExample/DebugLogOverlay.swift
+++ b/Bonni/AttentiveExample/DebugLogOverlay.swift
@@ -17,11 +17,11 @@ import ATTNSDKFramework
 /// Owned by `SceneDelegate` for the lifetime of the scene; tear down with `uninstall()`.
 final class DebugLogOverlay {
     /// Persisted user preference for whether the overlay chrome (the LOGS button) is
-    /// shown at all. Defaults to visible so QA builds expose the overlay without any
-    /// setup; toggle it from Bonni's Settings screen. Log capture keeps running while
-    /// hidden, so re-showing the overlay still has the full buffer history.
+    /// shown at all. Hidden by default; enable it from Bonni's Settings screen. Log
+    /// capture keeps running while hidden, so showing the overlay later still has the
+    /// full buffer history from launch.
     static var isVisible: Bool {
-        get { UserDefaults.standard.object(forKey: visibilityKey) as? Bool ?? true }
+        get { UserDefaults.standard.bool(forKey: visibilityKey) }
         set {
             UserDefaults.standard.set(newValue, forKey: visibilityKey)
             NotificationCenter.default.post(name: .debugLogOverlayVisibilityChanged, object: nil)

--- a/Bonni/AttentiveExample/DebugLogOverlay.swift
+++ b/Bonni/AttentiveExample/DebugLogOverlay.swift
@@ -52,11 +52,30 @@ final class DebugLogOverlay {
 /// A window that ignores taps on its empty regions, so the underlying app keeps
 /// receiving touches everywhere except on the LOGS button and the floating panel.
 private final class OverlayWindow: UIWindow {
+    /// Never become key: the app's main window must keep keyboard focus, and code
+    /// that resolves the key window (alerts, creatives) must not land on the overlay.
+    override var canBecomeKey: Bool { false }
+
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         let view = super.hitTest(point, with: event)
         if view === rootViewController?.view { return nil }
         return view
     }
+}
+
+/// Clamps a proposed center so at least `minVisible` points of the view stay inside
+/// `bounds` on each axis, keeping dragged chrome reachable.
+private func clampedCenter(_ proposed: CGPoint, viewSize: CGSize, bounds: CGRect, minVisible: CGFloat = 24) -> CGPoint {
+    let visibleX = min(minVisible, viewSize.width)
+    let visibleY = min(minVisible, viewSize.height)
+    let minX = bounds.minX + visibleX - viewSize.width / 2
+    let maxX = bounds.maxX - visibleX + viewSize.width / 2
+    let minY = bounds.minY + visibleY - viewSize.height / 2
+    let maxY = bounds.maxY - visibleY + viewSize.height / 2
+    return CGPoint(
+        x: min(max(proposed.x, minX), maxX),
+        y: min(max(proposed.y, minY), maxY)
+    )
 }
 
 private final class OverlayContainerViewController: UIViewController {
@@ -87,12 +106,17 @@ private final class OverlayContainerViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        // Preserve user-dragged position across rotations.
-        guard !didPositionToggle else { return }
-        didPositionToggle = true
-        let bounds = view.bounds
-        let safeBottom = view.safeAreaInsets.bottom
-        toggleButton.frame.origin = CGPoint(x: bounds.width - 76, y: bounds.height - safeBottom - 144)
+        if !didPositionToggle {
+            didPositionToggle = true
+            let bounds = view.bounds
+            let safeBottom = view.safeAreaInsets.bottom
+            toggleButton.frame.origin = CGPoint(x: bounds.width - 76, y: bounds.height - safeBottom - 144)
+        } else {
+            // Preserve user-dragged positions across rotations, but re-clamp so a
+            // position that was on-screen in the old orientation stays reachable.
+            toggleButton.center = clampedCenter(toggleButton.center, viewSize: toggleButton.bounds.size, bounds: view.bounds)
+            panel.center = clampedCenter(panel.center, viewSize: panel.bounds.size, bounds: view.bounds)
+        }
     }
 
     @objc private func togglePanel() {
@@ -104,7 +128,8 @@ private final class OverlayContainerViewController: UIViewController {
     @objc private func handleDrag(_ gesture: UIPanGestureRecognizer) {
         guard let target = gesture.view, let parent = target.superview else { return }
         let translation = gesture.translation(in: parent)
-        target.center = CGPoint(x: target.center.x + translation.x, y: target.center.y + translation.y)
+        let proposed = CGPoint(x: target.center.x + translation.x, y: target.center.y + translation.y)
+        target.center = clampedCenter(proposed, viewSize: target.bounds.size, bounds: parent.bounds)
         gesture.setTranslation(.zero, in: parent)
     }
 }
@@ -298,7 +323,8 @@ private final class DebugLogPanelView: UIView {
     @objc private func handleDrag(_ gesture: UIPanGestureRecognizer) {
         guard let parent = superview else { return }
         let translation = gesture.translation(in: parent)
-        center = CGPoint(x: center.x + translation.x, y: center.y + translation.y)
+        let proposed = CGPoint(x: center.x + translation.x, y: center.y + translation.y)
+        center = clampedCenter(proposed, viewSize: bounds.size, bounds: parent.bounds)
         gesture.setTranslation(.zero, in: parent)
     }
 }

--- a/Bonni/AttentiveExample/DebugLogOverlay.swift
+++ b/Bonni/AttentiveExample/DebugLogOverlay.swift
@@ -16,13 +16,27 @@ import ATTNSDKFramework
 ///
 /// Owned by `SceneDelegate` for the lifetime of the scene; tear down with `uninstall()`.
 final class DebugLogOverlay {
+    /// Persisted user preference for whether the overlay chrome (the LOGS button) is
+    /// shown at all. Defaults to visible so QA builds expose the overlay without any
+    /// setup; toggle it from Bonni's Settings screen. Log capture keeps running while
+    /// hidden, so re-showing the overlay still has the full buffer history.
+    static var isVisible: Bool {
+        get { UserDefaults.standard.object(forKey: visibilityKey) as? Bool ?? true }
+        set {
+            UserDefaults.standard.set(newValue, forKey: visibilityKey)
+            NotificationCenter.default.post(name: .debugLogOverlayVisibilityChanged, object: nil)
+        }
+    }
+    private static let visibilityKey = "debugLogOverlayVisible"
+
     private let window: OverlayWindow
     private let streamTask: Task<Void, Never>
+    private var visibilityObserver: NSObjectProtocol?
 
     init(windowScene: UIWindowScene) {
         let window = OverlayWindow(windowScene: windowScene)
         window.windowLevel = .alert + 1
-        window.isHidden = false
+        window.isHidden = !Self.isVisible
         let containerVC = OverlayContainerViewController()
         window.rootViewController = containerVC
         self.window = window
@@ -37,16 +51,33 @@ final class DebugLogOverlay {
                 }
             }
         }
+
+        self.visibilityObserver = NotificationCenter.default.addObserver(
+            forName: .debugLogOverlayVisibilityChanged, object: nil, queue: .main
+        ) { [weak window] _ in
+            window?.isHidden = !Self.isVisible
+        }
     }
 
     func uninstall() {
         streamTask.cancel()
         window.isHidden = true
+        if let visibilityObserver {
+            NotificationCenter.default.removeObserver(visibilityObserver)
+            self.visibilityObserver = nil
+        }
     }
 
     deinit {
         streamTask.cancel()
+        if let visibilityObserver {
+            NotificationCenter.default.removeObserver(visibilityObserver)
+        }
     }
+}
+
+extension Notification.Name {
+    static let debugLogOverlayVisibilityChanged = Notification.Name("DebugLogOverlayVisibilityChanged")
 }
 
 /// A window that ignores taps on its empty regions, so the underlying app keeps

--- a/Bonni/AttentiveExample/DebugLogOverlay.swift
+++ b/Bonni/AttentiveExample/DebugLogOverlay.swift
@@ -13,33 +13,39 @@ import ATTNSDKFramework
 ///
 /// - Tap the floating "LOGS" button to show/hide the panel.
 /// - Drag the LOGS button or the panel's title bar to reposition them.
+///
+/// Owned by `SceneDelegate` for the lifetime of the scene; tear down with `uninstall()`.
 final class DebugLogOverlay {
-    static let shared = DebugLogOverlay()
+    private let window: OverlayWindow
+    private let streamTask: Task<Void, Never>
 
-    private var window: OverlayWindow?
-    private var streamTask: Task<Void, Never>?
-
-    private init() {}
-
-    func install(on windowScene: UIWindowScene) {
-        guard window == nil else { return }
+    init(windowScene: UIWindowScene) {
         let window = OverlayWindow(windowScene: windowScene)
         window.windowLevel = .alert + 1
         window.isHidden = false
-        window.rootViewController = OverlayContainerViewController()
+        let containerVC = OverlayContainerViewController()
+        window.rootViewController = containerVC
         self.window = window
 
-        let containerVC = window.rootViewController as? OverlayContainerViewController
-        containerVC?.panel.replace(with: ATTNSDK.recentLogs())
+        let panelRef = containerVC.panel
+        panelRef.replace(with: ATTNSDK.recentLogs())
 
-        let containerRef = containerVC
-        streamTask = Task {
+        self.streamTask = Task {
             for await entry in ATTNSDK.logStream {
                 await MainActor.run {
-                    containerRef?.panel.append(entry)
+                    panelRef.append(entry)
                 }
             }
         }
+    }
+
+    func uninstall() {
+        streamTask.cancel()
+        window.isHidden = true
+    }
+
+    deinit {
+        streamTask.cancel()
     }
 }
 

--- a/Bonni/AttentiveExample/SceneDelegate.swift
+++ b/Bonni/AttentiveExample/SceneDelegate.swift
@@ -10,6 +10,7 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    private var debugLogOverlay: DebugLogOverlay?
 
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
@@ -27,9 +28,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.rootViewController = navController
         self.window = window
         window.makeKeyAndVisible()
-        guard let windowScene = (scene as? UIWindowScene) else { return }
 
-        DebugLogOverlay.shared.install(on: windowScene)
+        debugLogOverlay = DebugLogOverlay(windowScene: windowScene)
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -37,6 +37,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This occurs shortly after the scene enters the background, or when its session is discarded.
         // Release any resources associated with this scene that can be re-created the next time the scene connects.
         // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+        debugLogOverlay?.uninstall()
+        debugLogOverlay = nil
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {

--- a/Bonni/AttentiveExample/SceneDelegate.swift
+++ b/Bonni/AttentiveExample/SceneDelegate.swift
@@ -27,7 +27,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.rootViewController = navController
         self.window = window
         window.makeKeyAndVisible()
-        guard let _ = (scene as? UIWindowScene) else { return }
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+
+        DebugLogOverlay.shared.install(on: windowScene)
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Bonni/AttentiveExample/SettingsViewController.swift
+++ b/Bonni/AttentiveExample/SettingsViewController.swift
@@ -149,6 +149,20 @@ class SettingsViewController: UIViewController {
         return devicetokenLabel
     }()
 
+    private let logOverlayLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Show SDK Log Overlay"
+        label.font = UIFont(name: "DegularDisplay-Regular", size: 16)
+        label.numberOfLines = 1
+        return label
+    }()
+
+    private let logOverlaySwitch: UISwitch = {
+        let toggle = UISwitch()
+        toggle.isOn = DebugLogOverlay.isVisible
+        return toggle
+    }()
+
     private let addEmailButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("Add email", for: .normal)
@@ -277,6 +291,12 @@ class SettingsViewController: UIViewController {
         stackView.addArrangedSubview(devicetokenLabel)
         stackView.addArrangedSubview(copyDeviceTokenButton)
 
+        let logOverlayRow = UIStackView(arrangedSubviews: [logOverlayLabel, logOverlaySwitch])
+        logOverlayRow.axis = .horizontal
+        logOverlayRow.spacing = 12
+        logOverlayRow.alignment = .center
+        stackView.addArrangedSubview(logOverlayRow)
+
         if let degular = UIFont(name: "DegularDisplay-Regular", size: 16) {
             let allButtons: [UIButton] = [
                 switchAccountButton,
@@ -339,6 +359,7 @@ class SettingsViewController: UIViewController {
         cartDeepLinkButton.addTarget(self, action: #selector(cartDeepLinkTapped), for: .touchUpInside)
         clearUserButton.addTarget(self, action: #selector(clearUserTapped), for: .touchUpInside)
         clearCookiesButton.addTarget(self, action: #selector(clearCookiesTapped), for: .touchUpInside)
+        logOverlaySwitch.addTarget(self, action: #selector(logOverlaySwitchChanged(_:)), for: .valueChanged)
 
         addEmailButton.addTarget(self, action: #selector(addEmailTapped), for: .touchUpInside)
         optInEmailButton.addTarget(self, action: #selector(optInEmailTapped), for: .touchUpInside)
@@ -516,6 +537,10 @@ class SettingsViewController: UIViewController {
     @objc private func clearUserTapped() {
         getAttentiveSdk().clearUser()
         showToast(with: "User cleared")
+    }
+
+    @objc private func logOverlaySwitchChanged(_ sender: UISwitch) {
+        DebugLogOverlay.isVisible = sender.isOn
     }
 
     @objc private func clearCookiesTapped() {

--- a/Sources/Helpers/ATTNLogBuffer.swift
+++ b/Sources/Helpers/ATTNLogBuffer.swift
@@ -1,0 +1,63 @@
+//
+//  ATTNLogBuffer.swift
+//  attentive-ios-sdk-framework
+//
+//  Created by Umair Sharif on 5/12/26.
+//
+
+import Foundation
+
+/// In-process ring buffer of recent SDK log lines. Used by the in-app debug overlay
+/// in TestFlight/release builds where `OSLogStore` would not surface `.debug` entries.
+final class ATTNLogBuffer: @unchecked Sendable {
+    static let shared = ATTNLogBuffer()
+
+    private let capacity: Int
+    private let evictionSlack: Int
+    private let queue = DispatchQueue(label: "com.attentive.sdk.logbuffer")
+    private var entries: [ATTNLogEntry] = []
+    private var subscribers: [UUID: AsyncStream<ATTNLogEntry>.Continuation] = [:]
+
+    init(capacity: Int = 1000) {
+        self.capacity = capacity
+        // Trim 25% at a time to amortize the O(n) shift to O(1) per append.
+        self.evictionSlack = max(1, capacity / 4)
+        entries.reserveCapacity(capacity + evictionSlack)
+    }
+
+    func append(level: ATTNLogEntry.Level, category: String, message: String) {
+        let entry = ATTNLogEntry(date: Date(), category: category, level: level.rawValue, message: message)
+        queue.async {
+            self.entries.append(entry)
+            if self.entries.count >= self.capacity + self.evictionSlack {
+                self.entries.removeFirst(self.evictionSlack)
+            }
+            for continuation in self.subscribers.values {
+                continuation.yield(entry)
+            }
+        }
+    }
+
+    func snapshot(since: Date? = nil) -> [ATTNLogEntry] {
+        queue.sync {
+            guard let since else { return entries }
+            return entries.filter { $0.date >= since }
+        }
+    }
+
+    /// Async stream of new entries appended after subscription. The caller must
+    /// retain the resulting Task; cancelling it removes the subscription.
+    func stream() -> AsyncStream<ATTNLogEntry> {
+        AsyncStream { continuation in
+            let id = UUID()
+            queue.async {
+                self.subscribers[id] = continuation
+            }
+            continuation.onTermination = { [weak self] _ in
+                self?.queue.async {
+                    self?.subscribers.removeValue(forKey: id)
+                }
+            }
+        }
+    }
+}

--- a/Sources/Helpers/ATTNLogBuffer.swift
+++ b/Sources/Helpers/ATTNLogBuffer.swift
@@ -9,8 +9,20 @@ import Foundation
 
 /// In-process ring buffer of recent SDK log lines. Used by the in-app debug overlay
 /// in TestFlight/release builds where `OSLogStore` would not surface `.debug` entries.
+///
+/// Off by default — apps that don't show the overlay pay zero buffer overhead. Set
+/// `isCapturing = true` once at launch to start retaining entries.
 final class ATTNLogBuffer: @unchecked Sendable {
     static let shared = ATTNLogBuffer()
+
+    /// When `false` (the default), `append(...)` is a no-op and no entries are
+    /// retained, dispatched, or yielded to subscribers. Toggling this on does not
+    /// retroactively recover entries that were dropped while disabled.
+    var isCapturing: Bool {
+        get { queue.sync { _isCapturing } }
+        set { queue.async { self._isCapturing = newValue } }
+    }
+    private var _isCapturing = false
 
     private let capacity: Int
     private let evictionSlack: Int
@@ -26,8 +38,9 @@ final class ATTNLogBuffer: @unchecked Sendable {
     }
 
     func append(level: ATTNLogEntry.Level, category: String, message: String) {
-        let entry = ATTNLogEntry(date: Date(), category: category, level: level.rawValue, message: message)
         queue.async {
+            guard self._isCapturing else { return }
+            let entry = ATTNLogEntry(date: Date(), category: category, level: level, message: message)
             self.entries.append(entry)
             if self.entries.count >= self.capacity + self.evictionSlack {
                 self.entries.removeFirst(self.evictionSlack)
@@ -47,8 +60,11 @@ final class ATTNLogBuffer: @unchecked Sendable {
 
     /// Async stream of new entries appended after subscription. The caller must
     /// retain the resulting Task; cancelling it removes the subscription.
+    ///
+    /// Drops the oldest pending entries when a consumer falls behind so a single
+    /// slow subscriber cannot grow memory without bound.
     func stream() -> AsyncStream<ATTNLogEntry> {
-        AsyncStream { continuation in
+        AsyncStream(bufferingPolicy: .bufferingNewest(capacity)) { continuation in
             let id = UUID()
             queue.async {
                 self.subscribers[id] = continuation

--- a/Sources/Helpers/Logger.swift
+++ b/Sources/Helpers/Logger.swift
@@ -8,10 +8,100 @@
 import Foundation
 import os
 
+/// Subsystem identifier shared by all SDK loggers.
 enum Loggers {
-    private static var subsystem: String { "com.attentive.attentive-ios-sdk" }
+    static let subsystem: String = "com.attentive.attentive-ios-sdk"
 
-    static var network = Logger(subsystem: subsystem, category: "network")
-    static var event = Logger(subsystem: subsystem, category: "event")
-    static var creative = Logger(subsystem: subsystem, category: "creative")
+    static var network = ATTNLogger(category: "network")
+    static var event = ATTNLogger(category: "event")
+    static var creative = ATTNLogger(category: "creative")
+}
+
+/// A logger that fans out to both `os.Logger` (for Console.app / device logs) and
+/// `ATTNLogBuffer` (for the in-app debug overlay). The string-interpolation API
+/// matches `os.Logger`'s, so call sites do not need to change.
+///
+/// Privacy note: every interpolation is forwarded to `os.Logger` as a single
+/// `.public` value, since the rendered message is already a `String`. Every existing
+/// SDK call site already annotates `, privacy: .public`, so this is a no-op today.
+/// Adding `, privacy: .private` to a future call site will not redact the value in
+/// Console.app — switch to `os.Logger` directly if that's required.
+struct ATTNLogger {
+    let category: String
+    private let osLogger: Logger
+
+    init(category: String) {
+        self.category = category
+        self.osLogger = Logger(subsystem: Loggers.subsystem, category: category)
+    }
+
+    func debug(_ message: ATTNLogMessage) {
+        osLogger.debug("\(message.rendered, privacy: .public)")
+        ATTNLogBuffer.shared.append(level: .debug, category: category, message: message.rendered)
+    }
+
+    func info(_ message: ATTNLogMessage) {
+        osLogger.info("\(message.rendered, privacy: .public)")
+        ATTNLogBuffer.shared.append(level: .info, category: category, message: message.rendered)
+    }
+
+    func notice(_ message: ATTNLogMessage) {
+        osLogger.notice("\(message.rendered, privacy: .public)")
+        ATTNLogBuffer.shared.append(level: .notice, category: category, message: message.rendered)
+    }
+
+    func warning(_ message: ATTNLogMessage) {
+        osLogger.warning("\(message.rendered, privacy: .public)")
+        ATTNLogBuffer.shared.append(level: .warning, category: category, message: message.rendered)
+    }
+
+    func error(_ message: ATTNLogMessage) {
+        osLogger.error("\(message.rendered, privacy: .public)")
+        ATTNLogBuffer.shared.append(level: .error, category: category, message: message.rendered)
+    }
+
+    func fault(_ message: ATTNLogMessage) {
+        osLogger.fault("\(message.rendered, privacy: .public)")
+        ATTNLogBuffer.shared.append(level: .fault, category: category, message: message.rendered)
+    }
+}
+
+/// Mirrors the call-site shape of `os.Logger`'s string interpolation, including the
+/// `, privacy:` argument, so existing call sites compile unchanged. The interpolation
+/// is rendered eagerly into `rendered` for the in-app log buffer.
+struct ATTNLogMessage: ExpressibleByStringInterpolation, ExpressibleByStringLiteral {
+    let rendered: String
+
+    init(stringLiteral value: String) {
+        self.rendered = value
+    }
+
+    init(stringInterpolation: StringInterpolation) {
+        self.rendered = stringInterpolation.value
+    }
+
+    struct StringInterpolation: StringInterpolationProtocol {
+        var value: String
+
+        init(literalCapacity: Int, interpolationCount: Int) {
+            value = ""
+            value.reserveCapacity(literalCapacity)
+        }
+
+        mutating func appendLiteral(_ literal: String) {
+            value.append(literal)
+        }
+
+        mutating func appendInterpolation<T>(_ argument: @autoclosure () -> T, privacy: OSLogPrivacy = .public) {
+            value.append("\(argument())")
+        }
+
+        mutating func appendInterpolation(_ argument: @autoclosure () -> String, privacy: OSLogPrivacy = .public) {
+            value.append(argument())
+        }
+
+        mutating func appendInterpolation(_ argument: @autoclosure () -> any CustomStringConvertible, privacy: OSLogPrivacy = .public) {
+            value.append(argument().description)
+        }
+    }
 }

--- a/Sources/Helpers/Logger.swift
+++ b/Sources/Helpers/Logger.swift
@@ -35,34 +35,70 @@ struct ATTNLogger {
         self.osLogger = Logger(subsystem: Loggers.subsystem, category: category)
     }
 
-    func debug(_ message: ATTNLogMessage) {
-        osLogger.debug("\(message.rendered, privacy: .public)")
-        ATTNLogBuffer.shared.append(level: .debug, category: category, message: message.rendered)
+    // Each level forwards `message` as an autoclosure into os.Logger's own lazy
+    // string interpolation. When the buffer isn't capturing, os.Logger keeps its
+    // native gating: on release builds with `.debug` disabled, the closure isn't
+    // evaluated and the call costs nothing — same as calling `os.Logger` directly.
+    // When capture is on, we evaluate once and feed both destinations.
+
+    func debug(_ message: @autoclosure @escaping () -> ATTNLogMessage) {
+        if ATTNLogBuffer.shared.isCapturing {
+            let rendered = message().rendered
+            osLogger.debug("\(rendered, privacy: .public)")
+            ATTNLogBuffer.shared.append(level: .debug, category: category, message: rendered)
+        } else {
+            osLogger.debug("\(message().rendered, privacy: .public)")
+        }
     }
 
-    func info(_ message: ATTNLogMessage) {
-        osLogger.info("\(message.rendered, privacy: .public)")
-        ATTNLogBuffer.shared.append(level: .info, category: category, message: message.rendered)
+    func info(_ message: @autoclosure @escaping () -> ATTNLogMessage) {
+        if ATTNLogBuffer.shared.isCapturing {
+            let rendered = message().rendered
+            osLogger.info("\(rendered, privacy: .public)")
+            ATTNLogBuffer.shared.append(level: .info, category: category, message: rendered)
+        } else {
+            osLogger.info("\(message().rendered, privacy: .public)")
+        }
     }
 
-    func notice(_ message: ATTNLogMessage) {
-        osLogger.notice("\(message.rendered, privacy: .public)")
-        ATTNLogBuffer.shared.append(level: .notice, category: category, message: message.rendered)
+    func notice(_ message: @autoclosure @escaping () -> ATTNLogMessage) {
+        if ATTNLogBuffer.shared.isCapturing {
+            let rendered = message().rendered
+            osLogger.notice("\(rendered, privacy: .public)")
+            ATTNLogBuffer.shared.append(level: .notice, category: category, message: rendered)
+        } else {
+            osLogger.notice("\(message().rendered, privacy: .public)")
+        }
     }
 
-    func warning(_ message: ATTNLogMessage) {
-        osLogger.warning("\(message.rendered, privacy: .public)")
-        ATTNLogBuffer.shared.append(level: .warning, category: category, message: message.rendered)
+    func warning(_ message: @autoclosure @escaping () -> ATTNLogMessage) {
+        if ATTNLogBuffer.shared.isCapturing {
+            let rendered = message().rendered
+            osLogger.warning("\(rendered, privacy: .public)")
+            ATTNLogBuffer.shared.append(level: .warning, category: category, message: rendered)
+        } else {
+            osLogger.warning("\(message().rendered, privacy: .public)")
+        }
     }
 
-    func error(_ message: ATTNLogMessage) {
-        osLogger.error("\(message.rendered, privacy: .public)")
-        ATTNLogBuffer.shared.append(level: .error, category: category, message: message.rendered)
+    func error(_ message: @autoclosure @escaping () -> ATTNLogMessage) {
+        if ATTNLogBuffer.shared.isCapturing {
+            let rendered = message().rendered
+            osLogger.error("\(rendered, privacy: .public)")
+            ATTNLogBuffer.shared.append(level: .error, category: category, message: rendered)
+        } else {
+            osLogger.error("\(message().rendered, privacy: .public)")
+        }
     }
 
-    func fault(_ message: ATTNLogMessage) {
-        osLogger.fault("\(message.rendered, privacy: .public)")
-        ATTNLogBuffer.shared.append(level: .fault, category: category, message: message.rendered)
+    func fault(_ message: @autoclosure @escaping () -> ATTNLogMessage) {
+        if ATTNLogBuffer.shared.isCapturing {
+            let rendered = message().rendered
+            osLogger.fault("\(rendered, privacy: .public)")
+            ATTNLogBuffer.shared.append(level: .fault, category: category, message: rendered)
+        } else {
+            osLogger.fault("\(message().rendered, privacy: .public)")
+        }
     }
 }
 

--- a/Sources/Public/ATTNLogEntry.swift
+++ b/Sources/Public/ATTNLogEntry.swift
@@ -21,13 +21,18 @@ public final class ATTNLogEntry: NSObject {
 
     @objc public let date: Date
     @objc public let category: String
+    /// Always one of `Level.rawValue`. Swift callers should prefer `logLevel`.
     @objc public let level: String
     @objc public let message: String
 
-    public init(date: Date, category: String, level: String, message: String) {
+    /// Typed accessor for Swift callers. Returns `nil` only if `level` was
+    /// constructed from a raw string outside `Level.rawValue`.
+    public var logLevel: Level? { Level(rawValue: level) }
+
+    public init(date: Date, category: String, level: Level, message: String) {
         self.date = date
         self.category = category
-        self.level = level
+        self.level = level.rawValue
         self.message = message
     }
 

--- a/Sources/Public/ATTNLogEntry.swift
+++ b/Sources/Public/ATTNLogEntry.swift
@@ -1,0 +1,48 @@
+//
+//  ATTNLogEntry.swift
+//  attentive-ios-sdk-framework
+//
+//  Created by Umair Sharif on 5/12/26.
+//
+
+import Foundation
+
+/// A snapshot of a single SDK log line, suitable for rendering in a debug console.
+@objc(ATTNLogEntry)
+public final class ATTNLogEntry: NSObject {
+    public enum Level: String, CaseIterable {
+        case debug
+        case info
+        case notice
+        case warning
+        case error
+        case fault
+    }
+
+    @objc public let date: Date
+    @objc public let category: String
+    @objc public let level: String
+    @objc public let message: String
+
+    public init(date: Date, category: String, level: String, message: String) {
+        self.date = date
+        self.category = category
+        self.level = level
+        self.message = message
+    }
+
+    private static let iso8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    /// Renders `entry` as `<timestamp> [<category>] <LEVEL>: <message>`.
+    public func formatted(timestamp: String) -> String {
+        "\(timestamp) [\(category)] \(level.uppercased()): \(message)"
+    }
+
+    public override var description: String {
+        formatted(timestamp: Self.iso8601Formatter.string(from: date))
+    }
+}

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -69,6 +69,20 @@ public final class ATTNSDK: NSObject {
     private var mode: ATTNSDKMode
     private var webViewHandler: ATTNWebViewHandling?
 
+    /// Recent SDK log entries from the in-process ring buffer. Captures every level
+    /// (including `.debug`) regardless of build configuration, so this works in
+    /// release/TestFlight builds where `OSLogStore` would not surface `.debug` lines.
+    /// - Parameter since: Optional cutoff; entries older than this are filtered out.
+    public static func recentLogs(since: Date? = nil) -> [ATTNLogEntry] {
+        ATTNLogBuffer.shared.snapshot(since: since)
+    }
+
+    /// Async stream that yields each SDK log entry as it is recorded. Use this to
+    /// drive a live debug overlay.
+    public static var logStream: AsyncStream<ATTNLogEntry> {
+        ATTNLogBuffer.shared.stream()
+    }
+
     /// Determinates if fatigue rules evaluation will be skipped for Creative. Default value is false.
     @objc public var skipFatigueOnCreative: Bool = false
 

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -72,7 +72,7 @@ public final class ATTNSDK: NSObject {
     /// Enables in-app log capture. Off by default; apps that don't display the SDK
     /// log overlay pay zero buffer overhead. Set this once at launch (e.g. before
     /// constructing the SDK) and the buffer will retain subsequent entries.
-    public static var isLogCaptureEnabled: Bool {
+    @objc public static var isLogCaptureEnabled: Bool {
         get { ATTNLogBuffer.shared.isCapturing }
         set { ATTNLogBuffer.shared.isCapturing = newValue }
     }
@@ -80,7 +80,7 @@ public final class ATTNSDK: NSObject {
     /// Recent SDK log entries from the in-process ring buffer. Returns an empty
     /// array when log capture is disabled (the default).
     /// - Parameter since: Optional cutoff; entries older than this are filtered out.
-    public static func recentLogs(since: Date? = nil) -> [ATTNLogEntry] {
+    @objc public static func recentLogs(since: Date? = nil) -> [ATTNLogEntry] {
         ATTNLogBuffer.shared.snapshot(since: since)
     }
 

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -69,16 +69,23 @@ public final class ATTNSDK: NSObject {
     private var mode: ATTNSDKMode
     private var webViewHandler: ATTNWebViewHandling?
 
-    /// Recent SDK log entries from the in-process ring buffer. Captures every level
-    /// (including `.debug`) regardless of build configuration, so this works in
-    /// release/TestFlight builds where `OSLogStore` would not surface `.debug` lines.
+    /// Enables in-app log capture. Off by default; apps that don't display the SDK
+    /// log overlay pay zero buffer overhead. Set this once at launch (e.g. before
+    /// constructing the SDK) and the buffer will retain subsequent entries.
+    public static var isLogCaptureEnabled: Bool {
+        get { ATTNLogBuffer.shared.isCapturing }
+        set { ATTNLogBuffer.shared.isCapturing = newValue }
+    }
+
+    /// Recent SDK log entries from the in-process ring buffer. Returns an empty
+    /// array when log capture is disabled (the default).
     /// - Parameter since: Optional cutoff; entries older than this are filtered out.
     public static func recentLogs(since: Date? = nil) -> [ATTNLogEntry] {
         ATTNLogBuffer.shared.snapshot(since: since)
     }
 
-    /// Async stream that yields each SDK log entry as it is recorded. Use this to
-    /// drive a live debug overlay.
+    /// Async stream that yields each SDK log entry as it is recorded after capture
+    /// is enabled. Use this to drive a live debug overlay.
     public static var logStream: AsyncStream<ATTNLogEntry> {
         ATTNLogBuffer.shared.stream()
     }

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -69,27 +69,6 @@ public final class ATTNSDK: NSObject {
     private var mode: ATTNSDKMode
     private var webViewHandler: ATTNWebViewHandling?
 
-    /// Enables in-app log capture. Off by default; apps that don't display the SDK
-    /// log overlay pay zero buffer overhead. Set this once at launch (e.g. before
-    /// constructing the SDK) and the buffer will retain subsequent entries.
-    @objc public static var isLogCaptureEnabled: Bool {
-        get { ATTNLogBuffer.shared.isCapturing }
-        set { ATTNLogBuffer.shared.isCapturing = newValue }
-    }
-
-    /// Recent SDK log entries from the in-process ring buffer. Returns an empty
-    /// array when log capture is disabled (the default).
-    /// - Parameter since: Optional cutoff; entries older than this are filtered out.
-    @objc public static func recentLogs(since: Date? = nil) -> [ATTNLogEntry] {
-        ATTNLogBuffer.shared.snapshot(since: since)
-    }
-
-    /// Async stream that yields each SDK log entry as it is recorded after capture
-    /// is enabled. Use this to drive a live debug overlay.
-    public static var logStream: AsyncStream<ATTNLogEntry> {
-        ATTNLogBuffer.shared.stream()
-    }
-
     /// Determinates if fatigue rules evaluation will be skipped for Creative. Default value is false.
     @objc public var skipFatigueOnCreative: Bool = false
 
@@ -1070,6 +1049,30 @@ private struct PendingMarketingRequest {
     let phone: String?
     let callback: ATTNAPICallback?
     let createdAt: Date
+}
+
+// MARK: Debug Log Capture
+extension ATTNSDK {
+    /// Enables in-app log capture. Off by default; apps that don't display the SDK
+    /// log overlay pay zero buffer overhead. Set this once at launch (e.g. before
+    /// constructing the SDK) and the buffer will retain subsequent entries.
+    @objc public static var isLogCaptureEnabled: Bool {
+        get { ATTNLogBuffer.shared.isCapturing }
+        set { ATTNLogBuffer.shared.isCapturing = newValue }
+    }
+
+    /// Recent SDK log entries from the in-process ring buffer. Returns an empty
+    /// array when log capture is disabled (the default).
+    /// - Parameter since: Optional cutoff; entries older than this are filtered out.
+    @objc public static func recentLogs(since: Date? = nil) -> [ATTNLogEntry] {
+        ATTNLogBuffer.shared.snapshot(since: since)
+    }
+
+    /// Async stream that yields each SDK log entry as it is recorded after capture
+    /// is enabled. Use this to drive a live debug overlay.
+    public static var logStream: AsyncStream<ATTNLogEntry> {
+        ATTNLogBuffer.shared.stream()
+    }
 }
 
 private extension Array {

--- a/Tests/TestCases/ATTNLogBufferTests.swift
+++ b/Tests/TestCases/ATTNLogBufferTests.swift
@@ -1,0 +1,207 @@
+//
+//  ATTNLogBufferTests.swift
+//  attentive-ios-sdk Tests
+//
+//  Created by Umair Sharif on 5/14/26.
+//
+
+import XCTest
+@testable import ATTNSDKFramework
+
+final class ATTNLogBufferTests: XCTestCase {
+
+    private var buffer: ATTNLogBuffer!
+
+    override func setUp() {
+        super.setUp()
+        buffer = ATTNLogBuffer(capacity: 8)
+        buffer.isCapturing = true
+        // isCapturing setter is async; flush the queue so capture is live before each test
+        flushBufferQueue()
+    }
+
+    override func tearDown() {
+        buffer = nil
+        super.tearDown()
+    }
+
+    // MARK: - Capture gating
+
+    func testAppend_whenNotCapturing_dropsEntries() {
+        let buffer = ATTNLogBuffer(capacity: 4)
+        // isCapturing defaults to false
+        buffer.append(level: .debug, category: "test", message: "ignored")
+        buffer.append(level: .info, category: "test", message: "ignored too")
+
+        XCTAssertEqual(buffer.snapshot().count, 0)
+    }
+
+    func testAppend_whenCapturing_retainsEntries() {
+        buffer.append(level: .debug, category: "net", message: "one")
+        buffer.append(level: .info, category: "evt", message: "two")
+
+        let snapshot = buffer.snapshot()
+        XCTAssertEqual(snapshot.count, 2)
+        XCTAssertEqual(snapshot[0].message, "one")
+        XCTAssertEqual(snapshot[0].logLevel, .debug)
+        XCTAssertEqual(snapshot[1].category, "evt")
+    }
+
+    func testSnapshot_withSinceDate_filtersEarlierEntries() {
+        buffer.append(level: .debug, category: "c", message: "old")
+        flushBufferQueue()
+        let cutoff = Date()
+        // ensure subsequent entries have date strictly >= cutoff
+        Thread.sleep(forTimeInterval: 0.01)
+        buffer.append(level: .debug, category: "c", message: "new")
+
+        let filtered = buffer.snapshot(since: cutoff)
+        XCTAssertEqual(filtered.map(\.message), ["new"])
+    }
+
+    // MARK: - Eviction boundary
+
+    func testEviction_triggersAtCapacityPlusSlack_andRetainsCapacity() {
+        // capacity = 8, evictionSlack = max(1, 8/4) = 2
+        // Filling up to 9 entries should leave us at 9 (under threshold of 10).
+        for i in 0..<9 {
+            buffer.append(level: .debug, category: "c", message: "msg-\(i)")
+        }
+        XCTAssertEqual(buffer.snapshot().count, 9, "should not evict before capacity + slack")
+
+        // The 10th append crosses the threshold (count == capacity + slack) and removes
+        // evictionSlack (2) entries from the front.
+        buffer.append(level: .debug, category: "c", message: "msg-9")
+
+        let snapshot = buffer.snapshot()
+        XCTAssertEqual(snapshot.count, 8, "should evict slack entries down to capacity")
+        XCTAssertEqual(snapshot.first?.message, "msg-2", "should drop oldest entries first")
+        XCTAssertEqual(snapshot.last?.message, "msg-9")
+    }
+
+    func testEviction_smallCapacity_usesMinimumSlackOfOne() {
+        // capacity = 1 -> evictionSlack = max(1, 1/4) = max(1, 0) = 1
+        let small = ATTNLogBuffer(capacity: 1)
+        small.isCapturing = true
+        flushBufferQueue(on: small)
+
+        small.append(level: .debug, category: "c", message: "a")
+        small.append(level: .debug, category: "c", message: "b") // count == 2 == capacity + slack -> evict 1
+
+        let snapshot = small.snapshot()
+        XCTAssertEqual(snapshot.count, 1)
+        XCTAssertEqual(snapshot.first?.message, "b")
+    }
+
+    // MARK: - Subscriber lifecycle
+
+    func testStream_subscriberReceivesAppendedEntries() async {
+        let stream = buffer.stream()
+        // Allow the queue.async that registers the continuation to run before we append.
+        flushBufferQueue()
+
+        buffer.append(level: .info, category: "evt", message: "first")
+        buffer.append(level: .info, category: "evt", message: "second")
+
+        var iterator = stream.makeAsyncIterator()
+        let a = await iterator.next()
+        let b = await iterator.next()
+
+        XCTAssertEqual(a?.message, "first")
+        XCTAssertEqual(b?.message, "second")
+    }
+
+    func testStream_multipleSubscribers_eachReceiveEveryEntry() async {
+        let s1 = buffer.stream()
+        let s2 = buffer.stream()
+        flushBufferQueue()
+
+        buffer.append(level: .info, category: "c", message: "x")
+
+        var i1 = s1.makeAsyncIterator()
+        var i2 = s2.makeAsyncIterator()
+        let v1 = await i1.next()
+        let v2 = await i2.next()
+
+        XCTAssertEqual(v1?.message, "x")
+        XCTAssertEqual(v2?.message, "x")
+    }
+
+    func testStream_cancellingTask_removesSubscriber() async {
+        let received = expectation(description: "received entry before cancel")
+        let task = Task { [buffer] in
+            // capture buffer locally so we don't reach across actor boundaries
+            for await entry in buffer!.stream() {
+                if entry.message == "ping" { received.fulfill() }
+            }
+        }
+
+        // Give the Task a moment to subscribe.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        flushBufferQueue()
+
+        XCTAssertEqual(subscriberCount(), 1, "subscriber should be registered after stream() runs")
+
+        buffer.append(level: .info, category: "c", message: "ping")
+        await fulfillment(of: [received], timeout: 1.0)
+
+        task.cancel()
+
+        // onTermination is queued onto the buffer's serial queue; wait for it to drain.
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        flushBufferQueue()
+
+        XCTAssertEqual(subscriberCount(), 0, "subscriber should be removed after task cancellation")
+    }
+
+    func testStream_appendsRacingWithCancellation_doNotCrash() async {
+        // Repeatedly subscribe/cancel while a producer hammers append(). This exercises
+        // the onTermination cleanup running concurrently with appends. The serial queue
+        // serializes both, so this should never crash or deadlock.
+        let producer = Task.detached { [buffer] in
+            for i in 0..<500 {
+                buffer!.append(level: .debug, category: "race", message: "m-\(i)")
+            }
+        }
+
+        for _ in 0..<20 {
+            let t = Task { [buffer] in
+                for await _ in buffer!.stream() { /* consume */ }
+            }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+            t.cancel()
+        }
+
+        await producer.value
+        // Allow any queued onTermination handlers to drain.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        flushBufferQueue()
+
+        XCTAssertEqual(subscriberCount(), 0, "all subscribers should be cleaned up after cancellation")
+    }
+
+    // MARK: - Helpers
+
+    private func subscriberCount(on target: ATTNLogBuffer? = nil) -> Int {
+        // Read through the same serial queue used by append/onTermination so we observe
+        // a fully-drained state. We use Mirror to avoid widening internal API.
+        let target = target ?? buffer!
+        flushBufferQueue(on: target)
+        let mirror = Mirror(reflecting: target)
+        let subscribers = mirror.children.first { $0.label == "subscribers" }?.value
+        return (subscribers as? [UUID: Any])?.count ?? -1
+    }
+
+    /// Submits and awaits a sync block on the buffer's serial queue, ensuring all
+    /// previously-enqueued async work (appends, isCapturing toggles, subscriber
+    /// add/remove) has completed.
+    private func flushBufferQueue(on target: ATTNLogBuffer? = nil) {
+        let target = target ?? buffer!
+        let mirror = Mirror(reflecting: target)
+        guard let queue = mirror.children.first(where: { $0.label == "queue" })?.value as? DispatchQueue else {
+            XCTFail("expected ATTNLogBuffer to expose a `queue` property via Mirror")
+            return
+        }
+        queue.sync { }
+    }
+}

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		FB2983F62C0F7CF10039759C /* ATTNUserIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2983F52C0F7CF10039759C /* ATTNUserIdentityTests.swift */; };
 		FB2983F82C0F7FB60039759C /* ATTNUserAgentBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2983F72C0F7FB60039759C /* ATTNUserAgentBuilderTests.swift */; };
 		FB2983FA2C0F80A30039759C /* ATTNPersistentStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2983F92C0F80A30039759C /* ATTNPersistentStorageTests.swift */; };
+		0AD0CE052F62A38000ABCDEF /* ATTNLogBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD0CE042F62A38000ABCDEF /* ATTNLogBufferTests.swift */; };
 		FB2983FC2C0F81FD0039759C /* ATTNParameterValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2983FB2C0F81FD0039759C /* ATTNParameterValidationTests.swift */; };
 		FB2983FE2C0F85770039759C /* ATTNCustomEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2983FD2C0F85770039759C /* ATTNCustomEventTests.swift */; };
 		FB2984002C0F86270039759C /* ATTNCreativeUrlFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2983FF2C0F86270039759C /* ATTNCreativeUrlFormatterTests.swift */; };
@@ -183,6 +184,7 @@
 		FB2983F52C0F7CF10039759C /* ATTNUserIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNUserIdentityTests.swift; sourceTree = "<group>"; };
 		FB2983F72C0F7FB60039759C /* ATTNUserAgentBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNUserAgentBuilderTests.swift; sourceTree = "<group>"; };
 		FB2983F92C0F80A30039759C /* ATTNPersistentStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNPersistentStorageTests.swift; sourceTree = "<group>"; };
+		0AD0CE042F62A38000ABCDEF /* ATTNLogBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNLogBufferTests.swift; sourceTree = "<group>"; };
 		FB2983FB2C0F81FD0039759C /* ATTNParameterValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNParameterValidationTests.swift; sourceTree = "<group>"; };
 		FB2983FD2C0F85770039759C /* ATTNCustomEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNCustomEventTests.swift; sourceTree = "<group>"; };
 		FB2983FF2C0F86270039759C /* ATTNCreativeUrlFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNCreativeUrlFormatterTests.swift; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 				FB2983F52C0F7CF10039759C /* ATTNUserIdentityTests.swift */,
 				FB2983F72C0F7FB60039759C /* ATTNUserAgentBuilderTests.swift */,
 				FB2983F92C0F80A30039759C /* ATTNPersistentStorageTests.swift */,
+				0AD0CE042F62A38000ABCDEF /* ATTNLogBufferTests.swift */,
 				F9CED4642DEF74D200780536 /* ATTNRetryingNetworkClientTests.swift */,
 				FB2983FB2C0F81FD0039759C /* ATTNParameterValidationTests.swift */,
 				FB2983FD2C0F85770039759C /* ATTNCustomEventTests.swift */,
@@ -861,6 +864,7 @@
 				FB2983F42C0F759D0039759C /* ATTNVisitorServiceTests.swift in Sources */,
 				0AE51BF12F7D8138004CC16E /* ATTNSnapshotTestCase.swift in Sources */,
 				FB2983FA2C0F80A30039759C /* ATTNPersistentStorageTests.swift in Sources */,
+				0AD0CE052F62A38000ABCDEF /* ATTNLogBufferTests.swift in Sources */,
 				F9CED4652DEF74D200780536 /* ATTNRetryingNetworkClientTests.swift in Sources */,
 				FB080C722C1C755F00834BAA /* ATTNCreativeUrlProviderSpy.swift in Sources */,
 				FB2983E52C0F73990039759C /* ATTNUserAgentBuilderMock.swift in Sources */,

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -88,6 +88,8 @@
 		FB90EF0D2C10A7F7004DFC4A /* NSURLSessionDataTaskMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB90EF0C2C10A7F7004DFC4A /* NSURLSessionDataTaskMock.swift */; };
 		FB90EF0F2C10A81E004DFC4A /* NSURLSessionMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB90EF0E2C10A81E004DFC4A /* NSURLSessionMock.swift */; };
 		FB91BE602C2B4C6200E5A9B8 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB91BE5F2C2B4C6200E5A9B8 /* Logger.swift */; };
+		0AD0CE012F62A38000ABCDEF /* ATTNLogBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD0CE002F62A38000ABCDEF /* ATTNLogBuffer.swift */; };
+		0AD0CE032F62A38000ABCDEF /* ATTNLogEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD0CE022F62A38000ABCDEF /* ATTNLogEntry.swift */; };
 		FBA9FA062C0A77AB00C65024 /* ATTNAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA9F9E42C0A77AB00C65024 /* ATTNAPI.swift */; };
 		FBA9FA072C0A77AB00C65024 /* ATTNEventRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA9F9E52C0A77AB00C65024 /* ATTNEventRequest.swift */; };
 		FBA9FA082C0A77AB00C65024 /* Dictionary+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA9F9E72C0A77AB00C65024 /* Dictionary+Extension.swift */; };
@@ -225,6 +227,8 @@
 		FB90EF0C2C10A7F7004DFC4A /* NSURLSessionDataTaskMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSURLSessionDataTaskMock.swift; sourceTree = "<group>"; };
 		FB90EF0E2C10A81E004DFC4A /* NSURLSessionMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSURLSessionMock.swift; sourceTree = "<group>"; };
 		FB91BE5F2C2B4C6200E5A9B8 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		0AD0CE002F62A38000ABCDEF /* ATTNLogBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNLogBuffer.swift; sourceTree = "<group>"; };
+		0AD0CE022F62A38000ABCDEF /* ATTNLogEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNLogEntry.swift; sourceTree = "<group>"; };
 		FBA9F9E42C0A77AB00C65024 /* ATTNAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ATTNAPI.swift; sourceTree = "<group>"; };
 		FBA9F9E52C0A77AB00C65024 /* ATTNEventRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ATTNEventRequest.swift; sourceTree = "<group>"; };
 		FBA9F9E72C0A77AB00C65024 /* Dictionary+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extension.swift"; sourceTree = "<group>"; };
@@ -462,6 +466,7 @@
 				FBA9F9E82C0A77AB00C65024 /* Extension */,
 				FB35C1842C0E35E7009FA048 /* ATTNJsonUtils.swift */,
 				FB91BE5F2C2B4C6200E5A9B8 /* Logger.swift */,
+				0AD0CE002F62A38000ABCDEF /* ATTNLogBuffer.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -569,6 +574,7 @@
 				FBA9F9FE2C0A77AB00C65024 /* ATTNUserIdentity.swift */,
 				FB35C1782C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift */,
 				FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */,
+				0AD0CE022F62A38000ABCDEF /* ATTNLogEntry.swift */,
 			);
 			path = Public;
 			sourceTree = "<group>";
@@ -779,6 +785,8 @@
 				FBF78AAE2C135ECD00596479 /* ATTNConstants.m in Sources */,
 				FBA9FA072C0A77AB00C65024 /* ATTNEventRequest.swift in Sources */,
 				FB91BE602C2B4C6200E5A9B8 /* Logger.swift in Sources */,
+				0AD0CE012F62A38000ABCDEF /* ATTNLogBuffer.swift in Sources */,
+				0AD0CE032F62A38000ABCDEF /* ATTNLogEntry.swift in Sources */,
 				FB35C1932C0E524E009FA048 /* ATTNPurchaseEvent+Extension.swift in Sources */,
 				FB35C18D2C0E3FAA009FA048 /* ATTNUserIdentity+Extension.swift in Sources */,
 				FB35C1832C0E1FD7009FA048 /* URLSession+Extension.swift in Sources */,


### PR DESCRIPTION
## PR Type
- [x] Feature

## What's new?
Final piece of [MSDK-329](https://attentivemobile.atlassian.net/browse/MSDK-329) — an always-available, in-app SDK log viewer for the Bonni example app. Lets QA inspect SDK log output on TestFlight/release builds without attaching a debugger.

### SDK
- Wraps \`os.Logger\` with a new \`ATTNLogger\` struct that fans out to both the OS unified log AND an in-process ring buffer (\`ATTNLogBuffer\`). Existing 178 \`Loggers.creative.debug(...)\` / etc. call sites compile unchanged thanks to a custom \`ATTNLogMessage: ExpressibleByStringInterpolation\` that mirrors \`os.Logger\`'s \`, privacy:\` API.
- \`ATTNLogBuffer\` is a thread-safe ring buffer (1000 entries, amortized O(1) eviction) with a snapshot accessor and a multi-subscriber \`AsyncStream\`.
- New public API: \`ATTNSDK.recentLogs(since:)\` and \`ATTNSDK.logStream\`. Both work in any build configuration — including TestFlight — because the buffer captures \`.debug\` directly instead of relying on \`OSLogStore\`, which only persists \`.notice\` and above by default.
- New public type: \`ATTNLogEntry\` (\`@objc\`-bridged snapshot of one log line with a shared \`formatted(timestamp:)\` helper).

### Bonni
- New \`DebugLogOverlay\`: a separate \`UIWindow\` at \`windowLevel = .alert + 1\` installed once from \`SceneDelegate\` so it floats above every screen.
- A draggable \"LOGS\" toggle button shows/hides a compact, draggable floating panel (320×240) that streams entries live via \`ATTNSDK.logStream\` and renders them with timestamp, category, level, and message.
- The overlay window uses a \`hitTest\` override so non-chrome regions pass touches through to the underlying app — the rest of Bonni stays fully usable with the overlay installed.
- Panel work is skipped while hidden (entries queue to a small pending buffer and flush in one batch on toggle); visible appends use \`textStorage.append\` rather than reassigning \`textView.text\`, so per-entry cost stays O(1).

### Limitations / non-goals
- Privacy: every \`Loggers.*\` call is forwarded to \`os.Logger\` as a single \`.public\` value. Every existing call site already annotates \`.public\`, so this is a no-op today; documented inline so future contributors don't expect \`.private\` to redact in Console.app.
- Subscriber bookkeeping uses a UUID-keyed dict rather than reusing an extracted helper — there is no other \`AsyncStream\` subscriber-management code in the SDK to share with yet.

## Testing
- Builds the SDK framework and the Bonni app cleanly.
- Verified in the iOS Simulator: the floating LOGS button overlays the login screen with login UI fully tappable. Real SDK entries (\`network DEBUG: Success on attempt 1\`, \`event INFO: Obtained existing visitor id: ...\`, \`event DEBUG: Successfully sent push token\`) stream into the panel live.

## Screenshots
https://github.com/user-attachments/assets/bad66b06-cdbf-4191-8024-17c1cf6f9185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-329]: https://attentivemobile.atlassian.net/browse/MSDK-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ