### PR TITLE
MSDK-410: wire real endpoint for mark message read

### DIFF
--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -490,6 +490,58 @@ final class ATTNAPI: ATTNAPIProtocol {
         }
     }
 
+    /// Marks the supplied messages as read on the server.
+    ///
+    /// PATCH /inbox/messages/read — identifier-based (visitor_id + push_token), body carries
+    /// the list of message ids. The response echoes the per-message read status and the
+    /// updated unread count so the caller can reconcile local state without a follow-up fetch.
+    func markMessagesRead(
+        pushToken: String,
+        visitorId: String,
+        messageIds: [String]
+    ) async throws -> UpdateReadStatusResponse {
+        Loggers.network.debug("Marking inbox messages read - Visitor ID: \(visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public), Count: \(messageIds.count, privacy: .public)")
+
+        var payload: [String: Any] = [
+            "visitor_id": visitorId,
+            "message_ids": messageIds
+        ]
+        if !pushToken.isEmpty { payload["push_token"] = pushToken }
+
+        guard let url = URL(string: "https://mobile.attentivemobile.com/inbox/messages/read") else {
+            Loggers.network.error("Invalid inbox mark-read URL")
+            throw ATTNError.badURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        request.timeoutInterval = 15
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+        Loggers.network.debug("PATCH /inbox/messages/read")
+
+        let (data, response) = try await dataTask(with: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            Loggers.network.error("Inbox mark-read returned a non-HTTP response")
+            throw ATTNError.inboxResponseDecodeFailed
+        }
+        Loggers.network.debug("Inbox mark-read status code: \(http.statusCode, privacy: .public)")
+        guard (200..<300).contains(http.statusCode) else {
+            Loggers.network.error("Inbox mark-read API returned status \(http.statusCode, privacy: .public)")
+            throw ATTNError.inboxRequestFailed(statusCode: http.statusCode)
+        }
+
+        do {
+            return try JSONDecoder().decode(UpdateReadStatusResponse.self, from: data)
+        } catch {
+            Loggers.network.error("Failed to decode inbox mark-read response: \(error.localizedDescription, privacy: .public)")
+            throw ATTNError.inboxResponseDecodeFailed
+        }
+    }
+
     private static let inboxJSONDecoder: JSONDecoder = {
         let decoder = JSONDecoder()
         // Accept ISO-8601 timestamps with or without fractional seconds. Foundation's built-in

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -502,11 +502,11 @@ final class ATTNAPI: ATTNAPIProtocol {
     ) async throws -> UpdateReadStatusResponse {
         Loggers.network.debug("Marking inbox messages read - Visitor ID: \(visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public), Count: \(messageIds.count, privacy: .public)")
 
-        var payload: [String: Any] = [
-            "visitor_id": visitorId,
-            "message_ids": messageIds
-        ]
-        if !pushToken.isEmpty { payload["push_token"] = pushToken }
+        let body = UpdateReadStatusRequest(
+            visitorId: visitorId,
+            pushToken: Self.inboxPushToken(pushToken),
+            messageIds: messageIds
+        )
 
         guard let url = URL(string: "https://mobile.attentivemobile.com/inbox/messages/read") else {
             Loggers.network.error("Invalid inbox mark-read URL")
@@ -518,7 +518,7 @@ final class ATTNAPI: ATTNAPIProtocol {
         request.timeoutInterval = 15
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
-        request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
+        request.httpBody = try JSONEncoder().encode(body)
 
         Loggers.network.debug("PATCH /inbox/messages/read")
 
@@ -540,6 +540,13 @@ final class ATTNAPI: ATTNAPIProtocol {
             Loggers.network.error("Failed to decode inbox mark-read response: \(error.localizedDescription, privacy: .public)")
             throw ATTNError.inboxResponseDecodeFailed
         }
+    }
+
+    /// The inbox backend expects push tokens namespaced by transport (e.g. `apns:<token>`).
+    /// Returns `nil` for an empty token so `push_token` is omitted from the request body
+    /// rather than sent as an empty (and unusable) identifier.
+    private static func inboxPushToken(_ pushToken: String) -> String? {
+        pushToken.isEmpty ? nil : "apns:\(pushToken)"
     }
 
     private static let inboxJSONDecoder: JSONDecoder = {

--- a/Sources/API/ATTNAPIProtocol.swift
+++ b/Sources/API/ATTNAPIProtocol.swift
@@ -95,4 +95,12 @@ protocol ATTNAPIProtocol {
         pageSize: Int,
         pageToken: String?
     ) async throws -> InboxResponse
+
+    /// Marks the supplied messages as read on the server. Returns the server-confirmed
+    /// per-message read status and the resulting authoritative unread count.
+    func markMessagesRead(
+        pushToken: String,
+        visitorId: String,
+        messageIds: [String]
+    ) async throws -> UpdateReadStatusResponse
 }

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -52,9 +52,10 @@ actor InboxManager {
     /// load returning inside the refresh window resets that flag but must not release this one.
     private var isRefreshingFirstPage: Bool = false
 
-    /// Server-authoritative unread count. Only `refreshUnreadCount()` writes it; local
-    /// `markRead` / `markUnread` do not. Reads should go through the `unreadCount` accessor,
-    /// which awaits the init-time refresh so the first read never returns a stale 0.
+    /// Server-authoritative unread count. Written by `refreshUnreadCount()` and by the mark-read
+    /// API response (see `applyReadStatusResponse`); local `markUnread` does not touch it. Reads
+    /// should go through the `unreadCount` accessor, which awaits the init-time refresh so the
+    /// first read never returns a stale 0.
     private var storedUnreadCount: Int = 0
 
     private let api: ATTNAPIProtocol
@@ -332,10 +333,35 @@ actor InboxManager {
         }
     }
 
-    func markRead(_ messageID: Message.ID) {
-        guard messagesByID[messageID]?.isRead == false else { return }
-        messagesByID[messageID]?.isRead = true
-        send(.loaded(orderedMessagesSnapshot()))
+    /// Marks a message read. Optimistically flips the local state, then reconciles from the
+    /// server response. On failure the local flip is reverted so the UI reflects true state.
+    func markRead(_ messageID: Message.ID) async {
+        guard let previousIsRead = messagesByID[messageID]?.isRead else { return }
+        if !previousIsRead {
+            messagesByID[messageID]?.isRead = true
+            send(.loaded(allMessages))
+        }
+
+        let identity = identityProvider()
+        guard !identity.visitorId.isEmpty else {
+            Loggers.network.debug("Skipping inbox mark-read: empty visitor ID")
+            return
+        }
+
+        do {
+            let response = try await api.markMessagesRead(
+                pushToken: identity.pushToken,
+                visitorId: identity.visitorId,
+                messageIds: [messageID]
+            )
+            applyReadStatusResponse(response)
+        } catch {
+            Loggers.network.error("Failed to mark inbox message read: \(error.localizedDescription, privacy: .public)")
+            if messagesByID[messageID] != nil, !previousIsRead {
+                messagesByID[messageID]?.isRead = previousIsRead
+                send(.loaded(allMessages))
+            }
+        }
     }
 
     func markUnread(_ messageID: Message.ID) {
@@ -417,5 +443,15 @@ extension InboxManager {
             messagesByID[message.id] = message
             messageOrder.append(message.id)
         }
+    }
+
+    /// Reconcile per-message read status and the authoritative unread count from a
+    /// mark-read/mark-unread response.
+    private func applyReadStatusResponse(_ response: UpdateReadStatusResponse) {
+        for status in response.messages {
+            messagesByID[status.messageId]?.isRead = status.isRead
+        }
+        unreadCount = response.unreadCount
+        send(.loaded(allMessages))
     }
 }

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -337,10 +337,6 @@ actor InboxManager {
     /// server response. On failure the local flip is reverted so the UI reflects true state.
     func markRead(_ messageID: Message.ID) async {
         guard let previousIsRead = messagesByID[messageID]?.isRead else { return }
-        if !previousIsRead {
-            messagesByID[messageID]?.isRead = true
-            send(.loaded(allMessages))
-        }
 
         let identity = identityProvider()
         guard !identity.visitorId.isEmpty else {
@@ -348,18 +344,31 @@ actor InboxManager {
             return
         }
 
+        if !previousIsRead {
+            messagesByID[messageID]?.isRead = true
+            send(.loaded(orderedMessagesSnapshot()))
+        }
+
+        // Snapshot the refresh generation before the request. If an identity change
+        // (`resetForIdentityChange`) or a newer `refreshUnreadCount` lands while the PATCH is in
+        // flight, the generation advances and we drop this now-stale response instead of
+        // restoring an old unread count.
+        let generation = refreshGeneration
+
         do {
             let response = try await api.markMessagesRead(
                 pushToken: identity.pushToken,
                 visitorId: identity.visitorId,
                 messageIds: [messageID]
             )
+            guard generation == refreshGeneration else { return }
             applyReadStatusResponse(response)
         } catch {
             Loggers.network.error("Failed to mark inbox message read: \(error.localizedDescription, privacy: .public)")
+            guard generation == refreshGeneration else { return }
             if messagesByID[messageID] != nil, !previousIsRead {
                 messagesByID[messageID]?.isRead = previousIsRead
-                send(.loaded(allMessages))
+                send(.loaded(orderedMessagesSnapshot()))
             }
         }
     }
@@ -451,7 +460,7 @@ extension InboxManager {
         for status in response.messages {
             messagesByID[status.messageId]?.isRead = status.isRead
         }
-        unreadCount = response.unreadCount
-        send(.loaded(allMessages))
+        storedUnreadCount = response.unreadCount
+        send(.loaded(orderedMessagesSnapshot()))
     }
 }

--- a/Sources/Inbox/Models/UpdateReadStatusResponse.swift
+++ b/Sources/Inbox/Models/UpdateReadStatusResponse.swift
@@ -5,6 +5,21 @@
 
 import Foundation
 
+/// Request body shared by the mark-read (`PATCH /inbox/messages/read`) and mark-unread
+/// (`PATCH /inbox/messages/unread`) endpoints. `pushToken` is optional so an empty token is
+/// omitted from the wire payload rather than sent as `""`.
+struct UpdateReadStatusRequest: Encodable {
+    let visitorId: String
+    let pushToken: String?
+    let messageIds: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case visitorId = "visitor_id"
+        case pushToken = "push_token"
+        case messageIds = "message_ids"
+    }
+}
+
 struct UpdateReadStatusResponse: Codable {
     struct MessageReadStatus: Codable {
         let messageId: String

--- a/Sources/Inbox/Models/UpdateReadStatusResponse.swift
+++ b/Sources/Inbox/Models/UpdateReadStatusResponse.swift
@@ -1,0 +1,26 @@
+//
+//  UpdateReadStatusResponse.swift
+//  attentive-ios-sdk
+//
+
+import Foundation
+
+struct UpdateReadStatusResponse: Codable {
+    struct MessageReadStatus: Codable {
+        let messageId: String
+        let isRead: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case messageId = "message_id"
+            case isRead = "is_read"
+        }
+    }
+
+    let messages: [MessageReadStatus]
+    let unreadCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case messages
+        case unreadCount = "unread_count"
+    }
+}

--- a/Tests/Doubles/Mocks/NSURLSessionMock.swift
+++ b/Tests/Doubles/Mocks/NSURLSessionMock.swift
@@ -12,6 +12,7 @@ class NSURLSessionMock: URLSession {
     var didCallEventsApi = false
     var didCallInboxUnreadCountApi = false
     var didCallInboxMessagesApi = false
+    var didCallInboxMarkReadApi = false
     var urlCalls: [URL] = []
     var requests: [URLRequest] = []
 
@@ -26,6 +27,12 @@ class NSURLSessionMock: URLSession {
     var inboxMessagesStatusCode: Int = 200
     var inboxMessagesResponseBody: Data = Data("{\"messages\": []}".utf8)
     var inboxMessagesError: Error?
+
+    /// Override the response returned for the mark-read endpoint.
+    /// Default: 200 with an empty per-message list and unread_count=0.
+    var inboxMarkReadStatusCode: Int = 200
+    var inboxMarkReadResponseBody: Data = Data("{\"messages\": [], \"unread_count\": 0}".utf8)
+    var inboxMarkReadError: Error?
 
     override init() {
         super.init()
@@ -45,12 +52,23 @@ class NSURLSessionMock: URLSession {
             }
 
             // Order matters: check the more specific `/inbox/messages/unread/count` before the
-            // `/inbox/messages` prefix so the general check doesn't shadow it.
+            // `/inbox/messages/read` and `/inbox/messages` prefixes so the general checks
+            // don't shadow it.
             if url.absoluteString.contains("/inbox/messages/unread/count") {
                 didCallInboxUnreadCountApi = true
                 let body = inboxUnreadCountResponseBody
                 let status = inboxUnreadCountStatusCode
                 let error = inboxUnreadCountError
+                return NSURLSessionDataTaskMock { _, _, _ in
+                    completionHandler(body, HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil), error)
+                }
+            }
+
+            if url.absoluteString.hasSuffix("/inbox/messages/read") {
+                didCallInboxMarkReadApi = true
+                let body = inboxMarkReadResponseBody
+                let status = inboxMarkReadStatusCode
+                let error = inboxMarkReadError
                 return NSURLSessionDataTaskMock { _, _, _ in
                     completionHandler(body, HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil), error)
                 }

--- a/Tests/Doubles/Spies/ATTNAPISpy.swift
+++ b/Tests/Doubles/Spies/ATTNAPISpy.swift
@@ -226,6 +226,9 @@ final class ATTNAPISpy: ATTNAPIProtocol {
         messages: [],
         unreadCount: 0
     )
+    /// Invoked while the mark-read call is "in flight" (after recording, before returning), letting
+    /// a test interleave an identity change/refresh to exercise stale-response handling.
+    var onMarkMessagesRead: (@Sendable () async -> Void)?
 
     func markMessagesRead(
         pushToken: String,
@@ -237,6 +240,7 @@ final class ATTNAPISpy: ATTNAPIProtocol {
         lastMarkReadPushToken = pushToken
         lastMarkReadVisitorId = visitorId
         lastMarkReadMessageIds = messageIds
+        if let hook = onMarkMessagesRead { await hook() }
         if let error = stubbedMarkReadError { throw error }
         return stubbedMarkReadResponse
     }

--- a/Tests/Doubles/Spies/ATTNAPISpy.swift
+++ b/Tests/Doubles/Spies/ATTNAPISpy.swift
@@ -214,4 +214,30 @@ final class ATTNAPISpy: ATTNAPIProtocol {
         let index = min(callIndex, stubbedInboxMessagesResponses.count - 1)
         return stubbedInboxMessagesResponses[index]
     }
+
+    // MARK: - Mark Messages Read
+    private(set) var markMessagesReadWasCalled = false
+    private(set) var markMessagesReadCallCount = 0
+    private(set) var lastMarkReadPushToken: String?
+    private(set) var lastMarkReadVisitorId: String?
+    private(set) var lastMarkReadMessageIds: [String]?
+    var stubbedMarkReadError: Error?
+    var stubbedMarkReadResponse: UpdateReadStatusResponse = UpdateReadStatusResponse(
+        messages: [],
+        unreadCount: 0
+    )
+
+    func markMessagesRead(
+        pushToken: String,
+        visitorId: String,
+        messageIds: [String]
+    ) async throws -> UpdateReadStatusResponse {
+        markMessagesReadWasCalled = true
+        markMessagesReadCallCount += 1
+        lastMarkReadPushToken = pushToken
+        lastMarkReadVisitorId = visitorId
+        lastMarkReadMessageIds = messageIds
+        if let error = stubbedMarkReadError { throw error }
+        return stubbedMarkReadResponse
+    }
 }

--- a/Tests/TestCases/ATTNInboxMarkReadAPITests.swift
+++ b/Tests/TestCases/ATTNInboxMarkReadAPITests.swift
@@ -1,0 +1,131 @@
+//
+//  ATTNInboxMarkReadAPITests.swift
+//  attentive-ios-sdk Tests
+//
+
+import XCTest
+@testable import ATTNSDKFramework
+
+final class ATTNInboxMarkReadAPITests: XCTestCase {
+    private let testDomain = "some-domain"
+    private var sessionMock: NSURLSessionMock!
+    private var api: ATTNAPI!
+    private var userIdentity: ATTNUserIdentity!
+
+    override func setUp() {
+        super.setUp()
+        sessionMock = NSURLSessionMock()
+        api = ATTNAPI(domain: testDomain, urlSession: sessionMock)
+        userIdentity = ATTNTestEventUtils.buildUserIdentity()
+    }
+
+    override func tearDown() {
+        sessionMock = nil
+        api = nil
+        userIdentity = nil
+        super.tearDown()
+    }
+
+    private func markRead(
+        pushToken: String = "fcm:abc123",
+        messageIds: [String] = ["msg-1"],
+        identity: ATTNUserIdentity? = nil
+    ) async throws -> UpdateReadStatusResponse {
+        try await api.markMessagesRead(
+            pushToken: pushToken,
+            visitorId: (identity ?? userIdentity).visitorId,
+            messageIds: messageIds
+        )
+    }
+
+    func testMarkRead_success_decodesServerResponse() async throws {
+        sessionMock.inboxMarkReadResponseBody = Data("""
+        {
+          "messages": [
+            {"message_id": "msg-1", "is_read": true},
+            {"message_id": "msg-2", "is_read": true}
+          ],
+          "unread_count": 3
+        }
+        """.utf8)
+
+        let response = try await markRead(messageIds: ["msg-1", "msg-2"])
+
+        XCTAssertEqual(response.unreadCount, 3)
+        XCTAssertEqual(response.messages.count, 2)
+        XCTAssertEqual(response.messages.first?.messageId, "msg-1")
+        XCTAssertTrue(response.messages.first?.isRead ?? false)
+        XCTAssertTrue(sessionMock.didCallInboxMarkReadApi)
+        XCTAssertEqual(sessionMock.urlCalls.count, 1)
+        XCTAssertEqual(sessionMock.urlCalls[0].absoluteString, "https://mobile.attentivemobile.com/inbox/messages/read")
+    }
+
+    func testMarkRead_sendsExpectedRequest() async throws {
+        _ = try await markRead(messageIds: ["msg-1", "msg-2"])
+
+        let request = try XCTUnwrap(sessionMock.requests.first)
+        XCTAssertEqual(request.httpMethod, "PATCH")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        XCTAssertEqual(json["visitor_id"] as? String, userIdentity.visitorId)
+        XCTAssertEqual(json["push_token"] as? String, "fcm:abc123")
+        XCTAssertEqual(json["message_ids"] as? [String], ["msg-1", "msg-2"])
+        // Contract carries only visitor_id / push_token / message_ids — no domain, email, phone.
+        XCTAssertNil(json["c"])
+        XCTAssertNil(json["email"])
+        XCTAssertNil(json["phone"])
+    }
+
+    func testMarkRead_omitsEmptyPushToken() async throws {
+        _ = try await markRead(pushToken: "")
+
+        let request = try XCTUnwrap(sessionMock.requests.first)
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        XCTAssertNil(json["push_token"])
+        XCTAssertEqual(json["visitor_id"] as? String, userIdentity.visitorId)
+    }
+
+    func testMarkRead_serverError_throwsInboxRequestFailed() async {
+        sessionMock.inboxMarkReadStatusCode = 500
+
+        do {
+            _ = try await markRead()
+            XCTFail("Expected request to throw")
+        } catch ATTNError.inboxRequestFailed(let status) {
+            XCTAssertEqual(status, 500)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testMarkRead_malformedBody_throwsDecodeFailed() async {
+        sessionMock.inboxMarkReadResponseBody = Data("not json".utf8)
+
+        do {
+            _ = try await markRead()
+            XCTFail("Expected request to throw")
+        } catch ATTNError.inboxResponseDecodeFailed {
+            // expected
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testMarkRead_networkError_throwsUnderlyingError() async {
+        let stubError = NSError(domain: "test", code: -1, userInfo: nil)
+        sessionMock.inboxMarkReadError = stubError
+
+        do {
+            _ = try await markRead()
+            XCTFail("Expected request to throw")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "test")
+            XCTAssertEqual(error.code, -1)
+        }
+    }
+}

--- a/Tests/TestCases/ATTNInboxMarkReadAPITests.swift
+++ b/Tests/TestCases/ATTNInboxMarkReadAPITests.swift
@@ -27,7 +27,7 @@ final class ATTNInboxMarkReadAPITests: XCTestCase {
     }
 
     private func markRead(
-        pushToken: String = "fcm:abc123",
+        pushToken: String = "abc123devicetoken",
         messageIds: [String] = ["msg-1"],
         identity: ATTNUserIdentity? = nil
     ) async throws -> UpdateReadStatusResponse {
@@ -71,7 +71,8 @@ final class ATTNInboxMarkReadAPITests: XCTestCase {
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
 
         XCTAssertEqual(json["visitor_id"] as? String, userIdentity.visitorId)
-        XCTAssertEqual(json["push_token"] as? String, "fcm:abc123")
+        // Push tokens are namespaced by transport for the inbox backend.
+        XCTAssertEqual(json["push_token"] as? String, "apns:abc123devicetoken")
         XCTAssertEqual(json["message_ids"] as? [String], ["msg-1", "msg-2"])
         // Contract carries only visitor_id / push_token / message_ids — no domain, email, phone.
         XCTAssertNil(json["c"])

--- a/Tests/TestCases/InboxManagerTests.swift
+++ b/Tests/TestCases/InboxManagerTests.swift
@@ -339,6 +339,30 @@ final class InboxManagerTests: XCTestCase {
         XCTAssertFalse(messages.first?.isRead ?? true, "Failed mark-read must revert the local flip")
     }
 
+    func testMarkRead_identityChangeDuringRequest_discardsStaleResponse() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 5
+        apiSpy.stubbedMarkReadResponse = UpdateReadStatusResponse(
+            messages: [.init(messageId: "1", isRead: true)],
+            unreadCount: 99 // stale value that must not survive the identity change
+        )
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+
+        // An identity change (e.g. clearUser/updateUser) lands while the PATCH is in flight,
+        // bumping the generation and zeroing the count for the new (logged-out) identity.
+        apiSpy.onMarkMessagesRead = { await manager.resetForIdentityChange() }
+
+        await manager.markRead("1")
+
+        let unread = await manager.unreadCount
+        XCTAssertEqual(unread, 0, "Stale mark-read response must not overwrite the post-reset unread count")
+    }
+
     func testMarkRead_alreadyRead_noOpsOnLocalStateButStillCallsApi() async {
         apiSpy.stubbedInboxMessagesResponses = [
             InboxResponse(messages: [makeMessage(id: "1", isRead: true)], nextPageToken: nil)

--- a/Tests/TestCases/InboxManagerTests.swift
+++ b/Tests/TestCases/InboxManagerTests.swift
@@ -296,19 +296,79 @@ final class InboxManagerTests: XCTestCase {
         }
     }
 
-    // MARK: - Local mutations
+    // MARK: - Mark Read
 
-    func testMarkRead_updatesLocalMessageState() async {
+    func testMarkRead_success_flipsLocalAndSyncsUnreadCountFromServer() async {
         apiSpy.stubbedInboxMessagesResponses = [
             InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
         ]
+        apiSpy.stubbedUnreadCount = 1
+        apiSpy.stubbedMarkReadResponse = UpdateReadStatusResponse(
+            messages: [.init(messageId: "1", isRead: true)],
+            unreadCount: 0
+        )
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+
+        await manager.markRead("1")
+
+        let messages = await manager.allMessages
+        let unread = await manager.unreadCount
+        XCTAssertTrue(messages.first?.isRead ?? false)
+        XCTAssertEqual(unread, 0, "unread_count from response should be authoritative")
+        XCTAssertEqual(apiSpy.markMessagesReadCallCount, 1)
+        XCTAssertEqual(apiSpy.lastMarkReadMessageIds, ["1"])
+        XCTAssertEqual(apiSpy.lastMarkReadVisitorId, "v_test")
+        XCTAssertEqual(apiSpy.lastMarkReadPushToken, "fcm:abc")
+    }
+
+    func testMarkRead_failure_revertsLocalFlip() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedMarkReadError = NSError(domain: "test", code: -1)
+
         let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
         _ = await waitForLoadedState(manager)
 
         await manager.markRead("1")
 
         let messages = await manager.allMessages
-        XCTAssertTrue(messages.first?.isRead == true)
+        XCTAssertFalse(messages.first?.isRead ?? true, "Failed mark-read must revert the local flip")
+    }
+
+    func testMarkRead_alreadyRead_noOpsOnLocalStateButStillCallsApi() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: true)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedMarkReadResponse = UpdateReadStatusResponse(
+            messages: [.init(messageId: "1", isRead: true)],
+            unreadCount: 0
+        )
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        await manager.markRead("1")
+
+        let unread = await manager.unreadCount
+        XCTAssertEqual(unread, 0)
+        XCTAssertEqual(apiSpy.markMessagesReadCallCount, 1)
+    }
+
+    func testMarkRead_unknownMessage_isNoOp() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
+        ]
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        await manager.markRead("does-not-exist")
+
+        XCTAssertEqual(apiSpy.markMessagesReadCallCount, 0, "Unknown message ID must not hit the network")
     }
 
     func testDelete_removesMessageFromList() async {

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0A411B432F31DE0400563599 /* InboxResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A411B422F31DDFA00563599 /* InboxResponse.swift */; };
 		0AE0001A377A1AAA00563599 /* InboxUnreadCountResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE00019377A1AAA00563599 /* InboxUnreadCountResponse.swift */; };
+		0AE0001D411A1AAA00563599 /* UpdateReadStatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE0001E411A1AAA00563599 /* UpdateReadStatusResponse.swift */; };
 		0A83DEAE2F21A1AA003FD456 /* InboxManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83DEAB2F21A1AA003FD456 /* InboxManager.swift */; };
 		0A83DEAF2F21A1AA003FD456 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83DEAC2F21A1AA003FD456 /* Message.swift */; };
 		0A83DEB22F22C309003FD456 /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83DEB12F22C2F9003FD456 /* InboxView.swift */; };
@@ -53,6 +54,7 @@
 		0AE0001C377A1AAC00563599 /* ATTNInboxAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE0001B377A1AAC00563599 /* ATTNInboxAPITests.swift */; };
 		0A413001413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A413000413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift */; };
 		0A413003413A1AAA00563599 /* InboxManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A413002413A1AAA00563599 /* InboxManagerTests.swift */; };
+		0AE00021410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE00022410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift */; };
 		FB2F35B12C18CFFA0016CAE8 /* ATTNSDKFramework.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FB2F35AF2C18CFFA0016CAE8 /* ATTNSDKFramework.podspec */; };
 		FB35C1792C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1782C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift */; };
 		FB35C17B2C0E0353009FA048 /* ATTNIdentifierType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */; };
@@ -127,6 +129,7 @@
 /* Begin PBXFileReference section */
 		0A411B422F31DDFA00563599 /* InboxResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxResponse.swift; sourceTree = "<group>"; };
 		0AE00019377A1AAA00563599 /* InboxUnreadCountResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxUnreadCountResponse.swift; sourceTree = "<group>"; };
+		0AE0001E411A1AAA00563599 /* UpdateReadStatusResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateReadStatusResponse.swift; sourceTree = "<group>"; };
 		0A812DF42F1827C50082B133 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 		0A83DEAB2F21A1AA003FD456 /* InboxManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxManager.swift; sourceTree = "<group>"; };
 		0A83DEAC2F21A1AA003FD456 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
@@ -186,6 +189,7 @@
 		0AE0001B377A1AAC00563599 /* ATTNInboxAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxAPITests.swift; sourceTree = "<group>"; };
 		0A413000413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxMessagesAPITests.swift; sourceTree = "<group>"; };
 		0A413002413A1AAA00563599 /* InboxManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxManagerTests.swift; sourceTree = "<group>"; };
+		0AE00022410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxMarkReadAPITests.swift; sourceTree = "<group>"; };
 		FB2F35AF2C18CFFA0016CAE8 /* ATTNSDKFramework.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ATTNSDKFramework.podspec; sourceTree = "<group>"; };
 		FB35C1782C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNCreativeTriggerStatus.swift; sourceTree = "<group>"; };
 		FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNIdentifierType.swift; sourceTree = "<group>"; };
@@ -283,6 +287,7 @@
 				0A411B422F31DDFA00563599 /* InboxResponse.swift */,
 				0AE00019377A1AAA00563599 /* InboxUnreadCountResponse.swift */,
 				0A83DEAC2F21A1AA003FD456 /* Message.swift */,
+				0AE0001E411A1AAA00563599 /* UpdateReadStatusResponse.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -437,6 +442,7 @@
 				FB2984072C0FAE040039759C /* ATTNAPITests.swift */,
 				0AE0001B377A1AAC00563599 /* ATTNInboxAPITests.swift */,
 				0A413000413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift */,
+				0AE00022410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift */,
 				0A413002413A1AAA00563599 /* InboxManagerTests.swift */,
 				FB90EF0A2C109CB4004DFC4A /* ATTNAPIITTests.swift */,
 				FB6553692C1B72D4008DB3B1 /* ATTNSDKTests.swift */,
@@ -775,6 +781,7 @@
 				FB35C1832C0E1FD7009FA048 /* URLSession+Extension.swift in Sources */,
 				0A411B432F31DE0400563599 /* InboxResponse.swift in Sources */,
 				0AE0001A377A1AAA00563599 /* InboxUnreadCountResponse.swift in Sources */,
+				0AE0001D411A1AAA00563599 /* UpdateReadStatusResponse.swift in Sources */,
 				FB35C1872C0E3929009FA048 /* ATTNEventTypes.swift in Sources */,
 				FBA9FA162C0A77AB00C65024 /* ATTNPrice.swift in Sources */,
 				FB35C1912C0E506D009FA048 /* ATTNEventRequestProvider.swift in Sources */,
@@ -849,6 +856,7 @@
 				FB2984082C0FAE040039759C /* ATTNAPITests.swift in Sources */,
 				0AE0001C377A1AAC00563599 /* ATTNInboxAPITests.swift in Sources */,
 				0A413001413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift in Sources */,
+				0AE00021410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift in Sources */,
 				0A413003413A1AAA00563599 /* InboxManagerTests.swift in Sources */,
 				FB65536A2C1B72D4008DB3B1 /* ATTNSDKTests.swift in Sources */,
 				FB90EF0D2C10A7F7004DFC4A /* NSURLSessionDataTaskMock.swift in Sources */,


### PR DESCRIPTION
## Summary

Wires `markRead` to the real `PATCH /inbox/messages/read` endpoint, replacing the previous local-only mutation. Part of the inbox real-endpoint rollout ([MSDK-410](https://attentivemobile.atlassian.net/browse/MSDK-410)).

## Key Changes

- `ATTNAPI.markMessagesRead(pushToken:visitorId:messageIds:)` issues `PATCH /inbox/messages/read` with the identifier-based body `{ visitor_id, push_token, message_ids }` and decodes `UpdateReadStatusResponse` (`{ messages: [{ message_id, is_read }], unread_count }`).
- `InboxManager.markRead` is now `async`: it optimistically flips `isRead` locally for immediate UI feedback, then reconciles per-message read status **and** the server-authoritative `unread_count` from the response. On failure it reverts the local flip so the UI reflects true state.
- Introduces the shared `UpdateReadStatusResponse` model (used by mark-unread in the stacked follow-up).
- The mark-read/unread response `unread_count` is treated as authoritative — no follow-up `refreshInboxUnreadCount` call, which would be a redundant round trip and could race a read replica into overwriting the fresh value with a stale one.

## Public API Impact

`ATTNSDK.markRead(for:)` was already `public` and `async`; its signature is unchanged and all call sites already `await`. No source/binary break for host apps. Behavior changes from local-only to a network call.

## Verification

- All 211 unit tests pass via `xcodebuild test` on the iOS 26.5 simulator (iPhone 17 Pro). Adds 6 API-level tests (`ATTNInboxMarkReadAPITests`: URL, PATCH method, body shape, empty push token, server-error, decode-error, network-error) and 4 `InboxManagerTests` cases (success reconciles `unread_count`, failure reverts the flip, already-read still calls the API, unknown id no-ops).
- `bundle exec fastlane ios lint` passes (0 serious violations).
- Exercised end-to-end in Bonni: swiping mark-read fires `PATCH /inbox/messages/read`, returns 200, and the SDK correctly decodes/stores/emits. **Note:** the prod backend currently routes to `MockInboxMessageClient`, which hardcodes `unread_count = 5` in every response, so the badge count does not move yet. The per-message flip is echoed correctly by the server. Badge movement will work once the real `InboxMessageClient` is swapped in server-side (raised with the backend team).

## Risk

Medium. Contained to the inbox mark-read path. The optimistic-flip + revert keeps the UI truthful even when the network fails. No change to identity, events, or push handling. Recent backend flakiness on the inbox endpoints (intermittent 401s in prod) means the call may fail in the field — but a failed call reverts cleanly and logs via `Loggers.network`.

## Observability

`Loggers.network` OSLog entries (`PATCH /inbox/messages/read`, status code, `Failed to mark inbox message read`) on-device; `mobile-api` service logs (`Received mark messages read request`) server-side. No dedicated dashboard for this endpoint yet.

## Rollback

No feature flag or config kill-switch — mitigation is a follow-up SDK release plus host-app re-adoption. The client-side revert-on-failure limits blast radius: a failing endpoint leaves the UI showing true read state rather than a wrong optimistic one.


[MSDK-410]: https://attentivemobile.atlassian.net/browse/MSDK-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ