### PR TITLE
Document write-pr skill in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,17 @@ If you've previously added the marketplace but don't see `mobile-sdk-internal`, 
 
 This keeps internal details out of the public SDK repo while letting Claude Code pull them in at runtime.
 
+### Drafting a PR description
+
+Once the `mobile-sdk-internal` plugin is installed, use its `write-pr` skill to draft PR descriptions that meet the mobile SDK team's expectations (verification with platform/OS coverage, public API impact, host-app rollback):
+
+```
+/mobile-sdk-internal:write-pr           # new PR
+/mobile-sdk-internal:write-pr --update  # update existing PR on this branch
+```
+
+The skill detects this repo from the git remote, confirms the base branch (important for `develop`-targeted PRs), reads the diff, and asks targeted questions before drafting.
+
 ## Build & Test
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a pointer in `CLAUDE.md` to the new `write-pr` skill in the `mobile-sdk-internal` plugin, so engineers using Claude Code on this repo know it exists and how to invoke it.

## Key Changes

- New "Drafting a PR description" subsection under the existing "Internal API Documentation" section.
- Documents both `/mobile-sdk-internal:write-pr` (new PR) and `/mobile-sdk-internal:write-pr --update` (existing PR).
- Calls out that the skill confirms the base branch, which matters here since experimental features target \`develop\` rather than \`main\`.

## Public API Impact

None — documentation only.

## Verification

Rendered the markdown locally and confirmed the new section fits under the existing plugin install instructions without disrupting the rest of the file.

## Risk

Low. Docs-only change. No source or build impact.

## Rollback

Revert this PR.