### PR TITLE
MSDK-377: wire real endpoint for inbox unread count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ fastlane/reports
 
 # Claude
 .claude/
+CLAUDE.local.md
 # Exceptions for shared config (if applicable)
 !.claude/CLAUDE.md
 !.claude/settings.json

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -376,6 +376,78 @@ final class ATTNAPI: ATTNAPIProtocol {
         }
         task.resume()
     }
+
+    // MARK: - Inbox
+
+    /// Fetches the unread inbox message count for the current user.
+    ///
+    /// Per RFC: this endpoint is identifier-based and unauthenticated. The server scopes the
+    /// response by resolving identity from the supplied push token (and other identifiers).
+    func fetchInboxUnreadCount(
+        pushToken: String,
+        email: String?,
+        phone: String?,
+        userIdentity: ATTNUserIdentity
+    ) async throws -> Int {
+        Loggers.network.debug("Fetching inbox unread count - Visitor ID: \(userIdentity.visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public)")
+
+        var payload: [String: Any] = [
+            "visitor_id": userIdentity.visitorId
+        ]
+        if !pushToken.isEmpty { payload["push_token"] = pushToken }
+        if let email = email?.trimmingCharacters(in: .whitespacesAndNewlines), !email.isEmpty {
+            payload["email"] = email
+        }
+        if let phone = phone?.trimmingCharacters(in: .whitespacesAndNewlines), !phone.isEmpty {
+            payload["phone"] = phone
+        }
+
+        guard let url = URL(string: "https://mobile.attentivemobile.com/inbox/messages/unread/count") else {
+            Loggers.network.error("Invalid inbox unread count URL")
+            throw ATTNError.badURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 15
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: payload, options: [])
+
+        Loggers.network.debug("POST /inbox/messages/unread/count payload: \(payload, privacy: .public)")
+
+        let (data, response): (Data, URLResponse) = try await withCheckedThrowingContinuation { continuation in
+            let task = urlSession.dataTask(with: request) { data, response, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let data = data, let response = response else {
+                    continuation.resume(throwing: ATTNError.inboxResponseDecodeFailed)
+                    return
+                }
+                continuation.resume(returning: (data, response))
+            }
+            task.resume()
+        }
+
+        if let http = response as? HTTPURLResponse {
+            Loggers.network.debug("Inbox unread count status code: \(http.statusCode, privacy: .public)")
+            guard (200..<300).contains(http.statusCode) else {
+                Loggers.network.error("Inbox unread count API returned status \(http.statusCode, privacy: .public)")
+                throw ATTNError.inboxRequestFailed(statusCode: http.statusCode)
+            }
+        }
+
+        do {
+            let decoded = try JSONDecoder().decode(InboxUnreadCountResponse.self, from: data)
+            Loggers.network.debug("Inbox unread count: \(decoded.unreadCount, privacy: .public)")
+            return decoded.unreadCount
+        } catch {
+            Loggers.network.error("Failed to decode inbox unread count response: \(error.localizedDescription, privacy: .public)")
+            throw ATTNError.inboxResponseDecodeFailed
+        }
+    }
 }
 
 fileprivate extension ATTNAPI {

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -392,7 +392,6 @@ final class ATTNAPI: ATTNAPIProtocol {
         Loggers.network.debug("Fetching inbox unread count - Visitor ID: \(visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public)")
 
         var payload: [String: Any] = [
-            "c": domain,
             "visitor_id": visitorId
         ]
         if !pushToken.isEmpty { payload["push_token"] = pushToken }

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -390,6 +390,7 @@ final class ATTNAPI: ATTNAPIProtocol {
         userIdentity: ATTNUserIdentity
     ) async throws -> Int {
         Loggers.network.debug("Fetching inbox unread count - Visitor ID: \(userIdentity.visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public)")
+        print("[MSDK-377] fetchInboxUnreadCount called — visitorId=\(userIdentity.visitorId), pushToken=\(pushToken.isEmpty ? "<empty>" : pushToken), email=\(email ?? "nil"), phone=\(phone ?? "nil")")
 
         var payload: [String: Any] = [
             "visitor_id": userIdentity.visitorId
@@ -404,6 +405,7 @@ final class ATTNAPI: ATTNAPIProtocol {
 
         guard let url = URL(string: "https://mobile.attentivemobile.com/inbox/messages/unread/count") else {
             Loggers.network.error("Invalid inbox unread count URL")
+            print("[MSDK-377] ❌ Invalid URL")
             throw ATTNError.badURL
         }
 
@@ -415,6 +417,7 @@ final class ATTNAPI: ATTNAPIProtocol {
         request.httpBody = try? JSONSerialization.data(withJSONObject: payload, options: [])
 
         Loggers.network.debug("POST /inbox/messages/unread/count payload: \(payload, privacy: .public)")
+        print("[MSDK-377] ➡️ POST \(url.absoluteString) — payload=\(payload)")
 
         let (data, response): (Data, URLResponse) = try await withCheckedThrowingContinuation { continuation in
             let task = urlSession.dataTask(with: request) { data, response, error in
@@ -431,20 +434,26 @@ final class ATTNAPI: ATTNAPIProtocol {
             task.resume()
         }
 
+        let bodyStr = String(data: data, encoding: .utf8) ?? "<non-utf8>"
         if let http = response as? HTTPURLResponse {
             Loggers.network.debug("Inbox unread count status code: \(http.statusCode, privacy: .public)")
+            print("[MSDK-377] ⬅️ status=\(http.statusCode) body=\(bodyStr)")
             guard (200..<300).contains(http.statusCode) else {
                 Loggers.network.error("Inbox unread count API returned status \(http.statusCode, privacy: .public)")
                 throw ATTNError.inboxRequestFailed(statusCode: http.statusCode)
             }
+        } else {
+            print("[MSDK-377] ⬅️ non-HTTP response body=\(bodyStr)")
         }
 
         do {
             let decoded = try JSONDecoder().decode(InboxUnreadCountResponse.self, from: data)
             Loggers.network.debug("Inbox unread count: \(decoded.unreadCount, privacy: .public)")
+            print("[MSDK-377] ✅ decoded unread_count=\(decoded.unreadCount)")
             return decoded.unreadCount
         } catch {
             Loggers.network.error("Failed to decode inbox unread count response: \(error.localizedDescription, privacy: .public)")
+            print("[MSDK-377] ❌ decode failed: \(error.localizedDescription) — body was: \(bodyStr)")
             throw ATTNError.inboxResponseDecodeFailed
         }
     }

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -394,7 +394,9 @@ final class ATTNAPI: ATTNAPIProtocol {
         var payload: [String: Any] = [
             "visitor_id": visitorId
         ]
-        if !pushToken.isEmpty { payload["push_token"] = pushToken }
+        // Prefix with the transport scheme so the server can route the token to APNs.
+        // Matches the RFC's `fcm:...` example on Android; iOS uses `apns:`.
+        if !pushToken.isEmpty { payload["push_token"] = "apns:\(pushToken)" }
         if let email = email?.trimmingCharacters(in: .whitespacesAndNewlines), !email.isEmpty {
             payload["email"] = email
         }

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -391,7 +391,10 @@ final class ATTNAPI: ATTNAPIProtocol {
     ) async throws -> Int {
         Loggers.network.debug("Fetching inbox unread count - Visitor ID: \(visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public)")
 
-        var payload: [String: Any] = ["visitor_id": visitorId]
+        var payload: [String: Any] = [
+            "c": domain,
+            "visitor_id": visitorId
+        ]
         if !pushToken.isEmpty { payload["push_token"] = pushToken }
         if let email = email?.trimmingCharacters(in: .whitespacesAndNewlines), !email.isEmpty {
             payload["email"] = email

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -387,14 +387,11 @@ final class ATTNAPI: ATTNAPIProtocol {
         pushToken: String,
         email: String?,
         phone: String?,
-        userIdentity: ATTNUserIdentity
+        visitorId: String
     ) async throws -> Int {
-        Loggers.network.debug("Fetching inbox unread count - Visitor ID: \(userIdentity.visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public)")
-        print("[MSDK-377] fetchInboxUnreadCount called — visitorId=\(userIdentity.visitorId), pushToken=\(pushToken.isEmpty ? "<empty>" : pushToken), email=\(email ?? "nil"), phone=\(phone ?? "nil")")
+        Loggers.network.debug("Fetching inbox unread count - Visitor ID: \(visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public)")
 
-        var payload: [String: Any] = [
-            "visitor_id": userIdentity.visitorId
-        ]
+        var payload: [String: Any] = ["visitor_id": visitorId]
         if !pushToken.isEmpty { payload["push_token"] = pushToken }
         if let email = email?.trimmingCharacters(in: .whitespacesAndNewlines), !email.isEmpty {
             payload["email"] = email
@@ -405,7 +402,6 @@ final class ATTNAPI: ATTNAPIProtocol {
 
         guard let url = URL(string: "https://mobile.attentivemobile.com/inbox/messages/unread/count") else {
             Loggers.network.error("Invalid inbox unread count URL")
-            print("[MSDK-377] ❌ Invalid URL")
             throw ATTNError.badURL
         }
 
@@ -414,47 +410,51 @@ final class ATTNAPI: ATTNAPIProtocol {
         request.timeoutInterval = 15
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: payload, options: [])
+        // Throw, don't `try?`: silently dropping the body would send a request the server
+        // can't service and surface as an opaque 4xx — much harder to debug than a clear error.
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 
-        Loggers.network.debug("POST /inbox/messages/unread/count payload: \(payload, privacy: .public)")
-        print("[MSDK-377] ➡️ POST \(url.absoluteString) — payload=\(payload)")
+        Loggers.network.debug("POST /inbox/messages/unread/count")
 
-        let (data, response): (Data, URLResponse) = try await withCheckedThrowingContinuation { continuation in
-            let task = urlSession.dataTask(with: request) { data, response, error in
-                if let error = error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-                guard let data = data, let response = response else {
-                    continuation.resume(throwing: ATTNError.inboxResponseDecodeFailed)
-                    return
-                }
-                continuation.resume(returning: (data, response))
-            }
-            task.resume()
+        let (data, response) = try await dataTask(with: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            Loggers.network.error("Inbox unread count returned a non-HTTP response")
+            throw ATTNError.inboxResponseDecodeFailed
         }
-
-        let bodyStr = String(data: data, encoding: .utf8) ?? "<non-utf8>"
-        if let http = response as? HTTPURLResponse {
-            Loggers.network.debug("Inbox unread count status code: \(http.statusCode, privacy: .public)")
-            print("[MSDK-377] ⬅️ status=\(http.statusCode) body=\(bodyStr)")
-            guard (200..<300).contains(http.statusCode) else {
-                Loggers.network.error("Inbox unread count API returned status \(http.statusCode, privacy: .public)")
-                throw ATTNError.inboxRequestFailed(statusCode: http.statusCode)
-            }
-        } else {
-            print("[MSDK-377] ⬅️ non-HTTP response body=\(bodyStr)")
+        Loggers.network.debug("Inbox unread count status code: \(http.statusCode, privacy: .public)")
+        guard (200..<300).contains(http.statusCode) else {
+            Loggers.network.error("Inbox unread count API returned status \(http.statusCode, privacy: .public)")
+            throw ATTNError.inboxRequestFailed(statusCode: http.statusCode)
         }
 
         do {
             let decoded = try JSONDecoder().decode(InboxUnreadCountResponse.self, from: data)
             Loggers.network.debug("Inbox unread count: \(decoded.unreadCount, privacy: .public)")
-            print("[MSDK-377] ✅ decoded unread_count=\(decoded.unreadCount)")
             return decoded.unreadCount
         } catch {
             Loggers.network.error("Failed to decode inbox unread count response: \(error.localizedDescription, privacy: .public)")
-            print("[MSDK-377] ❌ decode failed: \(error.localizedDescription) — body was: \(bodyStr)")
             throw ATTNError.inboxResponseDecodeFailed
+        }
+    }
+
+    /// async/await bridge over `URLSession.dataTask(with:completionHandler:)`. Used instead of
+    /// `URLSession.data(for:)` because the latter cannot be intercepted by `URLSession`
+    /// subclasses (it's defined in an extension and is non-`@objc`), which `NSURLSessionMock`
+    /// relies on for testing. Per URLSession's documented contract, when `error` is nil both
+    /// `data` and `response` are non-nil — the guard below is belt-and-suspenders only.
+    private func dataTask(with request: URLRequest) async throws -> (Data, URLResponse) {
+        try await withCheckedThrowingContinuation { continuation in
+            let task = urlSession.dataTask(with: request) { data, response, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                } else if let data = data, let response = response {
+                    continuation.resume(returning: (data, response))
+                } else {
+                    continuation.resume(throwing: URLError(.badServerResponse))
+                }
+            }
+            task.resume()
         }
     }
 }

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -392,6 +392,7 @@ final class ATTNAPI: ATTNAPIProtocol {
         Loggers.network.debug("Fetching inbox unread count - Visitor ID: \(visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public)")
 
         var payload: [String: Any] = [
+            "c": domain,
             "visitor_id": visitorId
         ]
         // Prefix with the transport scheme so the server can route the token to APNs.
@@ -414,8 +415,6 @@ final class ATTNAPI: ATTNAPIProtocol {
         request.timeoutInterval = 15
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
-        // Throw, don't `try?`: silently dropping the body would send a request the server
-        // can't service and surface as an opaque 4xx — much harder to debug than a clear error.
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 
         Loggers.network.debug("POST /inbox/messages/unread/count")
@@ -442,11 +441,8 @@ final class ATTNAPI: ATTNAPIProtocol {
         }
     }
 
-    /// async/await bridge over `URLSession.dataTask(with:completionHandler:)`. Used instead of
-    /// `URLSession.data(for:)` because the latter cannot be intercepted by `URLSession`
-    /// subclasses (it's defined in an extension and is non-`@objc`), which `NSURLSessionMock`
-    /// relies on for testing. Per URLSession's documented contract, when `error` is nil both
-    /// `data` and `response` are non-nil — the guard below is belt-and-suspenders only.
+    /// async bridge over `URLSession.dataTask(with:completionHandler:)` — `URLSession.data(for:)`
+    /// is an extension method and can't be intercepted by `NSURLSessionMock`.
     private func dataTask(with request: URLRequest) async throws -> (Data, URLResponse) {
         try await withCheckedThrowingContinuation { continuation in
             let task = urlSession.dataTask(with: request) { data, response, error in

--- a/Sources/API/ATTNAPIProtocol.swift
+++ b/Sources/API/ATTNAPIProtocol.swift
@@ -74,4 +74,12 @@ protocol ATTNAPIProtocol {
         operationContext: String,
         callback: ATTNAPICallback?
     )
+
+    // MARK: - Inbox
+    func fetchInboxUnreadCount(
+        pushToken: String,
+        email: String?,
+        phone: String?,
+        userIdentity: ATTNUserIdentity
+    ) async throws -> Int
 }

--- a/Sources/API/ATTNAPIProtocol.swift
+++ b/Sources/API/ATTNAPIProtocol.swift
@@ -80,6 +80,6 @@ protocol ATTNAPIProtocol {
         pushToken: String,
         email: String?,
         phone: String?,
-        userIdentity: ATTNUserIdentity
+        visitorId: String
     ) async throws -> Int
 }

--- a/Sources/API/ATTNError.swift
+++ b/Sources/API/ATTNError.swift
@@ -14,6 +14,8 @@ public enum ATTNError: Error {
     case geoDomainUnavailable
     case badURL
     case invalidDomain
+    case inboxRequestFailed(statusCode: Int)
+    case inboxResponseDecodeFailed
 }
 
 extension ATTNError: LocalizedError {
@@ -29,6 +31,10 @@ extension ATTNError: LocalizedError {
             return "Invalid URL"
         case .invalidDomain:
             return "The provided domain is not recognized. Please verify that the domain matches your Attentive settings."
+        case .inboxRequestFailed(let statusCode):
+            return "Inbox request failed with status code \(statusCode)"
+        case .inboxResponseDecodeFailed:
+            return "Failed to decode inbox response"
         }
     }
 }

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -13,9 +13,17 @@ public enum InboxState: Sendable {
     case error(Error)
 }
 
+/// Identifiers needed to call the inbox endpoints.
+struct InboxIdentitySnapshot: Sendable {
+    let visitorId: String
+    let pushToken: String
+    let email: String?
+    let phone: String?
+}
+
 /// Closure that supplies the identifiers needed to call the inbox endpoints.
 /// Resolved at call-time so the manager always uses the latest values from `ATTNSDK`.
-typealias InboxIdentityProvider = @Sendable () -> (userIdentity: ATTNUserIdentity, pushToken: String, email: String?, phone: String?)
+typealias InboxIdentityProvider = @Sendable () -> InboxIdentitySnapshot
 
 actor InboxManager {
     private var messagesByID: [Message.ID: Message] = [:]
@@ -25,11 +33,16 @@ actor InboxManager {
 
     /// Server-authoritative unread count. Updated only by `refreshUnreadCount()` and (future)
     /// mark-read/mark-unread/delete API responses — local `markRead`/`markUnread` mutations
-    /// do not change this value.
+    /// do not change this value. Defaults to 0 until the first successful refresh, so callers
+    /// cannot distinguish "no unread" from "not yet fetched".
     private(set) var unreadCount: Int = 0
 
-    private let api: ATTNAPIProtocol?
-    private let identityProvider: InboxIdentityProvider?
+    private let api: ATTNAPIProtocol
+    private let identityProvider: InboxIdentityProvider
+
+    /// Monotonic counter used to discard responses from refresh calls that have been
+    /// superseded by a newer in-flight call.
+    private var refreshGeneration: UInt = 0
 
     var allMessages: [Message] {
         if let cached = cachedSortedMessages {
@@ -60,13 +73,13 @@ actor InboxManager {
         }
     }
 
-    init(api: ATTNAPIProtocol? = nil, identityProvider: InboxIdentityProvider? = nil) {
+    init(api: ATTNAPIProtocol, identityProvider: @escaping InboxIdentityProvider) {
         self.api = api
         self.identityProvider = identityProvider
+        // `currentState` is already `.loading`; kick off the mock-message load and the
+        // unread-count fetch concurrently. Both run on this actor so they're serialized
+        // at write boundaries — the parallelism is for the awaits, not the state mutations.
         Task {
-            await send(.loading)
-            // Run mock-message load and unread-count fetch concurrently — they touch
-            // independent state and the network call should not wait on the local mock.
             async let messages: Void = updateMessages(Self.getMockInbox().messages)
             async let count: Void = refreshUnreadCount()
             _ = await (messages, count)
@@ -75,29 +88,35 @@ actor InboxManager {
 
     /// Fetches the latest unread count from the server and stores it as the
     /// authoritative value. Errors are logged; the previously stored count is preserved.
+    /// If multiple refreshes are in flight, only the most recently issued one is honored.
     func refreshUnreadCount() async {
-        print("[MSDK-377] InboxManager.refreshUnreadCount() entered")
-        guard let api = api, let identityProvider = identityProvider else {
-            Loggers.network.debug("Skipping refreshUnreadCount — no API or identity provider configured")
-            print("[MSDK-377] ⚠️ skipped: api=\(api == nil ? "nil" : "set") identityProvider=\(identityProvider == nil ? "nil" : "set")")
+        let identity = identityProvider()
+        // Without a visitor ID the server can't scope the request — skip rather than send
+        // an unscoped call that would 4xx and pollute logs.
+        guard !identity.visitorId.isEmpty else {
+            Loggers.network.debug("Skipping inbox unread count refresh: empty visitor ID")
             return
         }
-
-        let (userIdentity, pushToken, email, phone) = identityProvider()
+        refreshGeneration &+= 1
+        let generation = refreshGeneration
         do {
-            unreadCount = try await api.fetchInboxUnreadCount(
-                pushToken: pushToken,
-                email: email,
-                phone: phone,
-                userIdentity: userIdentity
+            let count = try await api.fetchInboxUnreadCount(
+                pushToken: identity.pushToken,
+                email: identity.email,
+                phone: identity.phone,
+                visitorId: identity.visitorId
             )
-            print("[MSDK-377] InboxManager.unreadCount updated to \(unreadCount)")
-            // Re-emit current state so observers re-read the updated `unreadCount`.
-            // The state value itself is unchanged; this is a nudge for badge UIs.
-            send(currentState)
+            // Drop superseded responses so a slow earlier call cannot overwrite a fresher one.
+            guard generation == refreshGeneration else { return }
+            unreadCount = count
+            // Nudge observers to re-read `unreadCount` once we already have messages.
+            // Skip the nudge while still loading or in error — re-emitting `.loading`
+            // would clobber the loaded list once it arrives.
+            if case .loaded = currentState {
+                send(currentState)
+            }
         } catch {
             Loggers.network.error("Failed to refresh inbox unread count: \(error.localizedDescription, privacy: .public)")
-            print("[MSDK-377] ❌ refreshUnreadCount error: \(error.localizedDescription)")
         }
     }
 

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -137,6 +137,17 @@ actor InboxManager {
     func refresh() {
         updateMessages(Self.getMockInbox().messages)
     }
+
+    /// Resets the cached unread count to 0 and bumps the refresh generation so any in-flight
+    /// fetch from the previous identity is discarded when it returns. Called on identity changes
+    /// (`clearUser`, `updateUser`) so a logged-out account's badge is not surfaced to the next user.
+    func resetUnreadCount() {
+        refreshGeneration &+= 1
+        unreadCount = 0
+        if case .loaded = currentState {
+            send(currentState)
+        }
+    }
 }
 
 // MARK: - Private methods

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -76,13 +76,9 @@ actor InboxManager {
     init(api: ATTNAPIProtocol, identityProvider: @escaping InboxIdentityProvider) {
         self.api = api
         self.identityProvider = identityProvider
-        // `currentState` is already `.loading`; kick off the mock-message load and the
-        // unread-count fetch concurrently. Both run on this actor so they're serialized
-        // at write boundaries — the parallelism is for the awaits, not the state mutations.
         Task {
-            async let messages: Void = updateMessages(Self.getMockInbox().messages)
-            async let count: Void = refreshUnreadCount()
-            _ = await (messages, count)
+            await updateMessages(Self.getMockInbox().messages)
+            await refreshUnreadCount()
         }
     }
 
@@ -138,8 +134,8 @@ actor InboxManager {
         send(.loaded(allMessages))
     }
 
-    func refresh() async {
-        await updateMessages(Self.getMockInbox().messages)
+    func refresh() {
+        updateMessages(Self.getMockInbox().messages)
     }
 }
 
@@ -183,9 +179,7 @@ extension InboxManager {
 }
 
 fileprivate extension InboxManager {
-    private static func getMockInbox() async -> InboxResponse {
-        #warning("Artificial delay to simulate delayed network response, should be removed in production.")
-        try? await Task.sleep(nanoseconds: 2000000000)
+    private static func getMockInbox() -> InboxResponse {
         let messages: [Message] = [
             Message(
                 id: "1",

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -31,26 +31,22 @@ actor InboxManager {
     private var currentState: InboxState = .loading
     private var continuations: [UUID: AsyncStream<InboxState>.Continuation] = [:]
 
-    /// Server-authoritative unread count. Updated only by `refreshUnreadCount()` and (future)
-    /// mark-read/mark-unread/delete API responses — local `markRead`/`markUnread` mutations
-    /// do not change this value. Prefer reading via the async `unreadCount` accessor below,
-    /// which awaits the init-time fetch on first read so callers don't see a stale 0.
+    /// Server-authoritative unread count. Only `refreshUnreadCount()` writes it; local
+    /// `markRead` / `markUnread` do not. Reads should go through the `unreadCount` accessor,
+    /// which awaits the init-time refresh so the first read never returns a stale 0.
     private var storedUnreadCount: Int = 0
 
     private let api: ATTNAPIProtocol
     private let identityProvider: InboxIdentityProvider
 
-    /// Init-time refresh task. `unreadCount` / `allMessages` await it once so passive-badge
-    /// callers see the server-authoritative value on their first read rather than the
-    /// pre-fetch default of 0.
+    /// Drained exactly once by `awaitInitialRefresh()` before the first `unreadCount` /
+    /// `allMessages` read returns.
     private var initialRefreshTask: Task<Void, Never>?
 
     /// Monotonic counter used to discard responses from refresh calls that have been
-    /// superseded by a newer in-flight call.
+    /// superseded by a newer in-flight call or an identity reset.
     private var refreshGeneration: UInt = 0
 
-    /// Async accessor for all messages. Awaits the init-time refresh on first read so passive
-    /// callers see server-authoritative state instead of a pre-fetch empty list.
     var allMessages: [Message] {
         get async {
             await awaitInitialRefresh()
@@ -58,8 +54,6 @@ actor InboxManager {
         }
     }
 
-    /// Async accessor for the server-authoritative unread count. Awaits the init-time refresh
-    /// on first read so passive callers don't see the pre-fetch default of 0.
     var unreadCount: Int {
         get async {
             await awaitInitialRefresh()
@@ -107,15 +101,9 @@ actor InboxManager {
     init(api: ATTNAPIProtocol, identityProvider: @escaping InboxIdentityProvider) {
         self.api = api
         self.identityProvider = identityProvider
-        // Kick off an initial unread-count fetch so hosts that consume the count via a
-        // passive badge (`await sdk.unreadCount`) don't have to also call `refreshInboxUnreadCount()`
-        // on their own to see a value. Host apps that never interact with the inbox surface
-        // never construct this manager — `ATTNSDK.materializedInboxManager()` gates construction
-        // on active use, so this fetch is not paid by non-inbox hosts.
-        //
-        // Held as `initialRefreshTask` so that the first `unreadCount` / `allMessages` read
-        // awaits it — otherwise a passive-badge UI reads `storedUnreadCount == 0` before the
-        // background fetch lands and never re-reads.
+        // Passive-badge hosts read `sdk.unreadCount` without opening the inbox surface, so
+        // the manager fetches on construction. Non-inbox hosts never construct it — see
+        // `ATTNSDK.materializedInboxManager()`.
         initialRefreshTask = Task { [weak self] in
             await self?.refreshUnreadCount()
         }
@@ -125,6 +113,21 @@ actor InboxManager {
     /// authoritative value. Errors are logged; the previously stored count is preserved.
     /// If multiple refreshes are in flight, only the most recently issued one is honored.
     func refreshUnreadCount() async {
+        await refreshUnreadCount(skipNotify: false)
+    }
+
+    /// Internal variant. `skipNotify == true` when the caller (e.g. `refresh()`) already
+    /// emits `.loaded` after `updateMessages`, so re-sending the same state here would
+    /// force subscribers to re-diff the identical payload.
+    private func refreshUnreadCount(skipNotify: Bool) async {
+        // Coalesce with the init-time fetch. A host that follows the RFC and calls
+        // `refreshInboxUnreadCount()` on app launch would otherwise race the manager's own
+        // init fetch and produce two identical POSTs.
+        if let task = initialRefreshTask {
+            initialRefreshTask = nil
+            await task.value
+            return
+        }
         let identity = identityProvider()
         // Without a visitor ID the server can't scope the request — skip rather than send
         // an unscoped call that would 4xx and pollute logs.
@@ -144,10 +147,10 @@ actor InboxManager {
             // Drop superseded responses so a slow earlier call cannot overwrite a fresher one.
             guard generation == refreshGeneration else { return }
             storedUnreadCount = count
-            // Nudge observers to re-read `unreadCount` once we already have messages.
-            // Skip the nudge while still loading or in error — re-emitting `.loading`
-            // would clobber the loaded list once it arrives.
-            if case .loaded = currentState {
+            // Nudge observers so passive-badge subscribers re-read `unreadCount` once messages
+            // are already loaded. Skip when still loading / errored (re-emitting `.loading`
+            // would clobber the loaded list) or when the caller will emit its own `.loaded`.
+            if !skipNotify, case .loaded = currentState {
                 send(currentState)
             }
         } catch {
@@ -175,12 +178,11 @@ actor InboxManager {
 
     /// Reloads inbox messages and re-fetches the server-authoritative unread count.
     /// Called on inbox open, pull-to-refresh, and (indirectly, via the host app) push open.
-    /// Runs the two fetches concurrently so pull-to-refresh does not double the perceived latency.
+    /// Once the real messages endpoint replaces `getMockInbox()` this should switch to
+    /// `async let` so the two network calls run concurrently.
     func refresh() async {
-        // Local mock reload is synchronous; wrap so `async let` schedules it alongside the network call.
-        async let messageReload: Void = updateMessages(Self.getMockInbox().messages)
-        async let countRefresh: Void = refreshUnreadCount()
-        _ = await (messageReload, countRefresh)
+        updateMessages(Self.getMockInbox().messages)
+        await refreshUnreadCount(skipNotify: true)
     }
 
     /// Resets the cached unread count to 0 and bumps the refresh generation so any in-flight

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -76,10 +76,10 @@ actor InboxManager {
     init(api: ATTNAPIProtocol, identityProvider: @escaping InboxIdentityProvider) {
         self.api = api
         self.identityProvider = identityProvider
-        Task {
-            await updateMessages(Self.getMockInbox().messages)
-            await refreshUnreadCount()
-        }
+        // No init-time network fetch: host apps that never touch the inbox surface should
+        // not incur an unread-count call. The first `refresh()` (invoked by `InboxView.task`
+        // on open, by `InboxViewModel.refresh()` for pull-to-refresh, or by the host calling
+        // `refreshInboxUnreadCount()`) loads data.
     }
 
     /// Fetches the latest unread count from the server and stores it as the
@@ -134,8 +134,14 @@ actor InboxManager {
         send(.loaded(allMessages))
     }
 
-    func refresh() {
-        updateMessages(Self.getMockInbox().messages)
+    /// Reloads inbox messages and re-fetches the server-authoritative unread count.
+    /// Called on inbox open, pull-to-refresh, and (indirectly, via the host app) push open.
+    /// Runs the two fetches concurrently so pull-to-refresh does not double the perceived latency.
+    func refresh() async {
+        // Local mock reload is synchronous; wrap so `async let` schedules it alongside the network call.
+        async let messageReload: Void = updateMessages(Self.getMockInbox().messages)
+        async let countRefresh: Void = refreshUnreadCount()
+        _ = await (messageReload, countRefresh)
     }
 
     /// Resets the cached unread count to 0 and bumps the refresh generation so any in-flight

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -104,8 +104,10 @@ actor InboxManager {
         // Passive-badge hosts read `sdk.unreadCount` without opening the inbox surface, so
         // the manager fetches on construction. Non-inbox hosts never construct it — see
         // `ATTNSDK.materializedInboxManager()`.
+        // The init task calls `performUnreadCountFetch` directly (not `refreshUnreadCount`)
+        // so it doesn't try to coalesce with itself.
         initialRefreshTask = Task { [weak self] in
-            await self?.refreshUnreadCount()
+            await self?.performUnreadCountFetch(skipNotify: false)
         }
     }
 
@@ -113,13 +115,6 @@ actor InboxManager {
     /// authoritative value. Errors are logged; the previously stored count is preserved.
     /// If multiple refreshes are in flight, only the most recently issued one is honored.
     func refreshUnreadCount() async {
-        await refreshUnreadCount(skipNotify: false)
-    }
-
-    /// Internal variant. `skipNotify == true` when the caller (e.g. `refresh()`) already
-    /// emits `.loaded` after `updateMessages`, so re-sending the same state here would
-    /// force subscribers to re-diff the identical payload.
-    private func refreshUnreadCount(skipNotify: Bool) async {
         // Coalesce with the init-time fetch. A host that follows the RFC and calls
         // `refreshInboxUnreadCount()` on app launch would otherwise race the manager's own
         // init fetch and produce two identical POSTs.
@@ -128,6 +123,13 @@ actor InboxManager {
             await task.value
             return
         }
+        await performUnreadCountFetch(skipNotify: false)
+    }
+
+    /// Internal worker. Always fires a network request — no coalesce check — so the init
+    /// task can call this without deadlocking on itself. `skipNotify == true` when the
+    /// caller (e.g. `refresh()`) will emit its own `.loaded` after `updateMessages`.
+    private func performUnreadCountFetch(skipNotify: Bool) async {
         let identity = identityProvider()
         // Without a visitor ID the server can't scope the request — skip rather than send
         // an unscoped call that would 4xx and pollute logs.
@@ -182,7 +184,8 @@ actor InboxManager {
     /// `async let` so the two network calls run concurrently.
     func refresh() async {
         updateMessages(Self.getMockInbox().messages)
-        await refreshUnreadCount(skipNotify: true)
+        // skipNotify because updateMessages above already emitted `.loaded`.
+        await performUnreadCountFetch(skipNotify: true)
     }
 
     /// Resets the cached unread count to 0 and bumps the refresh generation so any in-flight

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -148,11 +148,11 @@ actor InboxManager {
             )
             // Drop superseded responses so a slow earlier call cannot overwrite a fresher one.
             guard generation == refreshGeneration else { return }
+            let previous = storedUnreadCount
             storedUnreadCount = count
-            // Nudge observers so passive-badge subscribers re-read `unreadCount` once messages
-            // are already loaded. Skip when still loading / errored (re-emitting `.loading`
-            // would clobber the loaded list) or when the caller will emit its own `.loaded`.
-            if !skipNotify, case .loaded = currentState {
+            // Re-emit only when the value actually changed and we're in a loaded state — avoids
+            // waking subscribers with an identical payload on every no-op refresh.
+            if !skipNotify, count != previous, case .loaded = currentState {
                 send(currentState)
             }
         } catch {
@@ -193,6 +193,7 @@ actor InboxManager {
     /// (`clearUser`, `updateUser`) so a logged-out account's badge is not surfaced to the next user.
     func resetUnreadCount() {
         refreshGeneration &+= 1
+        guard storedUnreadCount != 0 else { return }
         storedUnreadCount = 0
         if case .loaded = currentState {
             send(currentState)

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -76,10 +76,12 @@ actor InboxManager {
     init(api: ATTNAPIProtocol, identityProvider: @escaping InboxIdentityProvider) {
         self.api = api
         self.identityProvider = identityProvider
-        // No init-time network fetch: host apps that never touch the inbox surface should
-        // not incur an unread-count call. The first `refresh()` (invoked by `InboxView.task`
-        // on open, by `InboxViewModel.refresh()` for pull-to-refresh, or by the host calling
-        // `refreshInboxUnreadCount()`) loads data.
+        // Kick off an initial unread-count fetch so hosts that consume the count via a
+        // passive badge (`await sdk.unreadCount`) don't have to also call `refreshInboxUnreadCount()`
+        // on their own to see a value. Host apps that never interact with the inbox surface
+        // never construct this manager — `ATTNSDK.materializedInboxManager()` gates construction
+        // on active use, so this fetch is not paid by non-inbox hosts.
+        Task { await refreshUnreadCount() }
     }
 
     /// Fetches the latest unread count from the server and stores it as the

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -33,18 +33,49 @@ actor InboxManager {
 
     /// Server-authoritative unread count. Updated only by `refreshUnreadCount()` and (future)
     /// mark-read/mark-unread/delete API responses — local `markRead`/`markUnread` mutations
-    /// do not change this value. Defaults to 0 until the first successful refresh, so callers
-    /// cannot distinguish "no unread" from "not yet fetched".
-    private(set) var unreadCount: Int = 0
+    /// do not change this value. Prefer reading via the async `unreadCount` accessor below,
+    /// which awaits the init-time fetch on first read so callers don't see a stale 0.
+    private var storedUnreadCount: Int = 0
 
     private let api: ATTNAPIProtocol
     private let identityProvider: InboxIdentityProvider
+
+    /// Init-time refresh task. `unreadCount` / `allMessages` await it once so passive-badge
+    /// callers see the server-authoritative value on their first read rather than the
+    /// pre-fetch default of 0.
+    private var initialRefreshTask: Task<Void, Never>?
 
     /// Monotonic counter used to discard responses from refresh calls that have been
     /// superseded by a newer in-flight call.
     private var refreshGeneration: UInt = 0
 
+    /// Async accessor for all messages. Awaits the init-time refresh on first read so passive
+    /// callers see server-authoritative state instead of a pre-fetch empty list.
     var allMessages: [Message] {
+        get async {
+            await awaitInitialRefresh()
+            return sortedMessagesSnapshot()
+        }
+    }
+
+    /// Async accessor for the server-authoritative unread count. Awaits the init-time refresh
+    /// on first read so passive callers don't see the pre-fetch default of 0.
+    var unreadCount: Int {
+        get async {
+            await awaitInitialRefresh()
+            return storedUnreadCount
+        }
+    }
+
+    private func awaitInitialRefresh() async {
+        // Drain the init-time refresh exactly once; subsequent reads are constant-time.
+        if let task = initialRefreshTask {
+            await task.value
+            initialRefreshTask = nil
+        }
+    }
+
+    private func sortedMessagesSnapshot() -> [Message] {
         if let cached = cachedSortedMessages {
             return cached
         }
@@ -81,7 +112,13 @@ actor InboxManager {
         // on their own to see a value. Host apps that never interact with the inbox surface
         // never construct this manager — `ATTNSDK.materializedInboxManager()` gates construction
         // on active use, so this fetch is not paid by non-inbox hosts.
-        Task { await refreshUnreadCount() }
+        //
+        // Held as `initialRefreshTask` so that the first `unreadCount` / `allMessages` read
+        // awaits it — otherwise a passive-badge UI reads `storedUnreadCount == 0` before the
+        // background fetch lands and never re-reads.
+        initialRefreshTask = Task { [weak self] in
+            await self?.refreshUnreadCount()
+        }
     }
 
     /// Fetches the latest unread count from the server and stores it as the
@@ -106,7 +143,7 @@ actor InboxManager {
             )
             // Drop superseded responses so a slow earlier call cannot overwrite a fresher one.
             guard generation == refreshGeneration else { return }
-            unreadCount = count
+            storedUnreadCount = count
             // Nudge observers to re-read `unreadCount` once we already have messages.
             // Skip the nudge while still loading or in error — re-emitting `.loading`
             // would clobber the loaded list once it arrives.
@@ -121,19 +158,19 @@ actor InboxManager {
     func markRead(_ messageID: Message.ID) {
         messagesByID[messageID]?.isRead = true
         updateCachedMessage(messageID)
-        send(.loaded(allMessages))
+        send(.loaded(sortedMessagesSnapshot()))
     }
 
     func markUnread(_ messageID: Message.ID) {
         messagesByID[messageID]?.isRead = false
         updateCachedMessage(messageID)
-        send(.loaded(allMessages))
+        send(.loaded(sortedMessagesSnapshot()))
     }
 
     func delete(_ messageID: Message.ID) {
         messagesByID.removeValue(forKey: messageID)
         invalidateCache()
-        send(.loaded(allMessages))
+        send(.loaded(sortedMessagesSnapshot()))
     }
 
     /// Reloads inbox messages and re-fetches the server-authoritative unread count.
@@ -151,7 +188,7 @@ actor InboxManager {
     /// (`clearUser`, `updateUser`) so a logged-out account's badge is not surfaced to the next user.
     func resetUnreadCount() {
         refreshGeneration &+= 1
-        unreadCount = 0
+        storedUnreadCount = 0
         if case .loaded = currentState {
             send(currentState)
         }
@@ -177,7 +214,7 @@ extension InboxManager {
             $0[$1.id] = $1
         }
         invalidateCache()
-        send(.loaded(allMessages))
+        send(.loaded(sortedMessagesSnapshot()))
     }
 
     private func invalidateCache() {

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -101,13 +101,13 @@ actor InboxManager {
     init(api: ATTNAPIProtocol, identityProvider: @escaping InboxIdentityProvider) {
         self.api = api
         self.identityProvider = identityProvider
-        // Passive-badge hosts read `sdk.unreadCount` without opening the inbox surface, so
-        // the manager fetches on construction. Non-inbox hosts never construct it — see
-        // `ATTNSDK.materializedInboxManager()`.
-        // The init task calls `performUnreadCountFetch` directly (not `refreshUnreadCount`)
-        // so it doesn't try to coalesce with itself.
+        // Populate mock messages and fetch the unread count on construction so passive-badge
+        // hosts (`sdk.unreadCount`) and stream/`allMessages` consumers both resolve without
+        // needing to present `inboxView()`. Non-inbox hosts never construct the manager — see
+        // `ATTNSDK.materializedInboxManager()`. Calls `performUnreadCountFetch` directly (not
+        // `refreshUnreadCount`) so it doesn't try to coalesce with itself.
         initialRefreshTask = Task { [weak self] in
-            await self?.performUnreadCountFetch(skipNotify: false)
+            await self?.loadInitialMessagesAndUnreadCount()
         }
     }
 
@@ -123,6 +123,16 @@ actor InboxManager {
             await task.value
             return
         }
+        await performUnreadCountFetch(skipNotify: false)
+    }
+
+    /// Init-time seed: populate mock messages so `allMessages` / `inboxStateStream` resolve
+    /// for hosts that never present `inboxView()`, then fetch the server-authoritative unread
+    /// count. `updateMessages` emits `.loaded` immediately; the count fetch runs with
+    /// `skipNotify: false` so subscribers get a nudge to re-read `unreadCount` when the
+    /// server value arrives.
+    private func loadInitialMessagesAndUnreadCount() async {
+        updateMessages(Self.getMockInbox().messages)
         await performUnreadCountFetch(skipNotify: false)
     }
 

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -209,6 +209,6 @@ fileprivate extension InboxManager {
                 actionURLString: "https://example.com/track/12345"
             )
         ]
-        return InboxResponse(messages: messages, unreadCount: 2)
+        return InboxResponse(messages: messages)
     }
 }

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -76,8 +76,10 @@ actor InboxManager {
     /// Fetches the latest unread count from the server and stores it as the
     /// authoritative value. Errors are logged; the previously stored count is preserved.
     func refreshUnreadCount() async {
+        print("[MSDK-377] InboxManager.refreshUnreadCount() entered")
         guard let api = api, let identityProvider = identityProvider else {
             Loggers.network.debug("Skipping refreshUnreadCount — no API or identity provider configured")
+            print("[MSDK-377] ⚠️ skipped: api=\(api == nil ? "nil" : "set") identityProvider=\(identityProvider == nil ? "nil" : "set")")
             return
         }
 
@@ -89,8 +91,13 @@ actor InboxManager {
                 phone: phone,
                 userIdentity: userIdentity
             )
+            print("[MSDK-377] InboxManager.unreadCount updated to \(unreadCount)")
+            // Re-emit current state so observers re-read the updated `unreadCount`.
+            // The state value itself is unchanged; this is a nudge for badge UIs.
+            send(currentState)
         } catch {
             Loggers.network.error("Failed to refresh inbox unread count: \(error.localizedDescription, privacy: .public)")
+            print("[MSDK-377] ❌ refreshUnreadCount error: \(error.localizedDescription)")
         }
     }
 

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -13,11 +13,23 @@ public enum InboxState: Sendable {
     case error(Error)
 }
 
+/// Closure that supplies the identifiers needed to call the inbox endpoints.
+/// Resolved at call-time so the manager always uses the latest values from `ATTNSDK`.
+typealias InboxIdentityProvider = @Sendable () -> (userIdentity: ATTNUserIdentity, pushToken: String, email: String?, phone: String?)
+
 actor InboxManager {
     private var messagesByID: [Message.ID: Message] = [:]
     private var cachedSortedMessages: [Message]?
     private var currentState: InboxState = .loading
     private var continuations: [UUID: AsyncStream<InboxState>.Continuation] = [:]
+
+    /// Server-authoritative unread count. Updated only by `refreshUnreadCount()` and (future)
+    /// mark-read/mark-unread/delete API responses — local `markRead`/`markUnread` mutations
+    /// do not change this value.
+    private(set) var unreadCount: Int = 0
+
+    private let api: ATTNAPIProtocol?
+    private let identityProvider: InboxIdentityProvider?
 
     var allMessages: [Message] {
         if let cached = cachedSortedMessages {
@@ -26,10 +38,6 @@ actor InboxManager {
         let sorted = messagesByID.values.sorted { $0.timestamp > $1.timestamp }
         cachedSortedMessages = sorted
         return sorted
-    }
-
-    var unreadCount: Int {
-        messagesByID.values.filter { !$0.isRead }.count
     }
 
     /// Returns an AsyncStream that immediately emits the current state,
@@ -52,10 +60,37 @@ actor InboxManager {
         }
     }
 
-    init() {
+    init(api: ATTNAPIProtocol? = nil, identityProvider: InboxIdentityProvider? = nil) {
+        self.api = api
+        self.identityProvider = identityProvider
         Task {
             await send(.loading)
-            await updateMessages(Self.getMockInbox().messages)
+            // Run mock-message load and unread-count fetch concurrently — they touch
+            // independent state and the network call should not wait on the local mock.
+            async let messages: Void = updateMessages(Self.getMockInbox().messages)
+            async let count: Void = refreshUnreadCount()
+            _ = await (messages, count)
+        }
+    }
+
+    /// Fetches the latest unread count from the server and stores it as the
+    /// authoritative value. Errors are logged; the previously stored count is preserved.
+    func refreshUnreadCount() async {
+        guard let api = api, let identityProvider = identityProvider else {
+            Loggers.network.debug("Skipping refreshUnreadCount — no API or identity provider configured")
+            return
+        }
+
+        let (userIdentity, pushToken, email, phone) = identityProvider()
+        do {
+            unreadCount = try await api.fetchInboxUnreadCount(
+                pushToken: pushToken,
+                email: email,
+                phone: phone,
+                userIdentity: userIdentity
+            )
+        } catch {
+            Loggers.network.error("Failed to refresh inbox unread count: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/Sources/Inbox/InboxView.swift
+++ b/Sources/Inbox/InboxView.swift
@@ -12,37 +12,45 @@ struct InboxView: View {
     var viewModel: InboxViewModel
 
     var body: some View {
-        switch viewModel.state {
-        case .loading:
-            ProgressView()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        case .error:
-            Text(String.somethingWentWrong)
-        case .empty:
-            buildListView {
-                Text(String.noMessages)
-            }
-        case .loaded(let messages):
-            buildListView {
-                ForEach(messages) { message in
-                    InboxMessageRowView(message: message, style: viewModel.style)
-                        .swipeActions(edge: .trailing) {
-                            Button(role: .destructive) {
-                                viewModel.delete(message.id)
-                            } label: {
-                                Label(String.delete, systemImage: "trash")
+        Group {
+            switch viewModel.state {
+            case .loading:
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .error:
+                Text(String.somethingWentWrong)
+            case .empty:
+                buildListView {
+                    Text(String.noMessages)
+                }
+            case .loaded(let messages):
+                buildListView {
+                    ForEach(messages) { message in
+                        InboxMessageRowView(message: message, style: viewModel.style)
+                            .swipeActions(edge: .trailing) {
+                                Button(role: .destructive) {
+                                    viewModel.delete(message.id)
+                                } label: {
+                                    Label(String.delete, systemImage: "trash")
+                                }
                             }
-                        }
-                        .swipeActions(edge: .leading) {
-                            Button {
-                                message.isRead ? viewModel.markUnread(message.id) : viewModel.markAsRead(message.id)
-                            } label: {
-                                message.isRead ? Label(String.unread, systemImage: "envelope") : Label(String.read, systemImage: "envelope.open")
+                            .swipeActions(edge: .leading) {
+                                Button {
+                                    message.isRead ? viewModel.markUnread(message.id) : viewModel.markAsRead(message.id)
+                                } label: {
+                                    message.isRead ? Label(String.unread, systemImage: "envelope") : Label(String.read, systemImage: "envelope.open")
+                                }
+                                .tint(.blue)
                             }
-                            .tint(.blue)
-                        }
+                    }
                 }
             }
+        }
+        // Trigger the first load when the view appears. Cancels automatically when the view
+        // disappears; SwiftUI re-runs it whenever the identity provided by the `.task` id changes,
+        // but there's no id here so it runs once per appearance.
+        .task {
+            await viewModel.refresh()
         }
     }
 
@@ -51,6 +59,12 @@ struct InboxView: View {
             .listStyle(.plain)
             .navigationTitle(String.inbox)
             .navigationBarTitleDisplayMode(.inline)
-            .refreshable(action: viewModel.refresh)
+            // Wrap in a closure rather than passing `viewModel.refresh` directly: the method
+            // reference isn't `@Sendable` (viewModel is a `@MainActor ObservableObject`) and
+            // `.refreshable` requires a `@Sendable () async -> Void`. The closure hops onto
+            // the main actor via the `await`, satisfying both sides.
+            .refreshable {
+                await viewModel.refresh()
+            }
     }
 }

--- a/Sources/Inbox/InboxView.swift
+++ b/Sources/Inbox/InboxView.swift
@@ -46,9 +46,6 @@ struct InboxView: View {
                 }
             }
         }
-        // Trigger the first load when the view appears. Cancels automatically when the view
-        // disappears; SwiftUI re-runs it whenever the identity provided by the `.task` id changes,
-        // but there's no id here so it runs once per appearance.
         .task {
             await viewModel.refresh()
         }
@@ -59,10 +56,6 @@ struct InboxView: View {
             .listStyle(.plain)
             .navigationTitle(String.inbox)
             .navigationBarTitleDisplayMode(.inline)
-            // Wrap in a closure rather than passing `viewModel.refresh` directly: the method
-            // reference isn't `@Sendable` (viewModel is a `@MainActor ObservableObject`) and
-            // `.refreshable` requires a `@Sendable () async -> Void`. The closure hops onto
-            // the main actor via the `await`, satisfying both sides.
             .refreshable {
                 await viewModel.refresh()
             }

--- a/Sources/Inbox/Models/InboxResponse.swift
+++ b/Sources/Inbox/Models/InboxResponse.swift
@@ -7,5 +7,4 @@
 
 struct InboxResponse: Codable {
     var messages: [Message]
-    var unreadCount: Int
 }

--- a/Sources/Inbox/Models/InboxUnreadCountResponse.swift
+++ b/Sources/Inbox/Models/InboxUnreadCountResponse.swift
@@ -1,0 +1,14 @@
+//
+//  InboxUnreadCountResponse.swift
+//  attentive-ios-sdk
+//
+//  Created by Adela Gao on 6/4/26.
+//
+
+struct InboxUnreadCountResponse: Codable {
+    let unreadCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case unreadCount = "unread_count"
+    }
+}

--- a/Sources/Inbox/Models/InboxUnreadCountResponse.swift
+++ b/Sources/Inbox/Models/InboxUnreadCountResponse.swift
@@ -5,6 +5,8 @@
 //  Created by Adela Gao on 6/4/26.
 //
 
+import Foundation
+
 struct InboxUnreadCountResponse: Codable {
     let unreadCount: Int
 

--- a/Sources/Inbox/Models/Message.swift
+++ b/Sources/Inbox/Models/Message.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public struct Message: Codable, Identifiable, Sendable {
-    public enum Style: Codable {
+    public enum Style: Codable, Sendable {
         case small
         case large
     }

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -51,7 +51,19 @@ public final class ATTNSDK: NSObject {
     // Single accessor used across the SDK
     private var currentPushToken: String { pushTokenStore.token }
 
-    private let inboxManager = InboxManager()
+    private lazy var inboxManager: InboxManager = {
+        InboxManager(api: api, identityProvider: { [weak self] in
+            guard let self = self else {
+                return (ATTNUserIdentity(), "", nil, nil)
+            }
+            return (
+                self.userIdentity,
+                self.currentPushToken,
+                self.userIdentity.identifiers[ATTNIdentifierType.email] as? String,
+                self.userIdentity.identifiers[ATTNIdentifierType.phone] as? String
+            )
+        })
+    }()
 
     // MARK: Instance Properties
     var parentView: UIView?
@@ -259,11 +271,19 @@ public final class ATTNSDK: NSObject {
         }
     }
 
-    /// Async accessor for unread count.
+    /// Async accessor for unread count. Returns the most recently fetched server-authoritative
+    /// value. Call `refreshInboxUnreadCount()` to fetch the latest from the server.
     public var unreadCount: Int {
         get async {
             await inboxManager.unreadCount
         }
+    }
+
+    /// Refreshes the unread inbox message count from the server.
+    /// Per RFC, host apps should call this when navigating to the app's main page (e.g. on app launch)
+    /// and after opening a push notification.
+    public func refreshInboxUnreadCount() async {
+        await inboxManager.refreshUnreadCount()
     }
 
     @MainActor

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -52,11 +52,10 @@ public final class ATTNSDK: NSObject {
     // Single accessor used across the SDK
     private var currentPushToken: String { pushTokenStore.token }
 
-    private lazy var inboxManager: InboxManager = {
-        InboxManager(api: api, identityProvider: { [weak self] in
-            self?.identityStore.snapshot() ?? InboxIdentitySnapshot(visitorId: "", pushToken: "", email: nil, phone: nil)
-        })
-    }()
+    // Backing storage for the inbox manager. Optional (not `lazy var`) so `clearUser()` can
+    // reset an already-materialized manager without creating one for hosts that never used inbox.
+    // See `materializedInboxManager()` for the construction path.
+    private var _inboxManager: InboxManager?
 
     // MARK: Instance Properties
     var parentView: UIView?
@@ -224,8 +223,12 @@ public final class ATTNSDK: NSObject {
         let oldVisitorId = userIdentity.visitorId
         userIdentity.clearUser()
         publishIdentitySnapshot()
-        // Drop the previous user's cached unread count so the next user doesn't see their badge.
-        Task { [inboxManager] in await inboxManager.resetUnreadCount() }
+        // Drop the previous user's cached unread count so the next user doesn't see their badge —
+        // but only if the manager has already been materialized. Constructing it here would issue
+        // an unread-count fetch for host apps that never touch the inbox surface.
+        if let manager = _inboxManager {
+            Task { await manager.resetUnreadCount() }
+        }
         Loggers.creative.debug("User cleared successfully - Old Visitor ID: \(oldVisitorId, privacy: .public), New Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
     }
 
@@ -256,27 +259,34 @@ public final class ATTNSDK: NSObject {
     /// Returns an `AsyncStream` that immediately emits the current `InboxState`,
     /// then emits on any subsequent change.
     /// Usage: `for await state in await sdk.inboxStateStream { ... }`
+    ///
+    /// Reading this property materializes the inbox manager (subscribing to updates is
+    /// an active use).
     public var inboxStateStream: AsyncStream<InboxState> {
         get async {
-            await inboxManager.stateStream
+            await materializedInboxManager().stateStream
         }
     }
 
-    /// Async accessor for all messages.
+    /// Async accessor for all messages. Returns `[]` if the inbox has never been loaded.
+    /// Reading this property does not trigger a network fetch.
     public var allMessages: [Message] {
         get async {
-            await inboxManager.allMessages
+            guard let manager = _inboxManager else { return [] }
+            return await manager.allMessages
         }
     }
 
     /// Async accessor for unread count. Returns the most recently fetched server-authoritative
-    /// value, or `0` until the first successful refresh completes. Because the initial value
-    /// and the "no unread messages" value are both `0`, callers that need to distinguish
+    /// value, or `0` if the inbox has never been loaded on this device. Because the initial
+    /// value and the "no unread messages" value are both `0`, callers that need to distinguish
     /// "loading" from "zero unread" should track that state themselves (e.g. via
     /// `inboxStateStream`). Call `refreshInboxUnreadCount()` to fetch the latest from the server.
+    /// Reading this property does not trigger a network fetch.
     public var unreadCount: Int {
         get async {
-            await inboxManager.unreadCount
+            guard let manager = _inboxManager else { return 0 }
+            return await manager.unreadCount
         }
     }
 
@@ -284,12 +294,12 @@ public final class ATTNSDK: NSObject {
     /// Per RFC, host apps should call this when navigating to the app's main page (e.g. on app launch)
     /// and after opening a push notification.
     public func refreshInboxUnreadCount() async {
-        await inboxManager.refreshUnreadCount()
+        await materializedInboxManager().refreshUnreadCount()
     }
 
     @MainActor
     public func inboxView(style: InboxStyle = InboxStyle()) -> some View {
-        InboxView(viewModel: InboxViewModel(inboxManager: inboxManager, style: style))
+        InboxView(viewModel: InboxViewModel(inboxManager: materializedInboxManager(), style: style))
     }
 
     @MainActor
@@ -298,15 +308,15 @@ public final class ATTNSDK: NSObject {
     }
 
     public func markRead(for messageID: Message.ID) async {
-        await inboxManager.markRead(messageID)
+        await materializedInboxManager().markRead(messageID)
     }
 
     public func markUnread(for messageID: Message.ID) async {
-        await inboxManager.markUnread(messageID)
+        await materializedInboxManager().markUnread(messageID)
     }
 
     public func delete(messageID: Message.ID) async {
-        await inboxManager.delete(messageID)
+        await materializedInboxManager().delete(messageID)
     }
 
     // MARK: Push Permissions & Token
@@ -931,6 +941,19 @@ extension ATTNSDK: ATTNWebViewProviding {
 
 // MARK: Private Helpers
 fileprivate extension ATTNSDK {
+    /// Returns the existing `InboxManager` or lazily constructs one bound to this SDK
+    /// instance's api + identity store. Called on *active* inbox use only (opening the view,
+    /// explicit `refreshInboxUnreadCount()`, message mutations) so that hosts which never
+    /// interact with the inbox surface never trigger the manager's network activity.
+    func materializedInboxManager() -> InboxManager {
+        if let existing = _inboxManager { return existing }
+        let manager = InboxManager(api: api, identityProvider: { [weak self] in
+            self?.identityStore.snapshot() ?? InboxIdentitySnapshot(visitorId: "", pushToken: "", email: nil, phone: nil)
+        })
+        _inboxManager = manager
+        return manager
+    }
+
     /// Publishes the current identity (visitor id, push token, email, phone) into the
     /// thread-safe `identityStore` for `InboxManager`'s `@Sendable` provider to read.
     /// Call after any mutation of `userIdentity` or `currentPushToken`.

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -268,25 +268,26 @@ public final class ATTNSDK: NSObject {
         }
     }
 
-    /// Async accessor for all messages. Returns `[]` if the inbox has never been loaded.
-    /// Reading this property does not trigger a network fetch.
+    /// Async accessor for all messages. Materializes the inbox manager (reading messages counts
+    /// as active inbox use), which triggers a background unread-count fetch on first access.
     public var allMessages: [Message] {
         get async {
-            guard let manager = _inboxManager else { return [] }
-            return await manager.allMessages
+            await materializedInboxManager().allMessages
         }
     }
 
     /// Async accessor for unread count. Returns the most recently fetched server-authoritative
-    /// value, or `0` if the inbox has never been loaded on this device. Because the initial
-    /// value and the "no unread messages" value are both `0`, callers that need to distinguish
-    /// "loading" from "zero unread" should track that state themselves (e.g. via
-    /// `inboxStateStream`). Call `refreshInboxUnreadCount()` to fetch the latest from the server.
-    /// Reading this property does not trigger a network fetch.
+    /// value, or `0` until the first fetch completes. Because the initial value and the
+    /// "no unread messages" value are both `0`, callers that need to distinguish "loading" from
+    /// "zero unread" should track that state themselves (e.g. via `inboxStateStream`).
+    ///
+    /// Materializes the inbox manager on first read — passive-badge use cases (host reads
+    /// `sdk.unreadCount` without ever opening the inbox view) get an automatic refresh via
+    /// the manager's init. For latest-value semantics after known state changes (app launch,
+    /// push open), call `refreshInboxUnreadCount()` explicitly per the RFC.
     public var unreadCount: Int {
         get async {
-            guard let manager = _inboxManager else { return 0 }
-            return await manager.unreadCount
+            await materializedInboxManager().unreadCount
         }
     }
 

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -54,13 +54,14 @@ public final class ATTNSDK: NSObject {
     private lazy var inboxManager: InboxManager = {
         InboxManager(api: api, identityProvider: { [weak self] in
             guard let self = self else {
-                return (ATTNUserIdentity(), "", nil, nil)
+                return InboxIdentitySnapshot(visitorId: "", pushToken: "", email: nil, phone: nil)
             }
-            return (
-                self.userIdentity,
-                self.currentPushToken,
-                self.userIdentity.identifiers[ATTNIdentifierType.email] as? String,
-                self.userIdentity.identifiers[ATTNIdentifierType.phone] as? String
+            let identifiers = self.userIdentity.identifiers
+            return InboxIdentitySnapshot(
+                visitorId: self.userIdentity.visitorId,
+                pushToken: self.currentPushToken,
+                email: identifiers[ATTNIdentifierType.email] as? String,
+                phone: identifiers[ATTNIdentifierType.phone] as? String
             )
         })
     }()
@@ -272,7 +273,10 @@ public final class ATTNSDK: NSObject {
     }
 
     /// Async accessor for unread count. Returns the most recently fetched server-authoritative
-    /// value. Call `refreshInboxUnreadCount()` to fetch the latest from the server.
+    /// value, or `0` until the first successful refresh completes. Because the initial value
+    /// and the "no unread messages" value are both `0`, callers that need to distinguish
+    /// "loading" from "zero unread" should track that state themselves (e.g. via
+    /// `inboxStateStream`). Call `refreshInboxUnreadCount()` to fetch the latest from the server.
     public var unreadCount: Int {
         get async {
             await inboxManager.unreadCount

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -280,11 +280,7 @@ public final class ATTNSDK: NSObject {
     /// value, or `0` until the first fetch completes. Because the initial value and the
     /// "no unread messages" value are both `0`, callers that need to distinguish "loading" from
     /// "zero unread" should track that state themselves (e.g. via `inboxStateStream`).
-    ///
-    /// Materializes the inbox manager on first read — passive-badge use cases (host reads
-    /// `sdk.unreadCount` without ever opening the inbox view) get an automatic refresh via
-    /// the manager's init. For latest-value semantics after known state changes (app launch,
-    /// push open), call `refreshInboxUnreadCount()` explicitly per the RFC.
+    /// Call `refreshInboxUnreadCount()` after known state changes (app launch, push open).
     public var unreadCount: Int {
         get async {
             await materializedInboxManager().unreadCount

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -39,6 +39,7 @@ public final class ATTNSDK: NSObject {
 
     private var _containerView: UIView?
     private let pushTokenStore = PushTokenStore()
+    private let identityStore = IdentitySnapshotStore()
     private let marketingQueue = DispatchQueue(label: "com.attentive.sdk.MarketingQueue", qos: .userInitiated)
     private var pendingMarketingRequests: [PendingMarketingRequest] = []
     private var pendingMarketingExpiryTimer: DispatchSourceTimer?
@@ -53,16 +54,7 @@ public final class ATTNSDK: NSObject {
 
     private lazy var inboxManager: InboxManager = {
         InboxManager(api: api, identityProvider: { [weak self] in
-            guard let self = self else {
-                return InboxIdentitySnapshot(visitorId: "", pushToken: "", email: nil, phone: nil)
-            }
-            let identifiers = self.userIdentity.identifiers
-            return InboxIdentitySnapshot(
-                visitorId: self.userIdentity.visitorId,
-                pushToken: self.currentPushToken,
-                email: identifiers[ATTNIdentifierType.email] as? String,
-                phone: identifiers[ATTNIdentifierType.phone] as? String
-            )
+            self?.identityStore.snapshot() ?? InboxIdentitySnapshot(visitorId: "", pushToken: "", email: nil, phone: nil)
         })
     }()
 
@@ -109,6 +101,7 @@ public final class ATTNSDK: NSObject {
         )
 
         self.webViewHandler = ATTNWebViewHandler(webViewProvider: self)
+        self.publishIdentitySnapshot()
         self.sendInfoEvent()
         self.initializeSkipFatigueOnCreatives()
 
@@ -157,6 +150,7 @@ public final class ATTNSDK: NSObject {
     public func identify(_ userIdentifiers: [String: Any]) {
         Loggers.event.debug("Identifying user - Visitor ID: \(self.userIdentity.visitorId, privacy: .public), Identifiers: \(userIdentifiers, privacy: .public)")
         userIdentity.mergeIdentifiers(userIdentifiers)
+        publishIdentitySnapshot()
         api.send(userIdentity: userIdentity)
         Loggers.event.debug("User identity sent successfully - Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
     }
@@ -229,6 +223,9 @@ public final class ATTNSDK: NSObject {
     private func clearUserIdentifiers() {
         let oldVisitorId = userIdentity.visitorId
         userIdentity.clearUser()
+        publishIdentitySnapshot()
+        // Drop the previous user's cached unread count so the next user doesn't see their badge.
+        Task { [inboxManager] in await inboxManager.resetUnreadCount() }
         Loggers.creative.debug("User cleared successfully - Old Visitor ID: \(oldVisitorId, privacy: .public), New Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
     }
 
@@ -342,6 +339,7 @@ public final class ATTNSDK: NSObject {
         let tokenString = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
         Loggers.event.debug("Registering device token - Visitor ID: \(self.userIdentity.visitorId, privacy: .public), Push Token: \(tokenString, privacy: .public), Auth Status: \(authorizationStatus.stringValue, privacy: .public)")
         pushTokenStore.token = tokenString
+        publishIdentitySnapshot()
         flushPendingMarketingRequests(with: tokenString)
         // this is called after events are sent. we need a better way to persist this
         api.sendPushToken(tokenString, userIdentity: userIdentity, authorizationStatus: authorizationStatus) { data, url, response, error in
@@ -723,6 +721,7 @@ public final class ATTNSDK: NSObject {
                                     Loggers.event.debug("Push permission became authorized. Clearing cached token and forcing APNs re-registration.")
                                     UserDefaults.standard.removeObject(forKey: "attentiveDeviceToken")
                                     self.pushTokenStore.token = ""
+                                    self.publishIdentitySnapshot()
                                     await MainActor.run {
                                             UIApplication.shared.registerForRemoteNotifications()
                                     }
@@ -932,6 +931,19 @@ extension ATTNSDK: ATTNWebViewProviding {
 
 // MARK: Private Helpers
 fileprivate extension ATTNSDK {
+    /// Publishes the current identity (visitor id, push token, email, phone) into the
+    /// thread-safe `identityStore` for `InboxManager`'s `@Sendable` provider to read.
+    /// Call after any mutation of `userIdentity` or `currentPushToken`.
+    func publishIdentitySnapshot() {
+        let identifiers = userIdentity.identifiers
+        identityStore.update(InboxIdentitySnapshot(
+            visitorId: userIdentity.visitorId,
+            pushToken: currentPushToken,
+            email: identifiers[ATTNIdentifierType.email] as? String,
+            phone: identifiers[ATTNIdentifierType.phone] as? String
+        ))
+    }
+
     func sendInfoEvent() {
         api.send(event: ATTNInfoEvent(), userIdentity: userIdentity)
     }
@@ -944,6 +956,26 @@ fileprivate extension ATTNSDK {
         webViewHandler?.launchCreative(parentView: view, creativeId: creativeId, handler: handler)
     }
 
+}
+
+// MARK: - Identity snapshot storage
+
+/// Thread-safe holder for the latest `InboxIdentitySnapshot`. Writers (on the main thread)
+/// publish via `update`; the inbox provider closure reads via `snapshot()` from the
+/// `InboxManager` actor executor. The serial queue serializes all access so the underlying
+/// snapshot is never read while being mutated, eliminating the data race on
+/// `userIdentity.identifiers`.
+private final class IdentitySnapshotStore: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "com.attentive.sdk.IdentitySnapshotStore", qos: .userInitiated)
+    private var current = InboxIdentitySnapshot(visitorId: "", pushToken: "", email: nil, phone: nil)
+
+    func update(_ next: InboxIdentitySnapshot) {
+        queue.sync { current = next }
+    }
+
+    func snapshot() -> InboxIdentitySnapshot {
+        queue.sync { current }
+    }
 }
 
 // MARK: - PushToken storage

--- a/Tests/Doubles/Mocks/NSURLSessionMock.swift
+++ b/Tests/Doubles/Mocks/NSURLSessionMock.swift
@@ -10,8 +10,15 @@ import Foundation
 
 class NSURLSessionMock: URLSession {
     var didCallEventsApi = false
+    var didCallInboxUnreadCountApi = false
     var urlCalls: [URL] = []
     var requests: [URLRequest] = []
+
+    /// Override the response returned for the inbox unread count endpoint.
+    /// Default: 200 with `{ "unread_count": 5 }`.
+    var inboxUnreadCountStatusCode: Int = 200
+    var inboxUnreadCountResponseBody: Data = Data("{\"unread_count\": 5}".utf8)
+    var inboxUnreadCountError: Error?
 
     override init() {
         super.init()
@@ -27,6 +34,16 @@ class NSURLSessionMock: URLSession {
                 didCallEventsApi = true
                 return NSURLSessionDataTaskMock { data, response, error in
                     completionHandler(Data(), HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil), nil)
+                }
+            }
+
+            if url.absoluteString.contains("/inbox/messages/unread/count") {
+                didCallInboxUnreadCountApi = true
+                let body = inboxUnreadCountResponseBody
+                let status = inboxUnreadCountStatusCode
+                let error = inboxUnreadCountError
+                return NSURLSessionDataTaskMock { _, _, _ in
+                    completionHandler(body, HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil), error)
                 }
             }
         }

--- a/Tests/Doubles/Spies/ATTNAPISpy.swift
+++ b/Tests/Doubles/Spies/ATTNAPISpy.swift
@@ -148,4 +148,28 @@ final class ATTNAPISpy: ATTNAPIProtocol {
         lastOperationContext = operationContext
         callback?(nil, nil, nil, nil)
     }
+
+    // MARK: - Inbox
+    private(set) var fetchInboxUnreadCountWasCalled = false
+    private(set) var fetchInboxUnreadCountCallCount = 0
+    private(set) var lastInboxPushToken: String?
+    private(set) var lastInboxEmail: String?
+    private(set) var lastInboxPhone: String?
+    var stubbedUnreadCount: Int = 0
+    var stubbedInboxError: Error?
+
+    func fetchInboxUnreadCount(
+        pushToken: String,
+        email: String?,
+        phone: String?,
+        userIdentity: ATTNUserIdentity
+    ) async throws -> Int {
+        fetchInboxUnreadCountWasCalled = true
+        fetchInboxUnreadCountCallCount += 1
+        lastInboxPushToken = pushToken
+        lastInboxEmail = email
+        lastInboxPhone = phone
+        if let error = stubbedInboxError { throw error }
+        return stubbedUnreadCount
+    }
 }

--- a/Tests/Doubles/Spies/ATTNAPISpy.swift
+++ b/Tests/Doubles/Spies/ATTNAPISpy.swift
@@ -155,6 +155,7 @@ final class ATTNAPISpy: ATTNAPIProtocol {
     private(set) var lastInboxPushToken: String?
     private(set) var lastInboxEmail: String?
     private(set) var lastInboxPhone: String?
+    private(set) var lastInboxVisitorId: String?
     var stubbedUnreadCount: Int = 0
     var stubbedInboxError: Error?
 
@@ -162,13 +163,14 @@ final class ATTNAPISpy: ATTNAPIProtocol {
         pushToken: String,
         email: String?,
         phone: String?,
-        userIdentity: ATTNUserIdentity
+        visitorId: String
     ) async throws -> Int {
         fetchInboxUnreadCountWasCalled = true
         fetchInboxUnreadCountCallCount += 1
         lastInboxPushToken = pushToken
         lastInboxEmail = email
         lastInboxPhone = phone
+        lastInboxVisitorId = visitorId
         if let error = stubbedInboxError { throw error }
         return stubbedUnreadCount
     }

--- a/Tests/TestCases/ATTNInboxAPITests.swift
+++ b/Tests/TestCases/ATTNInboxAPITests.swift
@@ -29,7 +29,7 @@ final class ATTNInboxAPITests: XCTestCase {
     }
 
     private func fetch(
-        pushToken: String = "fcm:abc123",
+        pushToken: String = "abc123",
         email: String? = nil,
         phone: String? = nil,
         identity: ATTNUserIdentity? = nil
@@ -65,7 +65,7 @@ final class ATTNInboxAPITests: XCTestCase {
 
         XCTAssertNil(json["c"], "domain must not be sent — the server currently rejects it")
         XCTAssertEqual(json["visitor_id"] as? String, userIdentity.visitorId)
-        XCTAssertEqual(json["push_token"] as? String, "fcm:abc123")
+        XCTAssertEqual(json["push_token"] as? String, "apns:abc123", "SDK must prefix the raw device token with the APNs transport scheme")
         XCTAssertEqual(json["email"] as? String, "user@example.com")
         XCTAssertEqual(json["phone"] as? String, "+15551234567")
     }

--- a/Tests/TestCases/ATTNInboxAPITests.swift
+++ b/Tests/TestCases/ATTNInboxAPITests.swift
@@ -38,7 +38,7 @@ final class ATTNInboxAPITests: XCTestCase {
             pushToken: pushToken,
             email: email,
             phone: phone,
-            userIdentity: identity ?? userIdentity
+            visitorId: (identity ?? userIdentity).visitorId
         )
     }
 

--- a/Tests/TestCases/ATTNInboxAPITests.swift
+++ b/Tests/TestCases/ATTNInboxAPITests.swift
@@ -63,7 +63,7 @@ final class ATTNInboxAPITests: XCTestCase {
         let body = try XCTUnwrap(request.httpBody)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
 
-        XCTAssertNil(json["c"], "domain must not be sent — the server currently rejects it")
+        XCTAssertEqual(json["c"] as? String, testDomain)
         XCTAssertEqual(json["visitor_id"] as? String, userIdentity.visitorId)
         XCTAssertEqual(json["push_token"] as? String, "apns:abc123", "SDK must prefix the raw device token with the APNs transport scheme")
         XCTAssertEqual(json["email"] as? String, "user@example.com")
@@ -78,7 +78,7 @@ final class ATTNInboxAPITests: XCTestCase {
         let body = try XCTUnwrap(request.httpBody)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
 
-        XCTAssertNil(json["c"])
+        XCTAssertEqual(json["c"] as? String, testDomain)
         XCTAssertEqual(json["visitor_id"] as? String, emptyIdentity.visitorId)
         XCTAssertNil(json["push_token"])
         XCTAssertNil(json["email"])

--- a/Tests/TestCases/ATTNInboxAPITests.swift
+++ b/Tests/TestCases/ATTNInboxAPITests.swift
@@ -63,6 +63,7 @@ final class ATTNInboxAPITests: XCTestCase {
         let body = try XCTUnwrap(request.httpBody)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
 
+        XCTAssertEqual(json["c"] as? String, testDomain)
         XCTAssertEqual(json["visitor_id"] as? String, userIdentity.visitorId)
         XCTAssertEqual(json["push_token"] as? String, "fcm:abc123")
         XCTAssertEqual(json["email"] as? String, "user@example.com")
@@ -77,6 +78,7 @@ final class ATTNInboxAPITests: XCTestCase {
         let body = try XCTUnwrap(request.httpBody)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
 
+        XCTAssertEqual(json["c"] as? String, testDomain)
         XCTAssertEqual(json["visitor_id"] as? String, emptyIdentity.visitorId)
         XCTAssertNil(json["push_token"])
         XCTAssertNil(json["email"])

--- a/Tests/TestCases/ATTNInboxAPITests.swift
+++ b/Tests/TestCases/ATTNInboxAPITests.swift
@@ -1,0 +1,124 @@
+//
+//  ATTNInboxAPITests.swift
+//  attentive-ios-sdk Tests
+//
+//  Created by Adela Gao on 6/4/26.
+//
+
+import XCTest
+@testable import ATTNSDKFramework
+
+final class ATTNInboxAPITests: XCTestCase {
+    private let testDomain = "some-domain"
+    private var sessionMock: NSURLSessionMock!
+    private var api: ATTNAPI!
+    private var userIdentity: ATTNUserIdentity!
+
+    override func setUp() {
+        super.setUp()
+        sessionMock = NSURLSessionMock()
+        api = ATTNAPI(domain: testDomain, urlSession: sessionMock)
+        userIdentity = ATTNTestEventUtils.buildUserIdentity()
+    }
+
+    override func tearDown() {
+        sessionMock = nil
+        api = nil
+        userIdentity = nil
+        super.tearDown()
+    }
+
+    private func fetch(
+        pushToken: String = "fcm:abc123",
+        email: String? = nil,
+        phone: String? = nil,
+        identity: ATTNUserIdentity? = nil
+    ) async throws -> Int {
+        try await api.fetchInboxUnreadCount(
+            pushToken: pushToken,
+            email: email,
+            phone: phone,
+            userIdentity: identity ?? userIdentity
+        )
+    }
+
+    func testFetchInboxUnreadCount_success_returnsServerCount() async throws {
+        sessionMock.inboxUnreadCountResponseBody = Data("{\"unread_count\": 7}".utf8)
+
+        let count = try await fetch(email: "user@example.com", phone: "+15551234567")
+
+        XCTAssertEqual(count, 7)
+        XCTAssertTrue(sessionMock.didCallInboxUnreadCountApi)
+        XCTAssertEqual(sessionMock.urlCalls.count, 1)
+        XCTAssertEqual(sessionMock.urlCalls[0].absoluteString, "https://mobile.attentivemobile.com/inbox/messages/unread/count")
+    }
+
+    func testFetchInboxUnreadCount_sendsExpectedRequestBody() async throws {
+        _ = try await fetch(email: "user@example.com", phone: "+15551234567")
+
+        let request = try XCTUnwrap(sessionMock.requests.first)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        XCTAssertEqual(json["visitor_id"] as? String, userIdentity.visitorId)
+        XCTAssertEqual(json["push_token"] as? String, "fcm:abc123")
+        XCTAssertEqual(json["email"] as? String, "user@example.com")
+        XCTAssertEqual(json["phone"] as? String, "+15551234567")
+    }
+
+    func testFetchInboxUnreadCount_omitsEmptyOptionalFields() async throws {
+        let emptyIdentity = ATTNUserIdentity()
+        _ = try await fetch(pushToken: "", identity: emptyIdentity)
+
+        let request = try XCTUnwrap(sessionMock.requests.first)
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        XCTAssertEqual(json["visitor_id"] as? String, emptyIdentity.visitorId)
+        XCTAssertNil(json["push_token"])
+        XCTAssertNil(json["email"])
+        XCTAssertNil(json["phone"])
+    }
+
+    func testFetchInboxUnreadCount_serverError_throwsInboxRequestFailed() async {
+        sessionMock.inboxUnreadCountStatusCode = 500
+
+        do {
+            _ = try await fetch()
+            XCTFail("Expected request to throw")
+        } catch ATTNError.inboxRequestFailed(let status) {
+            XCTAssertEqual(status, 500)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testFetchInboxUnreadCount_malformedBody_throwsDecodeFailed() async {
+        sessionMock.inboxUnreadCountResponseBody = Data("not json".utf8)
+
+        do {
+            _ = try await fetch()
+            XCTFail("Expected request to throw")
+        } catch ATTNError.inboxResponseDecodeFailed {
+            // expected
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testFetchInboxUnreadCount_networkError_throwsUnderlyingError() async {
+        let stubError = NSError(domain: "test", code: -1, userInfo: nil)
+        sessionMock.inboxUnreadCountError = stubError
+
+        do {
+            _ = try await fetch()
+            XCTFail("Expected request to throw")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "test")
+            XCTAssertEqual(error.code, -1)
+        }
+    }
+}

--- a/Tests/TestCases/ATTNInboxAPITests.swift
+++ b/Tests/TestCases/ATTNInboxAPITests.swift
@@ -63,7 +63,7 @@ final class ATTNInboxAPITests: XCTestCase {
         let body = try XCTUnwrap(request.httpBody)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
 
-        XCTAssertEqual(json["c"] as? String, testDomain)
+        XCTAssertNil(json["c"], "domain must not be sent — the server currently rejects it")
         XCTAssertEqual(json["visitor_id"] as? String, userIdentity.visitorId)
         XCTAssertEqual(json["push_token"] as? String, "fcm:abc123")
         XCTAssertEqual(json["email"] as? String, "user@example.com")
@@ -78,7 +78,7 @@ final class ATTNInboxAPITests: XCTestCase {
         let body = try XCTUnwrap(request.httpBody)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
 
-        XCTAssertEqual(json["c"] as? String, testDomain)
+        XCTAssertNil(json["c"])
         XCTAssertEqual(json["visitor_id"] as? String, emptyIdentity.visitorId)
         XCTAssertNil(json["push_token"])
         XCTAssertNil(json["email"])

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0A411B432F31DE0400563599 /* InboxResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A411B422F31DDFA00563599 /* InboxResponse.swift */; };
+		0AE0001A377A1AAA00563599 /* InboxUnreadCountResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE00019377A1AAA00563599 /* InboxUnreadCountResponse.swift */; };
 		0A83DEAE2F21A1AA003FD456 /* InboxManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83DEAB2F21A1AA003FD456 /* InboxManager.swift */; };
 		0A83DEAF2F21A1AA003FD456 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83DEAC2F21A1AA003FD456 /* Message.swift */; };
 		0A83DEB22F22C309003FD456 /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83DEB12F22C2F9003FD456 /* InboxView.swift */; };
@@ -49,6 +50,7 @@
 		FB2984042C0F9D650039759C /* ATTNTestEventUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2984032C0F9D650039759C /* ATTNTestEventUtils.swift */; };
 		FB2984062C0FA2DA0039759C /* ATTNEventTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2984052C0FA2DA0039759C /* ATTNEventTrackerTests.swift */; };
 		FB2984082C0FAE040039759C /* ATTNAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2984072C0FAE040039759C /* ATTNAPITests.swift */; };
+		0AE0001C377A1AAC00563599 /* ATTNInboxAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE0001B377A1AAC00563599 /* ATTNInboxAPITests.swift */; };
 		FB2F35B12C18CFFA0016CAE8 /* ATTNSDKFramework.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FB2F35AF2C18CFFA0016CAE8 /* ATTNSDKFramework.podspec */; };
 		FB35C1792C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1782C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift */; };
 		FB35C17B2C0E0353009FA048 /* ATTNIdentifierType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */; };
@@ -122,6 +124,7 @@
 
 /* Begin PBXFileReference section */
 		0A411B422F31DDFA00563599 /* InboxResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxResponse.swift; sourceTree = "<group>"; };
+		0AE00019377A1AAA00563599 /* InboxUnreadCountResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxUnreadCountResponse.swift; sourceTree = "<group>"; };
 		0A812DF42F1827C50082B133 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 		0A83DEAB2F21A1AA003FD456 /* InboxManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxManager.swift; sourceTree = "<group>"; };
 		0A83DEAC2F21A1AA003FD456 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
@@ -178,6 +181,7 @@
 		FB2984032C0F9D650039759C /* ATTNTestEventUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNTestEventUtils.swift; sourceTree = "<group>"; };
 		FB2984052C0FA2DA0039759C /* ATTNEventTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNEventTrackerTests.swift; sourceTree = "<group>"; };
 		FB2984072C0FAE040039759C /* ATTNAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNAPITests.swift; sourceTree = "<group>"; };
+		0AE0001B377A1AAC00563599 /* ATTNInboxAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxAPITests.swift; sourceTree = "<group>"; };
 		FB2F35AF2C18CFFA0016CAE8 /* ATTNSDKFramework.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ATTNSDKFramework.podspec; sourceTree = "<group>"; };
 		FB35C1782C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNCreativeTriggerStatus.swift; sourceTree = "<group>"; };
 		FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNIdentifierType.swift; sourceTree = "<group>"; };
@@ -273,6 +277,7 @@
 			isa = PBXGroup;
 			children = (
 				0A411B422F31DDFA00563599 /* InboxResponse.swift */,
+				0AE00019377A1AAA00563599 /* InboxUnreadCountResponse.swift */,
 				0A83DEAC2F21A1AA003FD456 /* Message.swift */,
 			);
 			path = Models;
@@ -426,6 +431,7 @@
 				FB2983FF2C0F86270039759C /* ATTNCreativeUrlFormatterTests.swift */,
 				FB2984052C0FA2DA0039759C /* ATTNEventTrackerTests.swift */,
 				FB2984072C0FAE040039759C /* ATTNAPITests.swift */,
+				0AE0001B377A1AAC00563599 /* ATTNInboxAPITests.swift */,
 				FB90EF0A2C109CB4004DFC4A /* ATTNAPIITTests.swift */,
 				FB6553692C1B72D4008DB3B1 /* ATTNSDKTests.swift */,
 				FB86C03D2C40611A00E35580 /* ATTNAddToCartEventTests.swift */,
@@ -762,6 +768,7 @@
 				FB35C18D2C0E3FAA009FA048 /* ATTNUserIdentity+Extension.swift in Sources */,
 				FB35C1832C0E1FD7009FA048 /* URLSession+Extension.swift in Sources */,
 				0A411B432F31DE0400563599 /* InboxResponse.swift in Sources */,
+				0AE0001A377A1AAA00563599 /* InboxUnreadCountResponse.swift in Sources */,
 				FB35C1872C0E3929009FA048 /* ATTNEventTypes.swift in Sources */,
 				FBA9FA162C0A77AB00C65024 /* ATTNPrice.swift in Sources */,
 				FB35C1912C0E506D009FA048 /* ATTNEventRequestProvider.swift in Sources */,
@@ -834,6 +841,7 @@
 				FB080C722C1C755F00834BAA /* ATTNCreativeUrlProviderSpy.swift in Sources */,
 				FB2983E52C0F73990039759C /* ATTNUserAgentBuilderMock.swift in Sources */,
 				FB2984082C0FAE040039759C /* ATTNAPITests.swift in Sources */,
+				0AE0001C377A1AAC00563599 /* ATTNInboxAPITests.swift in Sources */,
 				FB65536A2C1B72D4008DB3B1 /* ATTNSDKTests.swift in Sources */,
 				FB90EF0D2C10A7F7004DFC4A /* NSURLSessionDataTaskMock.swift in Sources */,
 				FB2983FE2C0F85770039759C /* ATTNCustomEventTests.swift in Sources */,


### PR DESCRIPTION
## Summary
- Adds async `fetchInboxUnreadCount` on `ATTNAPI` that calls `POST /inbox/messages/unread/count` per the Inbox RFC, with `visitor_id` / `push_token` / `email` / `phone` in the payload.
- `InboxManager.unreadCount` is now **server-authoritative** — replaces the prior locally-derived value (computed from `messagesByID.values.filter { !$0.isRead }`). Local `markRead`/`markUnread` no longer mutate it; future mark-read API responses will (separate ticket).
- Exposes new public `ATTNSDK.refreshInboxUnreadCount()` so host apps can refresh on app launch / push open per RFC guidance.
- `InboxManager.init` now fans out the mock-message load and the unread-count fetch concurrently via `async let`.

## Jira
https://attentivemobile.atlassian.net/browse/MSDK-377

## Out of scope (future tickets)
- The `/inbox/messages` list fetch — still uses the existing mock generator.
- `mark-read`, `mark-unread`, `delete`, `track-click` endpoints.
- Centralizing identity-forwarding for additional inbox endpoints (will revisit when the 2nd inbox endpoint lands).

## Test plan
- [x] New `ATTNInboxAPITests` (6 tests) — success, body shape, omitted-empty fields, server error, malformed JSON, network error
- [x] `ATTNAPITests` and `ATTNSDKTests` still pass
- [ ] Manual: hit the real endpoint from Bonni once the backend is deployed; verify `await sdk.unreadCount` returns the server value after `refreshInboxUnreadCount()`

## Notes for reviewers
- Base branch is **develop** (not main) — Inbox is an experimental feature behind that branch.
- Heads up: `develop` is currently behind `main` by ~30 commits (MSDK-371/370/312/354/315/344, etc.) — separate ticket to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)