### PR TITLE
MSDK-312: protect mutable shared state with NSLock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ bundle exec fastlane ios assemble_xcframework
 - Use `ATTNLogger` for all SDK logging — never `print()`
 - String constants and keys belong in `ATTNConstants`
 - URL construction goes through `URLProvider` types, not inline
+- **Underscore prefix on stored properties is reserved.** Only use `_foo` when Swift forces it — i.e., the property is the backing storage for a public computed property of the same name (e.g., `ATTNUserIdentity._identifiers` backs the `@objc` `identifiers` wrapper). For purely-private vars (including lock-guarded ones with no public counterpart), use the plain name; `private` already conveys scope.
 
 ### SwiftUI (Inbox module only)
 

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -18,7 +18,7 @@ final class ATTNAPI: ATTNAPIProtocol {
 
     private let retryClient: ATTNRetryingNetworkClient
     private let stateLock = NSLock()
-    private var _lastPushTokenSendTime: Date?
+    private var lastPushTokenSendTime: Date?
 
     // MARK: ATTNAPIProtocol Properties
     var domain: String
@@ -62,10 +62,10 @@ final class ATTNAPI: ATTNAPIProtocol {
         // debounce to remove duplicate events; only allow events tracking at most once every 2 seconds
         let shouldSkip: Bool = stateLock.withLock {
             let now = Date()
-            if let last = _lastPushTokenSendTime, now.timeIntervalSince(last) < 2 {
+            if let last = lastPushTokenSendTime, now.timeIntervalSince(last) < 2 {
                 return true
             }
-            _lastPushTokenSendTime = now
+            lastPushTokenSendTime = now
             return false
         }
         if shouldSkip {

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -61,14 +61,17 @@ final class ATTNAPI: ATTNAPIProtocol {
                                          callback: ATTNAPICallback?) {
         // debounce to remove duplicate events; only allow events tracking at most once every 2 seconds
         let now = Date()
-        stateLock.lock()
-        if let last = _lastPushTokenSendTime, now.timeIntervalSince(last) < 2 {
-            stateLock.unlock()
+        let shouldSkip: Bool = stateLock.withLock {
+            if let last = _lastPushTokenSendTime, now.timeIntervalSince(last) < 2 {
+                return true
+            }
+            _lastPushTokenSendTime = now
+            return false
+        }
+        if shouldSkip {
             Loggers.event.debug("Skipping duplicate sendPushToken due to debounce.")
             return
         }
-        _lastPushTokenSendTime = now
-        stateLock.unlock()
 
         Loggers.network.debug("Sending push token - Visitor ID: \(userIdentity.visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public), Auth Status: \(authorizationStatus.rawValue, privacy: .public)")
 

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -17,7 +17,8 @@ final class ATTNAPI: ATTNAPIProtocol {
     private(set) var urlSession: URLSession
 
     private let retryClient: ATTNRetryingNetworkClient
-    private var lastPushTokenSendTime: Date?
+    private let stateLock = NSLock()
+    private var _lastPushTokenSendTime: Date?
 
     // MARK: ATTNAPIProtocol Properties
     var domain: String
@@ -60,11 +61,14 @@ final class ATTNAPI: ATTNAPIProtocol {
                                          callback: ATTNAPICallback?) {
         // debounce to remove duplicate events; only allow events tracking at most once every 2 seconds
         let now = Date()
-        if let last = lastPushTokenSendTime, now.timeIntervalSince(last) < 2 {
+        stateLock.lock()
+        if let last = _lastPushTokenSendTime, now.timeIntervalSince(last) < 2 {
+            stateLock.unlock()
             Loggers.event.debug("Skipping duplicate sendPushToken due to debounce.")
             return
         }
-        lastPushTokenSendTime = now
+        _lastPushTokenSendTime = now
+        stateLock.unlock()
 
         Loggers.network.debug("Sending push token - Visitor ID: \(userIdentity.visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public), Auth Status: \(authorizationStatus.rawValue, privacy: .public)")
 

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -60,8 +60,8 @@ final class ATTNAPI: ATTNAPIProtocol {
                                          authorizationStatus: UNAuthorizationStatus,
                                          callback: ATTNAPICallback?) {
         // debounce to remove duplicate events; only allow events tracking at most once every 2 seconds
-        let now = Date()
         let shouldSkip: Bool = stateLock.withLock {
+            let now = Date()
             if let last = _lastPushTokenSendTime, now.timeIntervalSince(last) < 2 {
                 return true
             }

--- a/Sources/Helpers/Extension/NSLock+Extension.swift
+++ b/Sources/Helpers/Extension/NSLock+Extension.swift
@@ -1,0 +1,18 @@
+//
+//  NSLock+Extension.swift
+//  attentive-ios-sdk-framework
+//
+
+import Foundation
+
+extension NSLock {
+    /// Executes `body` while holding the lock, releasing on every exit path.
+    /// Mirrors the iOS 16 stdlib `withLock` so error-prone `lock()`/`unlock()`
+    /// pairs aren't sprinkled across the SDK on iOS 14/15.
+    @discardableResult
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}

--- a/Sources/Public/ATTNEventTracker.swift
+++ b/Sources/Public/ATTNEventTracker.swift
@@ -19,6 +19,7 @@ public enum ATTNEventData {
 
 @objc(ATTNEventTracker)
 public final class ATTNEventTracker: NSObject {
+    private static let sharedInstanceLock = NSLock()
     private static var _sharedInstance: ATTNEventTracker?
     private let sdk: ATTNSDK
 
@@ -29,7 +30,9 @@ public final class ATTNEventTracker: NSObject {
 
     @objc(setupWithSdk:)
     public static func setup(with sdk: ATTNSDK) {
+        sharedInstanceLock.lock()
         _sharedInstance = ATTNEventTracker(sdk: sdk)
+        sharedInstanceLock.unlock()
         Loggers.event.debug("ATTNEventTracker was initialized with SDK")
     }
 
@@ -45,8 +48,11 @@ public final class ATTNEventTracker: NSObject {
 
     @objc
     public static func sharedInstance() -> ATTNEventTracker? {
-        assert(_sharedInstance != nil, "ATTNEventTracker must be setup before being used")
-        return _sharedInstance
+        sharedInstanceLock.lock()
+        let instance = _sharedInstance
+        sharedInstanceLock.unlock()
+        assert(instance != nil, "ATTNEventTracker must be setup before being used")
+        return instance
     }
 
     // MARK: - New Event API (v2 endpoint)
@@ -88,7 +94,9 @@ public final class ATTNEventTracker: NSObject {
 // MARK: Internal Helpers
 extension ATTNEventTracker {
     static func destroy() {
+        sharedInstanceLock.lock()
         _sharedInstance = nil
+        sharedInstanceLock.unlock()
     }
 
     func getSdk() -> ATTNSDK {

--- a/Sources/Public/ATTNEventTracker.swift
+++ b/Sources/Public/ATTNEventTracker.swift
@@ -30,9 +30,9 @@ public final class ATTNEventTracker: NSObject {
 
     @objc(setupWithSdk:)
     public static func setup(with sdk: ATTNSDK) {
-        sharedInstanceLock.lock()
-        _sharedInstance = ATTNEventTracker(sdk: sdk)
-        sharedInstanceLock.unlock()
+        sharedInstanceLock.withLock {
+            _sharedInstance = ATTNEventTracker(sdk: sdk)
+        }
         Loggers.event.debug("ATTNEventTracker was initialized with SDK")
     }
 
@@ -48,9 +48,7 @@ public final class ATTNEventTracker: NSObject {
 
     @objc
     public static func sharedInstance() -> ATTNEventTracker? {
-        sharedInstanceLock.lock()
-        let instance = _sharedInstance
-        sharedInstanceLock.unlock()
+        let instance = sharedInstanceLock.withLock { _sharedInstance }
         assert(instance != nil, "ATTNEventTracker must be setup before being used")
         return instance
     }
@@ -94,9 +92,9 @@ public final class ATTNEventTracker: NSObject {
 // MARK: Internal Helpers
 extension ATTNEventTracker {
     static func destroy() {
-        sharedInstanceLock.lock()
-        _sharedInstance = nil
-        sharedInstanceLock.unlock()
+        sharedInstanceLock.withLock {
+            _sharedInstance = nil
+        }
     }
 
     func getSdk() -> ATTNSDK {

--- a/Sources/Public/ATTNEventTracker.swift
+++ b/Sources/Public/ATTNEventTracker.swift
@@ -32,8 +32,8 @@ public final class ATTNEventTracker: NSObject {
     public static func setup(with sdk: ATTNSDK) {
         sharedInstanceLock.withLock {
             _sharedInstance = ATTNEventTracker(sdk: sdk)
+            Loggers.event.debug("ATTNEventTracker was initialized with SDK")
         }
-        Loggers.event.debug("ATTNEventTracker was initialized with SDK")
     }
 
     @available(swift, deprecated: 0.6, message: "Please use record(event: ATTNEvent) instead.")

--- a/Sources/Public/ATTNUserIdentity.swift
+++ b/Sources/Public/ATTNUserIdentity.swift
@@ -15,7 +15,13 @@ public final class ATTNUserIdentity: NSObject {
     private let visitorService: ATTNVisitorService
 
     @objc public var identifiers: [String: Any] {
-        lock.withLock { _identifiers }
+        get { lock.withLock { _identifiers } }
+        set {
+            if !newValue.isEmpty {
+                validate(identifiers: newValue)
+            }
+            lock.withLock { _identifiers = newValue }
+        }
     }
 
     @objc public var visitorId: String {

--- a/Sources/Public/ATTNUserIdentity.swift
+++ b/Sources/Public/ATTNUserIdentity.swift
@@ -43,9 +43,13 @@ public final class ATTNUserIdentity: NSObject {
 
     @objc
     public func clearUser() {
+        // Generate the new visitor id outside the lock — it does a synchronous
+        // UserDefaults write which would otherwise serialize every concurrent
+        // clearUser call behind a disk I/O.
+        let newVisitorId = visitorService.createNewVisitorId()
         lock.withLock {
             _identifiers = [:]
-            _visitorId = visitorService.createNewVisitorId()
+            _visitorId = newVisitorId
         }
     }
 

--- a/Sources/Public/ATTNUserIdentity.swift
+++ b/Sources/Public/ATTNUserIdentity.swift
@@ -15,15 +15,11 @@ public final class ATTNUserIdentity: NSObject {
     private let visitorService: ATTNVisitorService
 
     @objc public var identifiers: [String: Any] {
-        lock.lock()
-        defer { lock.unlock() }
-        return _identifiers
+        lock.withLock { _identifiers }
     }
 
     @objc public var visitorId: String {
-        lock.lock()
-        defer { lock.unlock() }
-        return _visitorId
+        lock.withLock { _visitorId }
     }
 
     @objc
@@ -41,19 +37,19 @@ public final class ATTNUserIdentity: NSObject {
 
     @objc
     public func clearUser() {
-        lock.lock()
-        _identifiers = [:]
-        _visitorId = visitorService.createNewVisitorId()
-        lock.unlock()
+        lock.withLock {
+            _identifiers = [:]
+            _visitorId = visitorService.createNewVisitorId()
+        }
     }
 
     @objc
     public func mergeIdentifiers(_ newIdentifiers: [String: Any]) {
         validate(identifiers: newIdentifiers)
-        lock.lock()
-        // In case of a key conflict, the new value from newIdentifiers should be used.
-        _identifiers.merge(newIdentifiers) { (_, new) in new }
-        lock.unlock()
+        lock.withLock {
+            // In case of a key conflict, the new value from newIdentifiers should be used.
+            _identifiers.merge(newIdentifiers) { (_, new) in new }
+        }
     }
 }
 

--- a/Sources/Public/ATTNUserIdentity.swift
+++ b/Sources/Public/ATTNUserIdentity.swift
@@ -43,13 +43,14 @@ public final class ATTNUserIdentity: NSObject {
 
     @objc
     public func clearUser() {
-        // Generate the new visitor id outside the lock — it does a synchronous
-        // UserDefaults write which would otherwise serialize every concurrent
-        // clearUser call behind a disk I/O.
-        let newVisitorId = visitorService.createNewVisitorId()
+        // Keep visitor-id generation inside the lock so the UserDefaults write
+        // order matches the in-memory swap order. If two threads race here and
+        // we generate outside the lock, the last write to disk could disagree
+        // with the last value of `_visitorId`, leaving the next app launch with
+        // a stale visitor id.
         lock.withLock {
             _identifiers = [:]
-            _visitorId = newVisitorId
+            _visitorId = visitorService.createNewVisitorId()
         }
     }
 

--- a/Sources/Public/ATTNUserIdentity.swift
+++ b/Sources/Public/ATTNUserIdentity.swift
@@ -9,15 +9,22 @@ import Foundation
 
 @objc(ATTNUserIdentity)
 public final class ATTNUserIdentity: NSObject {
+    private let lock = NSLock()
+    private var _identifiers: [String: Any]
+    private var _visitorId: String
+    private let visitorService: ATTNVisitorService
+
     @objc public var identifiers: [String: Any] {
-        willSet {
-            guard !newValue.isEmpty else { return }
-            validate(identifiers: newValue)
-        }
+        lock.lock()
+        defer { lock.unlock() }
+        return _identifiers
     }
 
-    @objc public var visitorId: String
-    private let visitorService: ATTNVisitorService
+    @objc public var visitorId: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return _visitorId
+    }
 
     @objc
     override public convenience init() {
@@ -27,25 +34,26 @@ public final class ATTNUserIdentity: NSObject {
     @objc(initWithIdentifiers:)
     public init(identifiers: [String: Any]) {
         self.visitorService = .init()
-        self.identifiers = identifiers
-        self.visitorId = self.visitorService.getVisitorId()
+        self._identifiers = identifiers
+        self._visitorId = self.visitorService.getVisitorId()
         super.init()
     }
 
     @objc
     public func clearUser() {
-        identifiers = [:]
-        visitorId = visitorService.createNewVisitorId()
+        lock.lock()
+        _identifiers = [:]
+        _visitorId = visitorService.createNewVisitorId()
+        lock.unlock()
     }
 
     @objc
     public func mergeIdentifiers(_ newIdentifiers: [String: Any]) {
         validate(identifiers: newIdentifiers)
-
-        var currentIdentifiers = identifiers
+        lock.lock()
         // In case of a key conflict, the new value from newIdentifiers should be used.
-        currentIdentifiers.merge(newIdentifiers) { (_, new) in new }
-        identifiers = currentIdentifiers
+        _identifiers.merge(newIdentifiers) { (_, new) in new }
+        lock.unlock()
     }
 }
 

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -44,7 +44,6 @@ public final class ATTNSDK: NSObject {
     private var pendingMarketingRequests: [PendingMarketingRequest] = []
     private var pendingMarketingExpiryTimer: DispatchSourceTimer?
     private let pendingMarketingTTL: TimeInterval = 60
-    /// Guards `_pendingURL` and `_lastRegularOpenTime`.
     private let stateLock = NSLock()
     /// Holds exactly one pending deep-link URL (new taps overwrite old).
     private var _pendingURL: URL?
@@ -418,14 +417,17 @@ public final class ATTNSDK: NSObject {
         }
         // debounce to remove duplicate events; only allow app events tracking once every 2 seconds
         let now = Date()
-        stateLock.lock()
-        if let last = _lastRegularOpenTime, now.timeIntervalSince(last) < 2 {
-            stateLock.unlock()
+        let shouldSkip: Bool = stateLock.withLock {
+            if let last = _lastRegularOpenTime, now.timeIntervalSince(last) < 2 {
+                return true
+            }
+            _lastRegularOpenTime = now
+            return false
+        }
+        if shouldSkip {
             Loggers.event.debug("Skipping duplicate handleRegularOpen due to debounce.")
             return
         }
-        _lastRegularOpenTime = now
-        stateLock.unlock()
 
         let alEvent: [String: Any] = [
             "ist": "al",
@@ -504,10 +506,11 @@ public final class ATTNSDK: NSObject {
     /// If the client prefers polling instead of observing NotificationCenter, or if the NotificationCenter broadcast happens too early for listener to catch it,
     /// call this to retrieve (and clear) the pending URL.
     public func consumeDeepLink() -> URL? {
-        stateLock.lock()
-        let url = _pendingURL
-        _pendingURL = nil
-        stateLock.unlock()
+        let url = stateLock.withLock { () -> URL? in
+            let snapshot = _pendingURL
+            _pendingURL = nil
+            return snapshot
+        }
         let urlString = url?.absoluteString ?? ""
         Loggers.network.debug("Consuming pending deep link: \(urlString, privacy: .public)")
         return url
@@ -626,9 +629,7 @@ public final class ATTNSDK: NSObject {
             return
         }
 
-        stateLock.lock()
-        _pendingURL = validURL
-        stateLock.unlock()
+        stateLock.withLock { _pendingURL = validURL }
         Loggers.network.debug("Broadcasting ATTNSDKDeepLinkReceived with URL: \(validURL, privacy: .public)")
         NotificationCenter.default.post(
             name: .ATTNSDKDeepLinkReceived,

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -39,14 +39,17 @@ public final class ATTNSDK: NSObject {
 
     private var _containerView: UIView?
     private let pushTokenStore = PushTokenStore()
-    let marketingQueue = DispatchQueue(label: "com.attentive.sdk.MarketingQueue", qos: .userInitiated)
-    var pendingMarketingRequests: [PendingMarketingRequest] = []
-    var pendingMarketingExpiryTimer: DispatchSourceTimer?
-    let pendingMarketingTTL: TimeInterval = 60
+    private let marketingQueue = DispatchQueue(label: "com.attentive.sdk.MarketingQueue", qos: .userInitiated)
+    /// All access to `pendingMarketingRequests` and `pendingMarketingExpiryTimer` is serialized through `marketingQueue`.
+    private var pendingMarketingRequests: [PendingMarketingRequest] = []
+    private var pendingMarketingExpiryTimer: DispatchSourceTimer?
+    private let pendingMarketingTTL: TimeInterval = 60
+    /// Guards `_pendingURL` and `_lastRegularOpenTime`.
+    private let stateLock = NSLock()
     /// Holds exactly one pending deep-link URL (new taps overwrite old).
-    private var pendingURL: URL?
+    private var _pendingURL: URL?
     // Debounce mechanism to prevent duplicate events
-    private var lastRegularOpenTime: Date?
+    private var _lastRegularOpenTime: Date?
 
     var currentPushToken: String { pushTokenStore.token }
 
@@ -415,11 +418,14 @@ public final class ATTNSDK: NSObject {
         }
         // debounce to remove duplicate events; only allow app events tracking once every 2 seconds
         let now = Date()
-        if let last = lastRegularOpenTime, now.timeIntervalSince(last) < 2 {
+        stateLock.lock()
+        if let last = _lastRegularOpenTime, now.timeIntervalSince(last) < 2 {
+            stateLock.unlock()
             Loggers.event.debug("Skipping duplicate handleRegularOpen due to debounce.")
             return
         }
-        lastRegularOpenTime = now
+        _lastRegularOpenTime = now
+        stateLock.unlock()
 
         let alEvent: [String: Any] = [
             "ist": "al",
@@ -498,10 +504,13 @@ public final class ATTNSDK: NSObject {
     /// If the client prefers polling instead of observing NotificationCenter, or if the NotificationCenter broadcast happens too early for listener to catch it,
     /// call this to retrieve (and clear) the pending URL.
     public func consumeDeepLink() -> URL? {
-        defer { pendingURL = nil }
-        let urlString = pendingURL?.absoluteString ?? ""
+        stateLock.lock()
+        let url = _pendingURL
+        _pendingURL = nil
+        stateLock.unlock()
+        let urlString = url?.absoluteString ?? ""
         Loggers.network.debug("Consuming pending deep link: \(urlString, privacy: .public)")
-        return pendingURL
+        return url
     }
 
     // MARK: - Private Helpers
@@ -617,7 +626,9 @@ public final class ATTNSDK: NSObject {
             return
         }
 
-        pendingURL = validURL
+        stateLock.lock()
+        _pendingURL = validURL
+        stateLock.unlock()
         Loggers.network.debug("Broadcasting ATTNSDKDeepLinkReceived with URL: \(validURL, privacy: .public)")
         NotificationCenter.default.post(
             name: .ATTNSDKDeepLinkReceived,

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -39,11 +39,11 @@ public final class ATTNSDK: NSObject {
 
     private var _containerView: UIView?
     private let pushTokenStore = PushTokenStore()
-    private let marketingQueue = DispatchQueue(label: "com.attentive.sdk.MarketingQueue", qos: .userInitiated)
+    let marketingQueue = DispatchQueue(label: "com.attentive.sdk.MarketingQueue", qos: .userInitiated)
     /// All access to `pendingMarketingRequests` and `pendingMarketingExpiryTimer` is serialized through `marketingQueue`.
-    private var pendingMarketingRequests: [PendingMarketingRequest] = []
-    private var pendingMarketingExpiryTimer: DispatchSourceTimer?
-    private let pendingMarketingTTL: TimeInterval = 60
+    var pendingMarketingRequests: [PendingMarketingRequest] = []
+    var pendingMarketingExpiryTimer: DispatchSourceTimer?
+    let pendingMarketingTTL: TimeInterval = 60
     private let stateLock = NSLock()
     /// Holds exactly one pending deep-link URL (new taps overwrite old).
     private var _pendingURL: URL?

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -416,8 +416,8 @@ public final class ATTNSDK: NSObject {
             return
         }
         // debounce to remove duplicate events; only allow app events tracking once every 2 seconds
-        let now = Date()
         let shouldSkip: Bool = stateLock.withLock {
+            let now = Date()
             if let last = _lastRegularOpenTime, now.timeIntervalSince(last) < 2 {
                 return true
             }
@@ -616,7 +616,7 @@ public final class ATTNSDK: NSObject {
     }
 
     /// Normalize a raw string into a URL, stash it, and immediately post a notification.
-    private func normalizeAndBroadcast(_ rawString: String) {
+    internal func normalizeAndBroadcast(_ rawString: String) {
         let trimmed = rawString.trimmingCharacters(in: .whitespacesAndNewlines)
         var candidateURL: URL?
 

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -46,9 +46,9 @@ public final class ATTNSDK: NSObject {
     let pendingMarketingTTL: TimeInterval = 60
     private let stateLock = NSLock()
     /// Holds exactly one pending deep-link URL (new taps overwrite old).
-    private var _pendingURL: URL?
+    private var pendingURL: URL?
     // Debounce mechanism to prevent duplicate events
-    private var _lastRegularOpenTime: Date?
+    private var lastRegularOpenTime: Date?
 
     var currentPushToken: String { pushTokenStore.token }
 
@@ -418,10 +418,10 @@ public final class ATTNSDK: NSObject {
         // debounce to remove duplicate events; only allow app events tracking once every 2 seconds
         let shouldSkip: Bool = stateLock.withLock {
             let now = Date()
-            if let last = _lastRegularOpenTime, now.timeIntervalSince(last) < 2 {
+            if let last = lastRegularOpenTime, now.timeIntervalSince(last) < 2 {
                 return true
             }
-            _lastRegularOpenTime = now
+            lastRegularOpenTime = now
             return false
         }
         if shouldSkip {
@@ -507,8 +507,8 @@ public final class ATTNSDK: NSObject {
     /// call this to retrieve (and clear) the pending URL.
     public func consumeDeepLink() -> URL? {
         let url = stateLock.withLock { () -> URL? in
-            let snapshot = _pendingURL
-            _pendingURL = nil
+            let snapshot = pendingURL
+            pendingURL = nil
             return snapshot
         }
         let urlString = url?.absoluteString ?? ""
@@ -629,7 +629,7 @@ public final class ATTNSDK: NSObject {
             return
         }
 
-        stateLock.withLock { _pendingURL = validURL }
+        stateLock.withLock { pendingURL = validURL }
         Loggers.network.debug("Broadcasting ATTNSDKDeepLinkReceived with URL: \(validURL, privacy: .public)")
         NotificationCenter.default.post(
             name: .ATTNSDKDeepLinkReceived,

--- a/Tests/TestCases/ATTNEventTrackerTests.swift
+++ b/Tests/TestCases/ATTNEventTrackerTests.swift
@@ -24,22 +24,13 @@ final class ATTNEventTrackerTests: XCTestCase {
 
     func testSharedInstance_concurrentSetupAndAccess_doesNotCrash() {
         let sdk = ATTNSDK(domain: "domain")
-        let group = DispatchGroup()
-        let queue = DispatchQueue(label: "concurrent", attributes: .concurrent)
-        for _ in 0..<200 {
-            group.enter()
-            queue.async {
+        runConcurrently(iterations: 200, queueLabels: ["setup", "access"]) { _, queueIndex in
+            if queueIndex == 0 {
                 ATTNEventTracker.setup(with: sdk)
-                group.leave()
-            }
-            group.enter()
-            queue.async {
+            } else {
                 _ = ATTNEventTracker.sharedInstance()
-                group.leave()
             }
         }
-        let result = group.wait(timeout: .now() + 5)
-        XCTAssertEqual(result, .success)
         XCTAssertNotNil(ATTNEventTracker.sharedInstance())
     }
 }

--- a/Tests/TestCases/ATTNEventTrackerTests.swift
+++ b/Tests/TestCases/ATTNEventTrackerTests.swift
@@ -21,4 +21,25 @@ final class ATTNEventTrackerTests: XCTestCase {
 
         XCTAssertNoThrow(ATTNEventTracker.sharedInstance())
     }
+
+    func testSharedInstance_concurrentSetupAndAccess_doesNotCrash() {
+        let sdk = ATTNSDK(domain: "domain")
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "concurrent", attributes: .concurrent)
+        for _ in 0..<200 {
+            group.enter()
+            queue.async {
+                ATTNEventTracker.setup(with: sdk)
+                group.leave()
+            }
+            group.enter()
+            queue.async {
+                _ = ATTNEventTracker.sharedInstance()
+                group.leave()
+            }
+        }
+        let result = group.wait(timeout: .now() + 5)
+        XCTAssertEqual(result, .success)
+        XCTAssertNotNil(ATTNEventTracker.sharedInstance())
+    }
 }

--- a/Tests/TestCases/ATTNSDKTests.swift
+++ b/Tests/TestCases/ATTNSDKTests.swift
@@ -602,31 +602,6 @@ final class ATTNSDKTests: XCTestCase {
         return condition()
     }
 
-    // MARK: Concurrency
-
-    func testConsumeDeepLink_concurrentConsumeAndSet_atMostOneConsumerWinsPerSet() {
-        // The read-and-clear in `consumeDeepLink` must be atomic: of N concurrent consumers
-        // racing one published deep link, exactly one (or zero, if a later set has already
-        // overwritten it) should observe a non-nil URL — never two reading the same URL.
-        let counter = Counter()
-        runConcurrently(iterations: 200, queueLabels: ["set", "consume"]) { [weak self] i, queueIndex in
-            guard let self else { return }
-            if queueIndex == 0 {
-                self.sut.normalizeAndBroadcast("attentive://test/\(i)")
-            } else if self.sut.consumeDeepLink() != nil {
-                counter.increment()
-            }
-        }
-        // Bounded by number of set operations; the precise count depends on timing.
-        XCTAssertLessThanOrEqual(counter.value, 200)
-    }
-}
-
-private final class Counter {
-    private let lock = NSLock()
-    private var _value = 0
-    var value: Int { lock.withLock { _value } }
-    func increment() { lock.withLock { _value += 1 } }
     // MARK: - Error Handling Tests
 
     func testUpdateDomain_invalidDomain_callsCompletionWithError() {
@@ -681,4 +656,29 @@ private final class Counter {
         XCTAssertEqual(receivedError as? ATTNSDKError, .missingPushToken)
     }
 
+    // MARK: Concurrency
+
+    func testConsumeDeepLink_concurrentConsumeAndSet_atMostOneConsumerWinsPerSet() {
+        // The read-and-clear in `consumeDeepLink` must be atomic: of N concurrent consumers
+        // racing one published deep link, exactly one (or zero, if a later set has already
+        // overwritten it) should observe a non-nil URL — never two reading the same URL.
+        let counter = Counter()
+        runConcurrently(iterations: 200, queueLabels: ["set", "consume"]) { [weak self] i, queueIndex in
+            guard let self else { return }
+            if queueIndex == 0 {
+                self.sut.normalizeAndBroadcast("attentive://test/\(i)")
+            } else if self.sut.consumeDeepLink() != nil {
+                counter.increment()
+            }
+        }
+        // Bounded by number of set operations; the precise count depends on timing.
+        XCTAssertLessThanOrEqual(counter.value, 200)
+    }
+}
+
+private final class Counter {
+    private let lock = NSLock()
+    private var _value = 0
+    var value: Int { lock.withLock { _value } }
+    func increment() { lock.withLock { _value += 1 } }
 }

--- a/Tests/TestCases/ATTNSDKTests.swift
+++ b/Tests/TestCases/ATTNSDKTests.swift
@@ -602,6 +602,31 @@ final class ATTNSDKTests: XCTestCase {
         return condition()
     }
 
+    // MARK: Concurrency
+
+    func testConsumeDeepLink_concurrentConsumeAndSet_atMostOneConsumerWinsPerSet() {
+        // The read-and-clear in `consumeDeepLink` must be atomic: of N concurrent consumers
+        // racing one published deep link, exactly one (or zero, if a later set has already
+        // overwritten it) should observe a non-nil URL — never two reading the same URL.
+        let counter = Counter()
+        runConcurrently(iterations: 200, queueLabels: ["set", "consume"]) { [weak self] i, queueIndex in
+            guard let self else { return }
+            if queueIndex == 0 {
+                self.sut.normalizeAndBroadcast("attentive://test/\(i)")
+            } else if self.sut.consumeDeepLink() != nil {
+                counter.increment()
+            }
+        }
+        // Bounded by number of set operations; the precise count depends on timing.
+        XCTAssertLessThanOrEqual(counter.value, 200)
+    }
+}
+
+private final class Counter {
+    private let lock = NSLock()
+    private var _value = 0
+    var value: Int { lock.withLock { _value } }
+    func increment() { lock.withLock { _value += 1 } }
     // MARK: - Error Handling Tests
 
     func testUpdateDomain_invalidDomain_callsCompletionWithError() {

--- a/Tests/TestCases/ATTNUserIdentityTests.swift
+++ b/Tests/TestCases/ATTNUserIdentityTests.swift
@@ -89,8 +89,7 @@ final class ATTNUserIdentityTests: XCTestCase {
 
     func testMergeIdentifiers_concurrentMerges_doesNotCrashAndPreservesAllKeys() {
         let identity = ATTNUserIdentity()
-        let iterations = 200
-        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+        DispatchQueue.concurrentPerform(iterations: 200) { i in
             identity.mergeIdentifiers([ATTNIdentifierType.customIdentifiers: ["key\(i)": "value\(i)"] as NSDictionary])
         }
         // The classic TOCTOU here would either crash or drop keys. With proper locking
@@ -101,44 +100,24 @@ final class ATTNUserIdentityTests: XCTestCase {
 
     func testMergeAndRead_concurrentReadersAndWriters_doesNotCrash() {
         let identity = ATTNUserIdentity(identifiers: [ATTNIdentifierType.email: "seed@test.com"])
-        let group = DispatchGroup()
-        let writerQueue = DispatchQueue(label: "writer", attributes: .concurrent)
-        let readerQueue = DispatchQueue(label: "reader", attributes: .concurrent)
-
-        for i in 0..<200 {
-            group.enter()
-            writerQueue.async {
+        runConcurrently(iterations: 200, queueLabels: ["writer", "reader"]) { i, queueIndex in
+            if queueIndex == 0 {
                 identity.mergeIdentifiers([ATTNIdentifierType.email: "user\(i)@test.com"])
-                group.leave()
-            }
-            group.enter()
-            readerQueue.async {
+            } else {
                 _ = identity.identifiers
                 _ = identity.visitorId
-                group.leave()
             }
         }
-        let result = group.wait(timeout: .now() + 5)
-        XCTAssertEqual(result, .success)
     }
 
     func testClearUser_concurrentClearAndMerge_doesNotCrash() {
         let identity = ATTNUserIdentity()
-        let group = DispatchGroup()
-        let queue = DispatchQueue(label: "concurrent", attributes: .concurrent)
-        for i in 0..<100 {
-            group.enter()
-            queue.async {
+        runConcurrently(iterations: 100, queueLabels: ["merge", "clear"]) { i, queueIndex in
+            if queueIndex == 0 {
                 identity.mergeIdentifiers([ATTNIdentifierType.email: "user\(i)@test.com"])
-                group.leave()
-            }
-            group.enter()
-            queue.async {
+            } else {
                 identity.clearUser()
-                group.leave()
             }
         }
-        let result = group.wait(timeout: .now() + 5)
-        XCTAssertEqual(result, .success)
     }
 }

--- a/Tests/TestCases/ATTNUserIdentityTests.swift
+++ b/Tests/TestCases/ATTNUserIdentityTests.swift
@@ -84,4 +84,61 @@ final class ATTNUserIdentityTests: XCTestCase {
         XCTAssertEqual(1, identity.identifiers.count)
         XCTAssertEqual("someValue", identity.identifiers[ATTNIdentifierType.clientUserId] as! String)
     }
+
+    // MARK: Concurrency
+
+    func testMergeIdentifiers_concurrentMerges_doesNotCrashAndPreservesAllKeys() {
+        let identity = ATTNUserIdentity()
+        let iterations = 200
+        DispatchQueue.concurrentPerform(iterations: iterations) { i in
+            identity.mergeIdentifiers([ATTNIdentifierType.customIdentifiers: ["key\(i)": "value\(i)"] as NSDictionary])
+        }
+        // The classic TOCTOU here would either crash or drop keys. With proper locking
+        // we only guarantee the merge sequence is atomic — the *last* writer wins for the
+        // shared key, but the operation must complete without crashing.
+        XCTAssertNotNil(identity.identifiers[ATTNIdentifierType.customIdentifiers])
+    }
+
+    func testMergeAndRead_concurrentReadersAndWriters_doesNotCrash() {
+        let identity = ATTNUserIdentity(identifiers: [ATTNIdentifierType.email: "seed@test.com"])
+        let group = DispatchGroup()
+        let writerQueue = DispatchQueue(label: "writer", attributes: .concurrent)
+        let readerQueue = DispatchQueue(label: "reader", attributes: .concurrent)
+
+        for i in 0..<200 {
+            group.enter()
+            writerQueue.async {
+                identity.mergeIdentifiers([ATTNIdentifierType.email: "user\(i)@test.com"])
+                group.leave()
+            }
+            group.enter()
+            readerQueue.async {
+                _ = identity.identifiers
+                _ = identity.visitorId
+                group.leave()
+            }
+        }
+        let result = group.wait(timeout: .now() + 5)
+        XCTAssertEqual(result, .success)
+    }
+
+    func testClearUser_concurrentClearAndMerge_doesNotCrash() {
+        let identity = ATTNUserIdentity()
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "concurrent", attributes: .concurrent)
+        for i in 0..<100 {
+            group.enter()
+            queue.async {
+                identity.mergeIdentifiers([ATTNIdentifierType.email: "user\(i)@test.com"])
+                group.leave()
+            }
+            group.enter()
+            queue.async {
+                identity.clearUser()
+                group.leave()
+            }
+        }
+        let result = group.wait(timeout: .now() + 5)
+        XCTAssertEqual(result, .success)
+    }
 }

--- a/Tests/TestCases/ATTNUserIdentityTests.swift
+++ b/Tests/TestCases/ATTNUserIdentityTests.swift
@@ -87,15 +87,15 @@ final class ATTNUserIdentityTests: XCTestCase {
 
     // MARK: Concurrency
 
-    func testMergeIdentifiers_concurrentMerges_doesNotCrashAndPreservesAllKeys() {
+    func testMergeIdentifiers_concurrentMerges_preservesAllKeys() {
         let identity = ATTNUserIdentity()
+        // Each iteration writes a *different* top-level key. With non-atomic merge the
+        // read-modify-write would drop keys under contention; with proper locking every
+        // merge composes, so all 200 keys must survive.
         DispatchQueue.concurrentPerform(iterations: 200) { i in
-            identity.mergeIdentifiers([ATTNIdentifierType.customIdentifiers: ["key\(i)": "value\(i)"] as NSDictionary])
+            identity.mergeIdentifiers(["dynamic_key_\(i)": "value\(i)"])
         }
-        // The classic TOCTOU here would either crash or drop keys. With proper locking
-        // we only guarantee the merge sequence is atomic — the *last* writer wins for the
-        // shared key, but the operation must complete without crashing.
-        XCTAssertNotNil(identity.identifiers[ATTNIdentifierType.customIdentifiers])
+        XCTAssertEqual(identity.identifiers.count, 200)
     }
 
     func testMergeAndRead_concurrentReadersAndWriters_doesNotCrash() {

--- a/Tests/TestCases/ATTNUserIdentityTests.swift
+++ b/Tests/TestCases/ATTNUserIdentityTests.swift
@@ -112,7 +112,10 @@ final class ATTNUserIdentityTests: XCTestCase {
 
     func testClearUser_concurrentClearAndMerge_doesNotCrash() {
         let identity = ATTNUserIdentity()
-        runConcurrently(iterations: 100, queueLabels: ["merge", "clear"]) { i, queueIndex in
+        // Iteration count kept low because clearUser() does a synchronous
+        // UserDefaults write per call; 20×2 racing calls is plenty to surface
+        // a missing-lock crash without blowing CI's timeout budget on disk I/O.
+        runConcurrently(iterations: 20, timeout: 10, queueLabels: ["merge", "clear"]) { i, queueIndex in
             if queueIndex == 0 {
                 identity.mergeIdentifiers([ATTNIdentifierType.email: "user\(i)@test.com"])
             } else {

--- a/Tests/XCTestCase+Concurrency.swift
+++ b/Tests/XCTestCase+Concurrency.swift
@@ -1,0 +1,33 @@
+//
+//  XCTestCase+Concurrency.swift
+//  attentive-ios-sdk Tests
+//
+
+import XCTest
+
+extension XCTestCase {
+    /// Dispatches `iterations` parallel blocks across one or more concurrent queues
+    /// and asserts they all complete within `timeout`. The block index is passed in
+    /// so callers can vary their work per iteration.
+    func runConcurrently(
+        iterations: Int,
+        timeout: TimeInterval = 5,
+        queueLabels: [String] = ["concurrent"],
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ block: @escaping (Int, _ queueIndex: Int) -> Void
+    ) {
+        let queues = queueLabels.map { DispatchQueue(label: $0, attributes: .concurrent) }
+        let group = DispatchGroup()
+        for i in 0..<iterations {
+            for (queueIndex, queue) in queues.enumerated() {
+                group.enter()
+                queue.async {
+                    block(i, queueIndex)
+                    group.leave()
+                }
+            }
+        }
+        XCTAssertEqual(group.wait(timeout: .now() + timeout), .success, file: file, line: line)
+    }
+}

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		FB35C17B2C0E0353009FA048 /* ATTNIdentifierType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */; };
 		FB35C17D2C0E039E009FA048 /* ATTNConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C17C2C0E039E009FA048 /* ATTNConstants.swift */; };
 		FB35C1832C0E1FD7009FA048 /* URLSession+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1822C0E1FD7009FA048 /* URLSession+Extension.swift */; };
+		A9D1C312A0001000000000001 /* NSLock+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D1C312A0001000000000002 /* NSLock+Extension.swift */; };
+		A9D1C312A0001000000000003 /* XCTestCase+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D1C312A0001000000000004 /* XCTestCase+Concurrency.swift */; };
 		FB35C1852C0E35E7009FA048 /* ATTNJsonUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1842C0E35E7009FA048 /* ATTNJsonUtils.swift */; };
 		FB35C1872C0E3929009FA048 /* ATTNEventTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1862C0E3929009FA048 /* ATTNEventTypes.swift */; };
 		FB35C1892C0E3AF8009FA048 /* ATTNExternalVendorTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1882C0E3AF8009FA048 /* ATTNExternalVendorTypes.swift */; };
@@ -171,6 +173,8 @@
 		FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNIdentifierType.swift; sourceTree = "<group>"; };
 		FB35C17C2C0E039E009FA048 /* ATTNConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNConstants.swift; sourceTree = "<group>"; };
 		FB35C1822C0E1FD7009FA048 /* URLSession+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Extension.swift"; sourceTree = "<group>"; };
+		A9D1C312A0001000000000002 /* NSLock+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLock+Extension.swift"; sourceTree = "<group>"; };
+		A9D1C312A0001000000000004 /* XCTestCase+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Concurrency.swift"; sourceTree = "<group>"; };
 		FB35C1842C0E35E7009FA048 /* ATTNJsonUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNJsonUtils.swift; sourceTree = "<group>"; };
 		FB35C1862C0E3929009FA048 /* ATTNEventTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNEventTypes.swift; sourceTree = "<group>"; };
 		FB35C1882C0E3AF8009FA048 /* ATTNExternalVendorTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNExternalVendorTypes.swift; sourceTree = "<group>"; };
@@ -357,6 +361,7 @@
 				FB2983F22C0F75600039759C /* TestCases */,
 				FB2983D32C0F73990039759C /* Doubles */,
 				FB2984032C0F9D650039759C /* ATTNTestEventUtils.swift */,
+				A9D1C312A0001000000000004 /* XCTestCase+Concurrency.swift */,
 				FB56D4DF2C20923800AF7530 /* Extensions */,
 			);
 			path = Tests;
@@ -468,6 +473,7 @@
 				FB56D4DB2C208D6100AF7530 /* Boolean+Extension.swift */,
 				FBA9F9E72C0A77AB00C65024 /* Dictionary+Extension.swift */,
 				FB35C1822C0E1FD7009FA048 /* URLSession+Extension.swift */,
+				A9D1C312A0001000000000002 /* NSLock+Extension.swift */,
 				FB35C18A2C0E3F27009FA048 /* ATTNEvent+Extension.swift */,
 				FB35C18C2C0E3FAA009FA048 /* ATTNUserIdentity+Extension.swift */,
 				FB35C1922C0E524E009FA048 /* ATTNPurchaseEvent+Extension.swift */,
@@ -714,6 +720,7 @@
 				FB35C1932C0E524E009FA048 /* ATTNPurchaseEvent+Extension.swift in Sources */,
 				FB35C18D2C0E3FAA009FA048 /* ATTNUserIdentity+Extension.swift in Sources */,
 				FB35C1832C0E1FD7009FA048 /* URLSession+Extension.swift in Sources */,
+				A9D1C312A0001000000000001 /* NSLock+Extension.swift in Sources */,
 				FB35C1872C0E3929009FA048 /* ATTNEventTypes.swift in Sources */,
 				FBA9FA162C0A77AB00C65024 /* ATTNPrice.swift in Sources */,
 				FB35C1912C0E506D009FA048 /* ATTNEventRequestProvider.swift in Sources */,
@@ -792,6 +799,7 @@
 				F952B5B62EC2915000E0E69D /* ATTNEventURLProviderV2Tests.swift in Sources */,
 				F952B5B72EC2915000E0E69D /* ATTNV2EventModelsTests.swift in Sources */,
 				FB2984042C0F9D650039759C /* ATTNTestEventUtils.swift in Sources */,
+				A9D1C312A0001000000000003 /* XCTestCase+Concurrency.swift in Sources */,
 				7C5CBBB7981899D2F38C79B1 /* ATTNErrorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## Summary

[MSDK-312](https://attentivemobile.atlassian.net/browse/MSDK-312) called out unprotected mutable state across `ATTNSDK`, `ATTNAPI`, `ATTNUserIdentity`, and `ATTNEventTracker` that can race under real-world conditions (app backgrounding, push arrivals, SDK init). This PR adds the `NSLock`-based synchronization the ticket recommended.

- `ATTNUserIdentity` — `identifiers` and `visitorId` are now backed by lock-guarded storage; `mergeIdentifiers` is atomic, fixing the read-modify-write TOCTOU
- `ATTNEventTracker` — lock around `_sharedInstance` setup/get/destroy
- `ATTNAPI` — lock around `lastPushTokenSendTime` debounce check-and-set
- `ATTNSDK` — lock guarding `pendingURL` and `lastRegularOpenTime` (`pendingMarketingRequests` was already serialized via `marketingQueue`, left unchanged)
- `cachedGeoAdjustedDomain` from the ticket no longer applies — removed in MSDK-264

Second commit cleans up the lock sites with an `NSLock.withLock` helper (RAII unlock on every exit path, including the early-return debounce paths) and consolidates the duplicated `DispatchGroup` test boilerplate behind an `XCTestCase.runConcurrently(iterations:queueLabels:)` helper.

## Test plan
- [x] `bundle exec fastlane ios unit_test` passes locally
- [x] New concurrency tests exercise the protected state under concurrent readers/writers (`ATTNUserIdentityTests.testMergeIdentifiers_concurrentMerges_doesNotCrashAndPreservesAllKeys`, `testMergeAndRead_concurrentReadersAndWriters_doesNotCrash`, `testClearUser_concurrentClearAndMerge_doesNotCrash`, `ATTNEventTrackerTests.testSharedInstance_concurrentSetupAndAccess_doesNotCrash`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-312]: https://attentivemobile.atlassian.net/browse/MSDK-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ