### PR TITLE
docs: fix mobile-sdk-internal plugin install instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,13 @@ Internal Attentive API documentation and instructions live in the private [`atte
 
 ```
 /plugin marketplace add attentive-mobile/claude-plugins
-/plugin install mobile-sdk-internal@attentive-mobile
+/plugin install mobile-sdk-internal@attentive-marketplace
+```
+
+If you've previously added the marketplace but don't see `mobile-sdk-internal`, refresh the local cache first:
+
+```
+/plugin marketplace update attentive-marketplace
 ```
 
 This keeps internal details out of the public SDK repo while letting Claude Code pull them in at runtime.


### PR DESCRIPTION
## Summary
- Fix install command suffix: `mobile-sdk-internal@attentive-mobile` → `mobile-sdk-internal@attentive-marketplace` (matches the marketplace's declared `name` field; the prior value would fail with "marketplace not found")
- Add a `/plugin marketplace update attentive-marketplace` instruction for users who added the marketplace before the plugin was published and have a stale local cache

## Test plan
- [ ] Fresh install path: `/plugin marketplace add attentive-mobile/claude-plugins` followed by `/plugin install mobile-sdk-internal@attentive-marketplace` succeeds
- [ ] Stale cache path: `/plugin marketplace update attentive-marketplace` then install succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)