### PR TITLE
MSDK-354: Fix plus sign encoding in URL query parameters

### DIFF
--- a/Sources/URLProviders/ATTNEventURLProvider.swift
+++ b/Sources/URLProviders/ATTNEventURLProvider.swift
@@ -22,7 +22,7 @@ struct ATTNEventURLProvider: ATTNEventURLProviding {
         queryParams["m"] = userIdentity.buildMetadataJson()
         queryParams["t"] = ATTNEventTypes.userIdentifierCollected
 
-        urlComponents.queryItems = queryParams.map { .init(name: $0.key, value: $0.value) }
+        Self.setFormEncodedQuery(on: &urlComponents, params: queryParams)
         return urlComponents.url
     }
 
@@ -39,7 +39,7 @@ struct ATTNEventURLProvider: ATTNEventURLProviding {
             queryParams["pd"] = deeplink
         }
 
-        urlComponents.queryItems = queryParams.map { .init(name: $0.key, value: $0.value) }
+        Self.setFormEncodedQuery(on: &urlComponents, params: queryParams)
         return urlComponents.url
     }
 
@@ -56,7 +56,7 @@ struct ATTNEventURLProvider: ATTNEventURLProviding {
             queryParams["pd"] = deeplink
         }
 
-        urlComponents.queryItems = queryParams.map { .init(name: $0.key, value: $0.value) }
+        Self.setFormEncodedQuery(on: &urlComponents, params: queryParams)
         return urlComponents.url
     }
 
@@ -93,5 +93,22 @@ extension ATTNEventURLProvider {
         components.path = path
         components.port = port
         return components
+    }
+
+    private static let formEncodedAllowedCharacters: CharacterSet = {
+        var chars = CharacterSet.urlQueryAllowed
+        chars.remove("+")
+        chars.remove("&")
+        chars.remove("=")
+        return chars
+    }()
+
+    static func setFormEncodedQuery(on components: inout URLComponents, params: [String: String]) {
+        let queryString = params.map { key, value in
+            let encodedKey = key.addingPercentEncoding(withAllowedCharacters: formEncodedAllowedCharacters) ?? key
+            let encodedValue = value.addingPercentEncoding(withAllowedCharacters: formEncodedAllowedCharacters) ?? value
+            return "\(encodedKey)=\(encodedValue)"
+        }.joined(separator: "&")
+        components.percentEncodedQuery = queryString
     }
 }

--- a/Tests/TestCases/ATTNEventURLProviderV2Tests.swift
+++ b/Tests/TestCases/ATTNEventURLProviderV2Tests.swift
@@ -273,4 +273,59 @@ final class ATTNEventURLProviderV2Tests: XCTestCase {
         XCTAssertNotNil(metadata?["email"])
         XCTAssertNotNil(metadata?["phone"])
     }
+
+    // MARK: - Plus sign encoding tests
+
+    func testBuildUrl_emailWithPlusSign_encodedAsPct2B() {
+        let identity = ATTNUserIdentity(identifiers: [
+            ATTNIdentifierType.email: "user+tag@example.com"
+        ])
+        let eventRequest = ATTNEventRequest(metadata: [:], eventNameAbbreviation: "p")
+
+        let url = urlProvider.buildUrl(
+            for: eventRequest,
+            userIdentity: identity,
+            domain: "test"
+        )
+
+        XCTAssertNotNil(url)
+        let urlString = url!.absoluteString
+        XCTAssertTrue(urlString.contains("%2B"), "Plus sign in email must be percent-encoded as %2B")
+        XCTAssertFalse(urlString.contains("user+tag"), "Raw + must not appear in URL query string")
+    }
+
+    func testBuildUrl_emailWithPlusSign_decodesCorrectlyAsFormUrlencoded() {
+        let identity = ATTNUserIdentity(identifiers: [
+            ATTNIdentifierType.email: "nikhil.kumar+attentivetest1@onequince.com"
+        ])
+        let eventRequest = ATTNEventRequest(metadata: [:], eventNameAbbreviation: "p")
+
+        let url = urlProvider.buildUrl(
+            for: eventRequest,
+            userIdentity: identity,
+            domain: "quince"
+        )
+
+        XCTAssertNotNil(url)
+        let metadata = ATTNTestEventUtils.getMetadataFromUrl(url: url!)
+        XCTAssertEqual(metadata?["email"] as? String, "nikhil.kumar+attentivetest1@onequince.com")
+    }
+
+    func testBuildUrl_phoneWithPlusSign_encodedAsPct2B() {
+        let identity = ATTNUserIdentity(identifiers: [
+            ATTNIdentifierType.phone: "+14155551234"
+        ])
+        let eventRequest = ATTNEventRequest(metadata: [:], eventNameAbbreviation: "p")
+
+        let url = urlProvider.buildUrl(
+            for: eventRequest,
+            userIdentity: identity,
+            domain: "test"
+        )
+
+        XCTAssertNotNil(url)
+        let urlString = url!.absoluteString
+        XCTAssertFalse(urlString.contains("+1415"), "Raw + in phone must not appear in URL query string")
+        XCTAssertTrue(urlString.contains("%2B1415"), "Plus sign in phone must be percent-encoded as %2B")
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes identity resolution failure for emails/phones containing `+` (e.g. `user+tag@example.com`, `+14155551234`)
- Swift's `URLComponents.queryItems` uses RFC 3986 encoding where `+` is valid and NOT percent-encoded. The backend (Spring `@RequestParam`) decodes using `application/x-www-form-urlencoded` where `+` = space. This caused emails like `nikhil.kumar+attentivetest1@onequince.com` to arrive at the enricher-consumer as `nikhil.kumar attentivetest1@onequince.com`, breaking identity resolution.
- Replaces `queryItems` assignment with a custom `setFormEncodedQuery` method that percent-encodes `+` as `%2B`, `&` as `%26`, and `=` as `%3D` using `percentEncodedQuery`

## Test plan

- [x] Unit tests added for email with `+` sign encoding
- [x] Unit test using Quince's exact email (`nikhil.kumar+attentivetest1@onequince.com`) verifies round-trip correctness
- [x] Unit test for phone number with `+` prefix encoding
- [x] All existing URL provider tests pass (no regressions)
- [ ] Verify in staging with a `+` email that identity resolution succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)