### PR TITLE
MSDK-417: document pushEnabled opt-out in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,40 @@ ATTNSDK *sdk = [[ATTNSDK alloc] initWithDomain:@"myCompanyDomain" mode:@"debug"]
 [ATTNEventTracker setupWithSDk:sdk];
 ```
 
+### Opting out of push (for apps that don't use Attentive for push)
+
+If another provider owns push on your app, pass `pushEnabled: false` at init. The SDK will then:
+
+- **Not** request push permission, register with APNs, or store any push token.
+- **Not** observe `UIApplication.didBecomeActiveNotification`, so `handleRegularOpen` is never fired automatically.
+- Treat every push entry point (`registerForPushNotifications`, `registerDeviceToken`, `failedToRegisterForPush`, `handleRegularOpen`, `handleForegroundPush`, `handlePushOpen`) as a no-op if you call them.
+- Continue to support all other features completely: identity (`identify` / `clearUser` / `updateUser`), events (Step 3), email/SMS subscriptions (Step 5), and creatives (Step 6).
+
+Email/SMS opt-in and opt-out (Step 5) still work: with `pushEnabled: false`, requests are sent immediately without a push token (rather than queueing until one is available, which is the push-enabled behavior).
+
+The default is `pushEnabled: true`; only set this to `false` if Attentive is not your push provider.
+
+#### Swift
+```swift
+ATTNSDK.initialize(domain: "myCompanyDomain", mode: .production, pushEnabled: false) { result in
+  switch result {
+  case .success(let sdk):
+    self.attentiveSdk = sdk
+    ATTNEventTracker.setup(with: sdk)
+  case .failure(let error):
+    print("Attentive SDK failed to initialize: \(error)")
+  }
+}
+```
+
+#### Objective-C
+```objective-c
+ATTNSDK *sdk = [[ATTNSDK alloc] initWithDomain:@"myCompanyDomain" mode:@"production" pushEnabled:NO];
+[ATTNEventTracker setupWithSDk:sdk];
+```
+
+When `pushEnabled` is `false`, you can skip **Step 4 - Integrate With Push** entirely; the calls in that section are no-ops in this mode.
+
 ## Step 2 - Identify the current user
 
 When you gather information about the current user (user ID, email, phone, etc), you can pass it to Attentive for identification purposes via the `identify` function. You can call identify every time to add any additional information about the user.
@@ -395,6 +429,9 @@ ATTNCustomEvent* customEvent = [[ATTNCustomEvent alloc] initWithType:@"Concert V
 ```
 
 ## Step 4 - Integrate With Push
+
+> If Attentive is not your push provider, initialize the SDK with `pushEnabled: false` and skip this step — see [Opting out of push](#opting-out-of-push-for-apps-that-dont-use-attentive-for-push) under Step 1.
+
 #### Swift
 
 Show push permission prompt:

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ ATTNSDK *sdk = [[ATTNSDK alloc] initWithDomain:@"myCompanyDomain"];
 
 ATTNSDK *sdk = [[ATTNSDK alloc] initWithDomain:@"myCompanyDomain" mode:@"debug"];
 
-[ATTNEventTracker setupWithSDk:sdk];
+[ATTNEventTracker setupWithSdk:sdk];
 ```
 
 ### Opting out of push (for apps that don't use Attentive for push)
@@ -132,7 +132,10 @@ If another provider owns push on your app, pass `pushEnabled: false` at init. Th
 - **Not** request push permission, register with APNs, or store any push token.
 - **Not** observe `UIApplication.didBecomeActiveNotification`, so `handleRegularOpen` is never fired automatically.
 - Treat every push entry point (`registerForPushNotifications`, `registerDeviceToken`, `failedToRegisterForPush`, `handleRegularOpen`, `handleForegroundPush`, `handlePushOpen`) as a no-op if you call them.
-- Continue to support all other features completely: identity (`identify` / `clearUser` / `updateUser`), events (Step 3), email/SMS subscriptions (Step 5), and creatives (Step 6).
+- Continue to support: `identify` and `clearUser`, events (Step 3), email/SMS subscriptions (Step 5), and creatives (Step 6).
+
+> [!NOTE]
+> **`updateUser` currently requires a push token.** `updateUser(email:phone:callback:)` will abort with `ATTNSDKError.missingPushToken` when no token is available, which will always be the case with `pushEnabled: false`. Use `clearUser()` followed by `identify(...)` to switch users on non-push installs until this is relaxed in a future SDK release.
 
 Email/SMS opt-in and opt-out (Step 5) still work: with `pushEnabled: false`, requests are sent immediately without a push token (rather than queueing until one is available, which is the push-enabled behavior).
 
@@ -154,7 +157,7 @@ ATTNSDK.initialize(domain: "myCompanyDomain", mode: .production, pushEnabled: fa
 #### Objective-C
 ```objective-c
 ATTNSDK *sdk = [[ATTNSDK alloc] initWithDomain:@"myCompanyDomain" mode:@"production" pushEnabled:NO];
-[ATTNEventTracker setupWithSDk:sdk];
+[ATTNEventTracker setupWithSdk:sdk];
 ```
 
 When `pushEnabled` is `false`, you can skip **Step 4 - Integrate With Push** entirely; the calls in that section are no-ops in this mode.


### PR DESCRIPTION
## Summary

- Adds a Step 1 subsection ("Opting out of push") explaining the `pushEnabled: false` init option for apps where another provider (Braze, Airship, OneSignal, in-house, etc.) owns push.
- Documents exactly what the SDK skips in this mode (APNs registration, push token storage, `didBecomeActive` observer, all six push entry points) and what still works (identity, events, email/SMS subs, creatives).
- Calls out the specific email/SMS opt-in/opt-out behavior change: with `pushEnabled: false`, requests fire immediately instead of queueing for a push token.
- Provides Swift and Objective-C init snippets for the opt-out.
- Adds a pointer at the top of Step 4 - Integrate With Push linking readers back to the opt-out section.

Docs-only change; no code touched. Related PR that introduced the option: #254.

Jira: https://attentivemobile.atlassian.net/browse/MSDK-417

## Test plan

- [ ] Read the rendered README on GitHub and confirm the new subsection reads cleanly under Step 1.
- [ ] Confirm the anchor link from Step 4 (`#opting-out-of-push-for-apps-that-dont-use-attentive-for-push`) resolves on the rendered page.
- [ ] Sanity-check the Swift/Obj-C snippets against `ATTNSDK.init(domain:mode:pushEnabled:)` and `initWithDomain:mode:pushEnabled:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)