### PR TITLE
Make Bonni example app dark-mode-aware

### DIFF
--- a/Bonni/AttentiveExample/AddressViewController.swift
+++ b/Bonni/AttentiveExample/AddressViewController.swift
@@ -15,7 +15,7 @@ class AddressViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Shipping & Billing"
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         setupTableView()
 
         countryPicker.dataSource = self

--- a/Bonni/AttentiveExample/CartTableViewCell.swift
+++ b/Bonni/AttentiveExample/CartTableViewCell.swift
@@ -31,36 +31,36 @@ class CartTableViewCell: UITableViewCell {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont(name: "DegularDisplay-Regular", size: 16)
-        label.textColor = .black
+        label.textColor = .label
         return label
     }()
-    
+
     /// Subtitle label for product type
     private let productTypeLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.systemFont(ofSize: 14)
-        label.textColor = .gray
+        label.textColor = .secondaryLabel
         label.text = "Daily Moisturizer"
         return label
     }()
-    
+
     /// Price label, aligned bottom-right
     private let productPriceLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont(name: "DegularDisplay-Regular", size: 16)
-        label.textColor = .gray
+        label.textColor = .secondaryLabel
         label.textAlignment = .right
         return label
     }()
-    
+
     /// Quantity controls
     private let minusButton: UIButton = {
         let btn = UIButton(type: .system)
         btn.setTitle("–", for: .normal)
-        btn.tintColor = .black
-        btn.backgroundColor = .lightGray
+        btn.tintColor = .label
+        btn.backgroundColor = .systemGray4
         btn.alpha = 0.5
         btn.layer.cornerRadius = 8
         btn.translatesAutoresizingMaskIntoConstraints = false
@@ -79,8 +79,8 @@ class CartTableViewCell: UITableViewCell {
     private let plusButton: UIButton = {
         let btn = UIButton(type: .system)
         btn.setTitle("+", for: .normal)
-        btn.tintColor = .black
-        btn.backgroundColor = .lightGray
+        btn.tintColor = .label
+        btn.backgroundColor = .systemGray4
         btn.alpha = 0.5
         btn.layer.cornerRadius = 8
         btn.translatesAutoresizingMaskIntoConstraints = false

--- a/Bonni/AttentiveExample/CartViewController.swift
+++ b/Bonni/AttentiveExample/CartViewController.swift
@@ -36,12 +36,11 @@ class CartViewController: UIViewController {
         super.viewDidLoad()
         
         title = "My Cart"
-        view.backgroundColor = .white
-        navigationController?.navigationBar.tintColor = .black
+        view.backgroundColor = .systemBackground
+        navigationController?.navigationBar.tintColor = .label
         setupSummaryView()
         setupTableView()
         setupCheckoutButton()
-        
     }
     
     private func setupTableView() {
@@ -51,11 +50,11 @@ class CartViewController: UIViewController {
         tableView.register(CartTableViewCell.self, forCellReuseIdentifier: "CartCell")
         tableView.rowHeight = 130
         tableView.separatorStyle = .singleLine
-        tableView.separatorColor = .black
+        tableView.separatorColor = .separator
         tableView.separatorInset = .init(top: 0, left: 8, bottom: 0, right: 0)
-        
+
         view.addSubview(tableView)
-        
+
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 8),
@@ -72,9 +71,9 @@ class CartViewController: UIViewController {
 
         let couponButton = UIButton(type: .system)
         couponButton.setTitle("Apply Coupon", for: .normal)
-        couponButton.tintColor = .black
+        couponButton.tintColor = .label
         couponButton.titleLabel?.font = UIFont(name: "DegularDisplay-Regular", size: 16)
-        couponButton.layer.borderColor = UIColor.black.cgColor
+        couponButton.layer.borderColor = UIColor.label.cgColor
         couponButton.layer.borderWidth = 1
         couponButton.translatesAutoresizingMaskIntoConstraints = false
 
@@ -133,7 +132,7 @@ class CartViewController: UIViewController {
         totalLabel.font    = mediumFont
         totalValueLabel.font = mediumFont;     totalValueLabel.textAlignment = .right
 
-        separator.backgroundColor = .black
+        separator.backgroundColor = .separator
 
         // add summaryView
         view.addSubview(summaryView)
@@ -176,11 +175,11 @@ class CartViewController: UIViewController {
     private func setupCheckoutButton() {
         let checkoutButton = UIButton(type: .system)
         checkoutButton.setTitle("CHECK OUT", for: .normal)
-        checkoutButton.tintColor = .black
+        checkoutButton.tintColor = .systemBackground
 
         checkoutButton.titleLabel?.font = UIFont(name: "DegularDisplay-Regular", size: 16)
-        checkoutButton.backgroundColor = .black
-        checkoutButton.setTitleColor(.white, for: .normal)
+        checkoutButton.backgroundColor = .label
+        checkoutButton.setTitleColor(.systemBackground, for: .normal)
         //checkoutButton.layer.cornerRadius = 10
         checkoutButton.addTarget(self, action: #selector(checkoutTapped), for: .touchUpInside)
         

--- a/Bonni/AttentiveExample/ContinueToBillingCell.swift
+++ b/Bonni/AttentiveExample/ContinueToBillingCell.swift
@@ -19,8 +19,8 @@ class ContinueToBillingCell: UITableViewCell {
         let button = UIButton(type: .system)
         button.setTitle("Continue", for: .normal)
         button.titleLabel?.font = UIFont(name: "DegularDisplay-Regular", size: 16)
-        button.backgroundColor = .black
-        button.setTitleColor(.white, for: .normal)
+        button.backgroundColor = .label
+        button.setTitleColor(.systemBackground, for: .normal)
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()

--- a/Bonni/AttentiveExample/CreateAccountViewController.swift
+++ b/Bonni/AttentiveExample/CreateAccountViewController.swift
@@ -69,7 +69,7 @@ class CreateAccountViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         title = "Create an account"
         setupUI()
     }

--- a/Bonni/AttentiveExample/DebugConsoleViewController.swift
+++ b/Bonni/AttentiveExample/DebugConsoleViewController.swift
@@ -20,7 +20,7 @@ class DebugConsoleViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
 
         view.alpha = 0.8
 

--- a/Bonni/AttentiveExample/Info.plist
+++ b/Bonni/AttentiveExample/Info.plist
@@ -23,6 +23,10 @@
 			<string>com.attentive.bonni</string>
 		</dict>
 	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleDarkContent</string>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Bonni/AttentiveExample/LoginViewController.swift
+++ b/Bonni/AttentiveExample/LoginViewController.swift
@@ -119,6 +119,9 @@ class LoginViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        // The LoginBackground image is a light brand asset; keep this screen
+        // in light mode so the buttons and text remain readable on it.
+        overrideUserInterfaceStyle = .light
         view.backgroundColor = .white
         setupUI()
     }

--- a/Bonni/AttentiveExample/OrderConfirmationViewController.swift
+++ b/Bonni/AttentiveExample/OrderConfirmationViewController.swift
@@ -25,7 +25,7 @@ class OrderConfirmationViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         title = "Order Confirmed"
         setupUI()
         setupCloseButton()

--- a/Bonni/AttentiveExample/PlaceOrderViewController.swift
+++ b/Bonni/AttentiveExample/PlaceOrderViewController.swift
@@ -86,7 +86,7 @@ class PlaceOrderViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         title = "Place Order"
         setupUI()
     }

--- a/Bonni/AttentiveExample/ProductCollectionViewCell.swift
+++ b/Bonni/AttentiveExample/ProductCollectionViewCell.swift
@@ -58,7 +58,7 @@ class ProductCollectionViewCell: UICollectionViewCell {
     private let productNameLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont(name: "DegularDisplay-Regular", size: 16)
-        label.textColor = .black
+        label.textColor = .label
         label.textAlignment = .left
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -68,7 +68,7 @@ class ProductCollectionViewCell: UICollectionViewCell {
     private let productPriceLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 14)
-        label.textColor = .gray
+        label.textColor = .secondaryLabel
         label.textAlignment = .left
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -80,8 +80,8 @@ class ProductCollectionViewCell: UICollectionViewCell {
         let cartImage = UIImage(named: "Shopping cart")?
             .withRenderingMode(.alwaysTemplate)
         button.setImage(cartImage, for: .normal)
-        button.tintColor = .black
-        button.backgroundColor = .white
+        button.tintColor = .label
+        button.backgroundColor = .systemBackground
         button.layer.cornerRadius = 15  // half of 30 to stay perfectly round
         button.layer.masksToBounds = true
         button.translatesAutoresizingMaskIntoConstraints = false

--- a/Bonni/AttentiveExample/ProductDetailViewController.swift
+++ b/Bonni/AttentiveExample/ProductDetailViewController.swift
@@ -74,7 +74,7 @@ class ProductDetailViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         setupUI()
         configureProduct()
     }

--- a/Bonni/AttentiveExample/ProductViewController.swift
+++ b/Bonni/AttentiveExample/ProductViewController.swift
@@ -34,7 +34,7 @@ class ProductViewController: UIViewController, UICollectionViewDataSource, UICol
     
     private lazy var allProductsLabel: UILabel = {
         let label = UILabel()
-        label.textColor = UIColor(red: 0.102, green: 0.118, blue: 0.133, alpha: 1)
+        label.textColor = .label
         label.font = UIFont(name: "Degular-Medium", size: kLabelFontSize)
         let attributedText = NSMutableAttributedString(string: "All Products", attributes: [
             .kern: kLabelKerning
@@ -75,7 +75,7 @@ class ProductViewController: UIViewController, UICollectionViewDataSource, UICol
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
 
         // Store the viewModel in AppDelegate for deep link access
         if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
@@ -101,19 +101,19 @@ class ProductViewController: UIViewController, UICollectionViewDataSource, UICol
             navigationController?.navigationBar.barTintColor = kNavColor
         }
         navigationController?.navigationBar.isTranslucent = false
-        
+
         // Left bar button: settings using "profile" image.
         let settingsImage = UIImage(named: "profile")
         let settingsButtonItem = UIBarButtonItem(image: settingsImage, style: .plain, target: self, action: #selector(settingsButtonTapped))
         settingsButtonItem.tintColor = .black
         navigationItem.leftBarButtonItem = settingsButtonItem
-        
+
         // Right bar button: cart using "Shopping cart" image.
         let cartImage = UIImage(named: "Shopping cart")
         let cartButtonItem = UIBarButtonItem(image: cartImage, style: .plain, target: self, action: #selector(cartButtonTapped))
         cartButtonItem.tintColor = .black
         navigationItem.rightBarButtonItem = cartButtonItem
-        
+
         // Center the logo in the navigation bar.
         let logoImageView = UIImageView(image: UIImage(named: "Union.svg"))
         logoImageView.contentMode = .scaleAspectFit

--- a/Bonni/AttentiveExample/SettingsViewController.swift
+++ b/Bonni/AttentiveExample/SettingsViewController.swift
@@ -62,7 +62,7 @@ class SettingsViewController: UIViewController {
     private let sdkVersionLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont(name: "DegularDisplay-Regular", size: 16)
-        label.textColor = .darkGray
+        label.textColor = .secondaryLabel
         label.numberOfLines = 0
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -204,7 +204,7 @@ class SettingsViewController: UIViewController {
         let savedDeviceToken = UserDefaults.standard.string(forKey: "deviceTokenForDisplay")
         devicetokenLabel.text = "Device Token: \(savedDeviceToken ?? "Not saved")"
         devicetokenLabel.font = UIFont(name: "DegularDisplay-Regular", size: 16)
-        devicetokenLabel.textColor = .darkGray
+        devicetokenLabel.textColor = .secondaryLabel
         devicetokenLabel.numberOfLines = 0
         return devicetokenLabel
     }()
@@ -274,9 +274,9 @@ class SettingsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Settings"
-        view.backgroundColor = .white
-        scrollView.backgroundColor = .white
-        contentView.backgroundColor = .white
+        view.backgroundColor = .systemBackground
+        scrollView.backgroundColor = .systemBackground
+        contentView.backgroundColor = .systemBackground
         if let navBar = navigationController?.navigationBar {
             navBar.barTintColor = UIColor(red: 1, green: 0.773, blue: 0.725, alpha: 1)
             navBar.isTranslucent = false
@@ -332,7 +332,7 @@ class SettingsViewController: UIViewController {
         stackView.addArrangedSubview(logOutButton)
 
         let divider = UIView()
-        divider.backgroundColor = .lightGray
+        divider.backgroundColor = .separator
         divider.translatesAutoresizingMaskIntoConstraints = false
         divider.heightAnchor.constraint(equalToConstant: 1).isActive = true
         stackView.addArrangedSubview(divider)
@@ -352,7 +352,7 @@ class SettingsViewController: UIViewController {
         stackView.addArrangedSubview(v2Row)
 
         let divider2 = UIView()
-        divider2.backgroundColor = .lightGray
+        divider2.backgroundColor = .separator
         divider2.translatesAutoresizingMaskIntoConstraints = false
         divider2.heightAnchor.constraint(equalToConstant: 1).isActive = true
         stackView.addArrangedSubview(divider2)
@@ -386,7 +386,7 @@ class SettingsViewController: UIViewController {
             ]
             allButtons.forEach {
                 $0.titleLabel?.font = degular
-                $0.titleLabel?.tintColor = .black
+                $0.titleLabel?.tintColor = .label
             }
             currentEmailLabel.font = degular
             currentPhoneLabel.font = degular
@@ -413,7 +413,7 @@ class SettingsViewController: UIViewController {
             [addEmailButton, optInEmailButton, optOutEmailButton,
              addPhoneButton, optInPhoneButton, optOutPhoneButton].forEach {
                 $0.titleLabel?.font = degular
-                $0.titleLabel?.tintColor = .black
+                $0.titleLabel?.tintColor = .label
             }
         }
     }

--- a/Bonni/AttentiveExample/TextfieldTableViewCell.swift
+++ b/Bonni/AttentiveExample/TextfieldTableViewCell.swift
@@ -18,7 +18,7 @@ class TextfieldTableViewCell: UITableViewCell {
         textfield.placeholder = ""
         // Match “Apply Coupon” styling
         textfield.font = UIFont(name: "DegularDisplay-Regular", size: 16)
-        textfield.layer.borderColor = UIColor.black.cgColor
+        textfield.layer.borderColor = UIColor.label.cgColor
         textfield.layer.borderWidth = 1
         textfield.layer.cornerRadius = 8
         // fixed height


### PR DESCRIPTION
## Summary
- Replace hardcoded `.white` / `.black` / `.gray` / `.lightGray` / `.darkGray` with their dynamic system equivalents (`.systemBackground`, `.label`, `.secondaryLabel`, `.separator`, `.systemGray4`) across the Bonni example app's view controllers and cells
- Pin `LoginViewController` to light mode via `overrideUserInterfaceStyle` since it sits on a fixed-light brand background image
- Force the status bar to dark content app-wide via `Info.plist` so it stays readable on the peach navigation bar regardless of system appearance

## Test plan
- [x] Launch Bonni in light mode — every screen renders correctly
- [x] Launch Bonni in dark mode — every screen renders correctly (login stays light by design)
- [x] Status bar text/icons remain dark on the peach nav bar in both modes

| Light | Dark |
|--------|--------|
| <img width="1206" height="2622" alt="light_product" src="https://github.com/user-attachments/assets/95f7d7d1-3ddf-40f8-bdc9-240870e5286d" /> | <img width="1206" height="2622" alt="dark_product" src="https://github.com/user-attachments/assets/13007965-e93c-4782-9c2e-41fbd1fdf705" /> |
| <img width="1206" height="2622" alt="light_product_detail" src="https://github.com/user-attachments/assets/2c6912ac-fc97-4883-b41c-303e5d652a9c" /> | <img width="1206" height="2622" alt="dark_product_detail" src="https://github.com/user-attachments/assets/b5792e00-d610-407a-889f-1de9db2936c8" /> |
| <img width="1206" height="2622" alt="light_cart" src="https://github.com/user-attachments/assets/b0effb62-e6ec-4ca9-9a96-b3fdc3e4c7bb" /> | <img width="1206" height="2622" alt="dark_cart" src="https://github.com/user-attachments/assets/b007c3ef-7787-4906-b09b-2b0fa2b6d927" /> |
| <img width="1206" height="2622" alt="light_setting" src="https://github.com/user-attachments/assets/060350fa-da75-4656-8c10-1e7ee37d284d" /> | <img width="1206" height="2622" alt="dark_setting" src="https://github.com/user-attachments/assets/70a817d4-ee0a-4b9c-bd34-6763913856f0" /> | 

🤖 Generated with [Claude Code](https://claude.com/claude-code)