### PR TITLE
Skip SwiftLint Xcode build phase in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,13 +105,6 @@ commands:
               ]
             }
 
-  install-swiftlint:
-    description: "Install SwiftLint (required by Xcode build phase)"
-    steps:
-      - run:
-          name: Install SwiftLint
-          command: command -v swiftlint || brew install swiftlint
-
   setup-fastlane:
     description: "Install Fastlane via Bundler"
     steps:
@@ -218,7 +211,6 @@ jobs:
       - attach_workspace:
           at: .
 
-      - install-swiftlint
       - setup-fastlane
 
       - run:
@@ -266,7 +258,6 @@ jobs:
       - attach_workspace:
           at: .
 
-      - install-swiftlint
       - setup-fastlane
 
       - run:
@@ -338,7 +329,6 @@ jobs:
       - attach_workspace:
           at: .
 
-      - install-swiftlint
       - setup-fastlane
 
       - run:

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -691,7 +691,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint\nelse\n    echo \"error: SwiftLint is required but not installed. Run 'brew install swiftlint' to install it.\"\n    exit 1\nfi\n";
+			shellScript = "if [ \"$CI\" = \"true\" ]\nthen\n    echo \"Skipping SwiftLint build phase in CI (handled by dedicated lint job)\"\n    exit 0\nfi\n\nif [[ \"$(uname -m)\" == arm64 ]]\nthen\n    export PATH=\"/opt/homebrew/bin:$PATH\"\nfi\n\nif command -v swiftlint >/dev/null 2>&1\nthen\n    swiftlint\nelse\n    echo \"error: SwiftLint is required but not installed. Run 'brew install swiftlint' to install it.\"\n    exit 1\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
## Summary
- The SwiftLint Xcode build phase fired on every CI job that builds the framework target (`build-framework`, `build-examples`, `unit-tests`, etc.), so a single lint violation cascaded into parallel failures alongside the dedicated `lint` job — making it hard to tell whether a job was failing for lint or for a real build/test issue ([example pipeline](https://app.circleci.com/pipelines/github/attentive-mobile/attentive-ios-sdk/457/workflows/80001d21-aab4-4f13-bb87-d68980d14417)).
- Gate the build phase on `$CI` so local Xcode builds still run SwiftLint inline, while CI relies solely on the dedicated `lint` job for the lint signal.
- Drop the now-unused `install-swiftlint` command from `build-framework`, `build-examples`, and `unit-tests`.

## Test plan
- [ ] `lint-validate-build-test` workflow passes on CI
- [ ] Verify that introducing a SwiftLint violation fails only the `lint` job, not the build/test jobs
- [ ] Verify SwiftLint still runs locally when building the framework target in Xcode

🤖 Generated with [Claude Code](https://claude.com/claude-code)