### PR TITLE
MSDK-312: bump concurrency test timeouts for CI headroom

### DIFF
--- a/Tests/TestCases/ATTNUserIdentityTests.swift
+++ b/Tests/TestCases/ATTNUserIdentityTests.swift
@@ -100,7 +100,7 @@ final class ATTNUserIdentityTests: XCTestCase {
 
     func testMergeAndRead_concurrentReadersAndWriters_doesNotCrash() {
         let identity = ATTNUserIdentity(identifiers: [ATTNIdentifierType.email: "seed@test.com"])
-        runConcurrently(iterations: 200, queueLabels: ["writer", "reader"]) { i, queueIndex in
+        runConcurrently(iterations: 200, timeout: 15, queueLabels: ["writer", "reader"]) { i, queueIndex in
             if queueIndex == 0 {
                 identity.mergeIdentifiers([ATTNIdentifierType.email: "user\(i)@test.com"])
             } else {
@@ -115,7 +115,7 @@ final class ATTNUserIdentityTests: XCTestCase {
         // Iteration count kept low because clearUser() does a synchronous
         // UserDefaults write per call; 20×2 racing calls is plenty to surface
         // a missing-lock crash without blowing CI's timeout budget on disk I/O.
-        runConcurrently(iterations: 20, timeout: 10, queueLabels: ["merge", "clear"]) { i, queueIndex in
+        runConcurrently(iterations: 20, timeout: 20, queueLabels: ["merge", "clear"]) { i, queueIndex in
             if queueIndex == 0 {
                 identity.mergeIdentifiers([ATTNIdentifierType.email: "user\(i)@test.com"])
             } else {


### PR DESCRIPTION
Two `ATTNUserIdentity` stress tests have been timing out on the CI iPhone-17-Pro simulator even on rerun:

- `testMergeAndRead_concurrentReadersAndWriters_doesNotCrash` — 200×2 iterations through `NSLock`, was using the 5s `runConcurrently` default
- `testClearUser_concurrentClearAndMerge_doesNotCrash` — 20×2 iterations where `clearUser()` does a synchronous `UserDefaults` write inside the lock, was at 10s

Bump the budgets to **15s** and **20s** respectively. The tests assert no-crash under contention, so the cost of a generous timeout is just slightly longer wall clock when CI is loaded; the cost of a tight one is repeated false failures.

## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Tests
- [ ] Other

[MSDK-312](https://attentivemobile.atlassian.net/browse/MSDK-312)

## What's new?

Raises the per-test timeouts on the two `ATTNUserIdentity` concurrency stress tests so they have headroom on CI's shared iPhone-17-Pro simulator. No production code changes; no change to what the tests assert (still no-crash under racing reads/writes/clears).

Prior MSDK-312 history that boxed us into this fix:
- `2b819df` hoisted `createNewVisitorId()` out of the `clearUser` lock to relieve disk-I/O serialization.
- `862358a` reverted it — Adela flagged that disk writes outside the lock can land in `UserDefaults` in a different order than the in-memory swap, leaving the next app launch with a stale visitor id.
- `654772e` dropped the `clearUser` test iteration count 100 → 20 and bumped its timeout 5s → 10s. That held for a while but is now insufficient on the current CI image.

The cleanest follow-up (out of scope here) would be to generate the UUID outside the lock but keep `save` + in-memory swap inside it — preserves write-order correctness and removes one syscall from the critical section.

## Testing

- Reran the failing CircleCI workflow twice on the prior branch; both runs failed on the same two tests.
- Locally re-running the suite stays green.
- This PR's CI run is the validation.

## Screenshots

n/a

[MSDK-312]: https://attentivemobile.atlassian.net/browse/MSDK-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ