### PR TITLE
MSDK-411: wire real endpoint for mark message unread

### DIFF
--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -549,6 +549,58 @@ final class ATTNAPI: ATTNAPIProtocol {
         pushToken.isEmpty ? nil : "apns:\(pushToken)"
     }
 
+    /// Marks the supplied messages as unread on the server.
+    ///
+    /// PATCH /inbox/messages/unread — identifier-based (visitor_id + push_token), body carries
+    /// the list of message ids. The response echoes the per-message read status and the
+    /// updated unread count so the caller can reconcile local state without a follow-up fetch.
+    func markMessagesUnread(
+        pushToken: String,
+        visitorId: String,
+        messageIds: [String]
+    ) async throws -> UpdateReadStatusResponse {
+        Loggers.network.debug("Marking inbox messages unread - Visitor ID: \(visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public), Count: \(messageIds.count, privacy: .public)")
+
+        let body = UpdateReadStatusRequest(
+            visitorId: visitorId,
+            pushToken: Self.inboxPushToken(pushToken),
+            messageIds: messageIds
+        )
+
+        guard let url = URL(string: "https://mobile.attentivemobile.com/inbox/messages/unread") else {
+            Loggers.network.error("Invalid inbox mark-unread URL")
+            throw ATTNError.badURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PATCH"
+        request.timeoutInterval = 15
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
+        request.httpBody = try JSONEncoder().encode(body)
+
+        Loggers.network.debug("PATCH /inbox/messages/unread")
+
+        let (data, response) = try await dataTask(with: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            Loggers.network.error("Inbox mark-unread returned a non-HTTP response")
+            throw ATTNError.inboxResponseDecodeFailed
+        }
+        Loggers.network.debug("Inbox mark-unread status code: \(http.statusCode, privacy: .public)")
+        guard (200..<300).contains(http.statusCode) else {
+            Loggers.network.error("Inbox mark-unread API returned status \(http.statusCode, privacy: .public)")
+            throw ATTNError.inboxRequestFailed(statusCode: http.statusCode)
+        }
+
+        do {
+            return try JSONDecoder().decode(UpdateReadStatusResponse.self, from: data)
+        } catch {
+            Loggers.network.error("Failed to decode inbox mark-unread response: \(error.localizedDescription, privacy: .public)")
+            throw ATTNError.inboxResponseDecodeFailed
+        }
+    }
+
     private static let inboxJSONDecoder: JSONDecoder = {
         let decoder = JSONDecoder()
         // Accept ISO-8601 timestamps with or without fractional seconds. Foundation's built-in

--- a/Sources/API/ATTNAPIProtocol.swift
+++ b/Sources/API/ATTNAPIProtocol.swift
@@ -103,4 +103,12 @@ protocol ATTNAPIProtocol {
         visitorId: String,
         messageIds: [String]
     ) async throws -> UpdateReadStatusResponse
+
+    /// Marks the supplied messages as unread on the server. Returns the server-confirmed
+    /// per-message read status and the resulting authoritative unread count.
+    func markMessagesUnread(
+        pushToken: String,
+        visitorId: String,
+        messageIds: [String]
+    ) async throws -> UpdateReadStatusResponse
 }

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -52,10 +52,10 @@ actor InboxManager {
     /// load returning inside the refresh window resets that flag but must not release this one.
     private var isRefreshingFirstPage: Bool = false
 
-    /// Server-authoritative unread count. Written by `refreshUnreadCount()` and by the mark-read
-    /// API response (see `applyReadStatusResponse`); local `markUnread` does not touch it. Reads
-    /// should go through the `unreadCount` accessor, which awaits the init-time refresh so the
-    /// first read never returns a stale 0.
+    /// Server-authoritative unread count. Written by `refreshUnreadCount()` and by the mark-read /
+    /// mark-unread API responses (see `applyReadStatusResponse`). Reads should go through the
+    /// `unreadCount` accessor, which awaits the init-time refresh so the first read never returns
+    /// a stale 0.
     private var storedUnreadCount: Int = 0
 
     private let api: ATTNAPIProtocol
@@ -373,10 +373,44 @@ actor InboxManager {
         }
     }
 
-    func markUnread(_ messageID: Message.ID) {
-        guard messagesByID[messageID]?.isRead == true else { return }
-        messagesByID[messageID]?.isRead = false
-        send(.loaded(orderedMessagesSnapshot()))
+    /// Marks a message unread. Optimistically flips the local state, then reconciles from the
+    /// server response. On failure the local flip is reverted so the UI reflects true state.
+    func markUnread(_ messageID: Message.ID) async {
+        guard let previousIsRead = messagesByID[messageID]?.isRead else { return }
+
+        let identity = identityProvider()
+        guard !identity.visitorId.isEmpty else {
+            Loggers.network.debug("Skipping inbox mark-unread: empty visitor ID")
+            return
+        }
+
+        if previousIsRead {
+            messagesByID[messageID]?.isRead = false
+            send(.loaded(orderedMessagesSnapshot()))
+        }
+
+        // Snapshot the refresh generation before the request. If an identity change
+        // (`resetForIdentityChange`) or a newer `refreshUnreadCount` lands while the PATCH is in
+        // flight, the generation advances and we drop this now-stale response instead of
+        // restoring an old unread count.
+        let generation = refreshGeneration
+
+        do {
+            let response = try await api.markMessagesUnread(
+                pushToken: identity.pushToken,
+                visitorId: identity.visitorId,
+                messageIds: [messageID]
+            )
+            guard generation == refreshGeneration else { return }
+            applyReadStatusResponse(response)
+        } catch {
+            Loggers.network.error("Failed to mark inbox message unread: \(error.localizedDescription, privacy: .public)")
+            guard generation == refreshGeneration else { return }
+            if messagesByID[messageID] != nil, previousIsRead {
+                messagesByID[messageID]?.isRead = previousIsRead
+                send(.loaded(orderedMessagesSnapshot()))
+            }
+        }
     }
 
     func delete(_ messageID: Message.ID) {

--- a/Tests/Doubles/Mocks/NSURLSessionMock.swift
+++ b/Tests/Doubles/Mocks/NSURLSessionMock.swift
@@ -13,6 +13,7 @@ class NSURLSessionMock: URLSession {
     var didCallInboxUnreadCountApi = false
     var didCallInboxMessagesApi = false
     var didCallInboxMarkReadApi = false
+    var didCallInboxMarkUnreadApi = false
     var urlCalls: [URL] = []
     var requests: [URLRequest] = []
 
@@ -34,6 +35,12 @@ class NSURLSessionMock: URLSession {
     var inboxMarkReadResponseBody: Data = Data("{\"messages\": [], \"unread_count\": 0}".utf8)
     var inboxMarkReadError: Error?
 
+    /// Override the response returned for the mark-unread endpoint.
+    /// Default: 200 with an empty per-message list and unread_count=0.
+    var inboxMarkUnreadStatusCode: Int = 200
+    var inboxMarkUnreadResponseBody: Data = Data("{\"messages\": [], \"unread_count\": 0}".utf8)
+    var inboxMarkUnreadError: Error?
+
     override init() {
         super.init()
     }
@@ -52,8 +59,8 @@ class NSURLSessionMock: URLSession {
             }
 
             // Order matters: check the more specific `/inbox/messages/unread/count` before the
-            // `/inbox/messages/read` and `/inbox/messages` prefixes so the general checks
-            // don't shadow it.
+            // `/inbox/messages/read`, `/inbox/messages/unread`, and `/inbox/messages` prefixes
+            // so the general checks don't shadow it.
             if url.absoluteString.contains("/inbox/messages/unread/count") {
                 didCallInboxUnreadCountApi = true
                 let body = inboxUnreadCountResponseBody
@@ -69,6 +76,16 @@ class NSURLSessionMock: URLSession {
                 let body = inboxMarkReadResponseBody
                 let status = inboxMarkReadStatusCode
                 let error = inboxMarkReadError
+                return NSURLSessionDataTaskMock { _, _, _ in
+                    completionHandler(body, HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil), error)
+                }
+            }
+
+            if url.absoluteString.hasSuffix("/inbox/messages/unread") {
+                didCallInboxMarkUnreadApi = true
+                let body = inboxMarkUnreadResponseBody
+                let status = inboxMarkUnreadStatusCode
+                let error = inboxMarkUnreadError
                 return NSURLSessionDataTaskMock { _, _, _ in
                     completionHandler(body, HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil), error)
                 }

--- a/Tests/Doubles/Spies/ATTNAPISpy.swift
+++ b/Tests/Doubles/Spies/ATTNAPISpy.swift
@@ -244,4 +244,34 @@ final class ATTNAPISpy: ATTNAPIProtocol {
         if let error = stubbedMarkReadError { throw error }
         return stubbedMarkReadResponse
     }
+
+    // MARK: - Mark Messages Unread
+    private(set) var markMessagesUnreadWasCalled = false
+    private(set) var markMessagesUnreadCallCount = 0
+    private(set) var lastMarkUnreadPushToken: String?
+    private(set) var lastMarkUnreadVisitorId: String?
+    private(set) var lastMarkUnreadMessageIds: [String]?
+    var stubbedMarkUnreadError: Error?
+    var stubbedMarkUnreadResponse: UpdateReadStatusResponse = UpdateReadStatusResponse(
+        messages: [],
+        unreadCount: 0
+    )
+    /// Invoked while the mark-unread call is "in flight" (after recording, before returning),
+    /// letting a test interleave an identity change/refresh to exercise stale-response handling.
+    var onMarkMessagesUnread: (@Sendable () async -> Void)?
+
+    func markMessagesUnread(
+        pushToken: String,
+        visitorId: String,
+        messageIds: [String]
+    ) async throws -> UpdateReadStatusResponse {
+        markMessagesUnreadWasCalled = true
+        markMessagesUnreadCallCount += 1
+        lastMarkUnreadPushToken = pushToken
+        lastMarkUnreadVisitorId = visitorId
+        lastMarkUnreadMessageIds = messageIds
+        if let hook = onMarkMessagesUnread { await hook() }
+        if let error = stubbedMarkUnreadError { throw error }
+        return stubbedMarkUnreadResponse
+    }
 }

--- a/Tests/TestCases/ATTNInboxMarkUnreadAPITests.swift
+++ b/Tests/TestCases/ATTNInboxMarkUnreadAPITests.swift
@@ -1,0 +1,132 @@
+//
+//  ATTNInboxMarkUnreadAPITests.swift
+//  attentive-ios-sdk Tests
+//
+
+import XCTest
+@testable import ATTNSDKFramework
+
+final class ATTNInboxMarkUnreadAPITests: XCTestCase {
+    private let testDomain = "some-domain"
+    private var sessionMock: NSURLSessionMock!
+    private var api: ATTNAPI!
+    private var userIdentity: ATTNUserIdentity!
+
+    override func setUp() {
+        super.setUp()
+        sessionMock = NSURLSessionMock()
+        api = ATTNAPI(domain: testDomain, urlSession: sessionMock)
+        userIdentity = ATTNTestEventUtils.buildUserIdentity()
+    }
+
+    override func tearDown() {
+        sessionMock = nil
+        api = nil
+        userIdentity = nil
+        super.tearDown()
+    }
+
+    private func markUnread(
+        pushToken: String = "abc123devicetoken",
+        messageIds: [String] = ["msg-1"],
+        identity: ATTNUserIdentity? = nil
+    ) async throws -> UpdateReadStatusResponse {
+        try await api.markMessagesUnread(
+            pushToken: pushToken,
+            visitorId: (identity ?? userIdentity).visitorId,
+            messageIds: messageIds
+        )
+    }
+
+    func testMarkUnread_success_decodesServerResponse() async throws {
+        sessionMock.inboxMarkUnreadResponseBody = Data("""
+        {
+          "messages": [
+            {"message_id": "msg-1", "is_read": false},
+            {"message_id": "msg-2", "is_read": false}
+          ],
+          "unread_count": 4
+        }
+        """.utf8)
+
+        let response = try await markUnread(messageIds: ["msg-1", "msg-2"])
+
+        XCTAssertEqual(response.unreadCount, 4)
+        XCTAssertEqual(response.messages.count, 2)
+        XCTAssertEqual(response.messages.first?.messageId, "msg-1")
+        XCTAssertFalse(response.messages.first?.isRead ?? true)
+        XCTAssertTrue(sessionMock.didCallInboxMarkUnreadApi)
+        XCTAssertEqual(sessionMock.urlCalls.count, 1)
+        XCTAssertEqual(sessionMock.urlCalls[0].absoluteString, "https://mobile.attentivemobile.com/inbox/messages/unread")
+    }
+
+    func testMarkUnread_sendsExpectedRequest() async throws {
+        _ = try await markUnread(messageIds: ["msg-1", "msg-2"])
+
+        let request = try XCTUnwrap(sessionMock.requests.first)
+        XCTAssertEqual(request.httpMethod, "PATCH")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        XCTAssertEqual(json["visitor_id"] as? String, userIdentity.visitorId)
+        // Push tokens are namespaced by transport for the inbox backend.
+        XCTAssertEqual(json["push_token"] as? String, "apns:abc123devicetoken")
+        XCTAssertEqual(json["message_ids"] as? [String], ["msg-1", "msg-2"])
+        // Contract carries only visitor_id / push_token / message_ids — no domain, email, phone.
+        XCTAssertNil(json["c"])
+        XCTAssertNil(json["email"])
+        XCTAssertNil(json["phone"])
+    }
+
+    func testMarkUnread_omitsEmptyPushToken() async throws {
+        _ = try await markUnread(pushToken: "")
+
+        let request = try XCTUnwrap(sessionMock.requests.first)
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        XCTAssertNil(json["push_token"])
+        XCTAssertEqual(json["visitor_id"] as? String, userIdentity.visitorId)
+    }
+
+    func testMarkUnread_serverError_throwsInboxRequestFailed() async {
+        sessionMock.inboxMarkUnreadStatusCode = 500
+
+        do {
+            _ = try await markUnread()
+            XCTFail("Expected request to throw")
+        } catch ATTNError.inboxRequestFailed(let status) {
+            XCTAssertEqual(status, 500)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testMarkUnread_malformedBody_throwsDecodeFailed() async {
+        sessionMock.inboxMarkUnreadResponseBody = Data("not json".utf8)
+
+        do {
+            _ = try await markUnread()
+            XCTFail("Expected request to throw")
+        } catch ATTNError.inboxResponseDecodeFailed {
+            // expected
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testMarkUnread_networkError_throwsUnderlyingError() async {
+        let stubError = NSError(domain: "test", code: -1, userInfo: nil)
+        sessionMock.inboxMarkUnreadError = stubError
+
+        do {
+            _ = try await markUnread()
+            XCTFail("Expected request to throw")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "test")
+            XCTAssertEqual(error.code, -1)
+        }
+    }
+}

--- a/Tests/TestCases/InboxManagerTests.swift
+++ b/Tests/TestCases/InboxManagerTests.swift
@@ -395,6 +395,105 @@ final class InboxManagerTests: XCTestCase {
         XCTAssertEqual(apiSpy.markMessagesReadCallCount, 0, "Unknown message ID must not hit the network")
     }
 
+    // MARK: - Mark Unread
+
+    func testMarkUnread_success_flipsLocalAndSyncsUnreadCountFromServer() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: true)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 0
+        apiSpy.stubbedMarkUnreadResponse = UpdateReadStatusResponse(
+            messages: [.init(messageId: "1", isRead: false)],
+            unreadCount: 7
+        )
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+
+        await manager.markUnread("1")
+
+        let messages = await manager.allMessages
+        let unread = await manager.unreadCount
+        XCTAssertFalse(messages.first?.isRead ?? true)
+        XCTAssertEqual(unread, 7, "unread_count from response should be authoritative")
+        XCTAssertEqual(apiSpy.markMessagesUnreadCallCount, 1)
+        XCTAssertEqual(apiSpy.lastMarkUnreadMessageIds, ["1"])
+        XCTAssertEqual(apiSpy.lastMarkUnreadVisitorId, "v_test")
+        XCTAssertEqual(apiSpy.lastMarkUnreadPushToken, "fcm:abc")
+    }
+
+    func testMarkUnread_failure_revertsLocalFlip() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: true)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedMarkUnreadError = NSError(domain: "test", code: -1)
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        await manager.markUnread("1")
+
+        let messages = await manager.allMessages
+        XCTAssertTrue(messages.first?.isRead ?? false, "Failed mark-unread must revert the local flip")
+    }
+
+    func testMarkUnread_identityChangeDuringRequest_discardsStaleResponse() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: true)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 5
+        apiSpy.stubbedMarkUnreadResponse = UpdateReadStatusResponse(
+            messages: [.init(messageId: "1", isRead: false)],
+            unreadCount: 99 // stale value that must not survive the identity change
+        )
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+
+        // An identity change (e.g. clearUser/updateUser) lands while the PATCH is in flight,
+        // bumping the generation and zeroing the count for the new (logged-out) identity.
+        apiSpy.onMarkMessagesUnread = { await manager.resetForIdentityChange() }
+
+        await manager.markUnread("1")
+
+        let unread = await manager.unreadCount
+        XCTAssertEqual(unread, 0, "Stale mark-unread response must not overwrite the post-reset unread count")
+    }
+
+    func testMarkUnread_alreadyUnread_noOpsOnLocalStateButStillCallsApi() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedMarkUnreadResponse = UpdateReadStatusResponse(
+            messages: [.init(messageId: "1", isRead: false)],
+            unreadCount: 2
+        )
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        await manager.markUnread("1")
+
+        let unread = await manager.unreadCount
+        XCTAssertEqual(unread, 2)
+        XCTAssertEqual(apiSpy.markMessagesUnreadCallCount, 1)
+    }
+
+    func testMarkUnread_unknownMessage_isNoOp() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: true)], nextPageToken: nil)
+        ]
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        await manager.markUnread("does-not-exist")
+
+        XCTAssertEqual(apiSpy.markMessagesUnreadCallCount, 0, "Unknown message ID must not hit the network")
+    }
+
     func testDelete_removesMessageFromList() async {
         apiSpy.stubbedInboxMessagesResponses = [
             InboxResponse(messages: [makeMessage(id: "1"), makeMessage(id: "2")], nextPageToken: nil)

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		0A413001413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A413000413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift */; };
 		0A413003413A1AAA00563599 /* InboxManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A413002413A1AAA00563599 /* InboxManagerTests.swift */; };
 		0AE00021410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE00022410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift */; };
+		0AE0001F411A1AAC00563599 /* ATTNInboxMarkUnreadAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE00020411A1AAC00563599 /* ATTNInboxMarkUnreadAPITests.swift */; };
 		FB2F35B12C18CFFA0016CAE8 /* ATTNSDKFramework.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FB2F35AF2C18CFFA0016CAE8 /* ATTNSDKFramework.podspec */; };
 		FB35C1792C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1782C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift */; };
 		FB35C17B2C0E0353009FA048 /* ATTNIdentifierType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */; };
@@ -190,6 +191,7 @@
 		0A413000413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxMessagesAPITests.swift; sourceTree = "<group>"; };
 		0A413002413A1AAA00563599 /* InboxManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxManagerTests.swift; sourceTree = "<group>"; };
 		0AE00022410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxMarkReadAPITests.swift; sourceTree = "<group>"; };
+		0AE00020411A1AAC00563599 /* ATTNInboxMarkUnreadAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxMarkUnreadAPITests.swift; sourceTree = "<group>"; };
 		FB2F35AF2C18CFFA0016CAE8 /* ATTNSDKFramework.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ATTNSDKFramework.podspec; sourceTree = "<group>"; };
 		FB35C1782C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNCreativeTriggerStatus.swift; sourceTree = "<group>"; };
 		FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNIdentifierType.swift; sourceTree = "<group>"; };
@@ -443,6 +445,7 @@
 				0AE0001B377A1AAC00563599 /* ATTNInboxAPITests.swift */,
 				0A413000413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift */,
 				0AE00022410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift */,
+				0AE00020411A1AAC00563599 /* ATTNInboxMarkUnreadAPITests.swift */,
 				0A413002413A1AAA00563599 /* InboxManagerTests.swift */,
 				FB90EF0A2C109CB4004DFC4A /* ATTNAPIITTests.swift */,
 				FB6553692C1B72D4008DB3B1 /* ATTNSDKTests.swift */,
@@ -857,6 +860,7 @@
 				0AE0001C377A1AAC00563599 /* ATTNInboxAPITests.swift in Sources */,
 				0A413001413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift in Sources */,
 				0AE00021410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift in Sources */,
+				0AE0001F411A1AAC00563599 /* ATTNInboxMarkUnreadAPITests.swift in Sources */,
 				0A413003413A1AAA00563599 /* InboxManagerTests.swift in Sources */,
 				FB65536A2C1B72D4008DB3B1 /* ATTNSDKTests.swift in Sources */,
 				FB90EF0D2C10A7F7004DFC4A /* NSURLSessionDataTaskMock.swift in Sources */,


### PR DESCRIPTION
## Summary

Wires `markUnread` to the real `PATCH /inbox/messages/unread` endpoint, replacing the previous local-only mutation. Part of the inbox real-endpoint rollout ([MSDK-411](https://attentivemobile.atlassian.net/browse/MSDK-411)).

**Stacked on top of [MSDK-410](https://attentivemobile.atlassian.net/browse/MSDK-410) — this PR targets `umair/MSDK-410-real-mark-read-endpoint`. Review/merge 410 first.** The diff here is only the unread-specific additions; the shared `UpdateReadStatusResponse` model and mark scaffolding land in 410.

## Key Changes

- `ATTNAPI.markMessagesUnread(pushToken:visitorId:messageIds:)` issues `PATCH /inbox/messages/unread` with the identifier-based body `{ visitor_id, push_token, message_ids }` and decodes `UpdateReadStatusResponse`.
- `InboxManager.markUnread` is now `async`: it optimistically flips `isRead = false` locally, then reconciles per-message read status and the server-authoritative `unread_count` from the response. On failure it reverts the local flip.

## Public API Impact

`ATTNSDK.markUnread(for:)` was already `public` and `async`; signature unchanged, all call sites already `await`. No source/binary break. Behavior changes from local-only to a network call.

## Verification

- All 211 unit tests pass via `xcodebuild test` on the iOS 26.5 simulator (iPhone 17 Pro). Adds 6 API-level tests (`ATTNInboxMarkUnreadAPITests`) and 4 `InboxManagerTests` cases (success reconciles `unread_count`, failure reverts, already-unread still calls the API, unknown id no-ops), mirroring the mark-read coverage.
- `bundle exec fastlane ios lint` passes (0 serious violations).
- Exercised end-to-end in Bonni: swiping mark-unread fires `PATCH /inbox/messages/unread`, returns 200, and the SDK correctly decodes/stores/emits. **Note:** the prod backend currently routes to `MockInboxMessageClient`, which hardcodes `unread_count = 5` in every response, so the badge count does not move yet. The per-message flip is echoed correctly by the server. Badge movement will work once the real `InboxMessageClient` is swapped in server-side (raised with the backend team).

## Risk

Medium. Contained to the inbox mark-unread path. Optimistic-flip + revert keeps the UI truthful on network failure. No change to identity, events, or push handling. Recent backend flakiness on inbox endpoints (intermittent 401s in prod) applies here too.

## Observability

`Loggers.network` OSLog entries (`PATCH /inbox/messages/unread`, status code, `Failed to mark inbox message unread`) on-device; `mobile-api` service logs (`Received mark messages unread request`) server-side. No dedicated dashboard for this endpoint yet.

## Rollback

No feature flag or config kill-switch — mitigation is a follow-up SDK release plus host-app re-adoption. Client-side revert-on-failure limits blast radius.


[MSDK-411]: https://attentivemobile.atlassian.net/browse/MSDK-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MSDK-410]: https://attentivemobile.atlassian.net/browse/MSDK-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ