### PR TITLE
MSDK-413: wire real endpoint for inbox message list

### DIFF
--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -379,6 +379,8 @@ final class ATTNAPI: ATTNAPIProtocol {
 
     // MARK: - Inbox
 
+    private static let inboxHost = "https://mobile.attentivemobile.com"
+
     /// Fetches the unread inbox message count for the current user.
     ///
     /// Per RFC: this endpoint is identifier-based and unauthenticated. The server scopes the
@@ -390,55 +392,14 @@ final class ATTNAPI: ATTNAPIProtocol {
         visitorId: String
     ) async throws -> Int {
         Loggers.network.debug("Fetching inbox unread count - Visitor ID: \(visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public)")
-
-        var payload: [String: Any] = [
-            "c": domain,
-            "visitor_id": visitorId
-        ]
-        // Prefix with the transport scheme so the server can route the token to APNs.
-        // Matches the RFC's `fcm:...` example on Android; iOS uses `apns:`.
-        if !pushToken.isEmpty { payload["push_token"] = "apns:\(pushToken)" }
-        if let email = email?.trimmingCharacters(in: .whitespacesAndNewlines), !email.isEmpty {
-            payload["email"] = email
-        }
-        if let phone = phone?.trimmingCharacters(in: .whitespacesAndNewlines), !phone.isEmpty {
-            payload["phone"] = phone
-        }
-
-        guard let url = URL(string: "https://mobile.attentivemobile.com/inbox/messages/unread/count") else {
-            Loggers.network.error("Invalid inbox unread count URL")
-            throw ATTNError.badURL
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.timeoutInterval = 15
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
-        request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
-
-        Loggers.network.debug("POST /inbox/messages/unread/count")
-
-        let (data, response) = try await dataTask(with: request)
-
-        guard let http = response as? HTTPURLResponse else {
-            Loggers.network.error("Inbox unread count returned a non-HTTP response")
-            throw ATTNError.inboxResponseDecodeFailed
-        }
-        Loggers.network.debug("Inbox unread count status code: \(http.statusCode, privacy: .public)")
-        guard (200..<300).contains(http.statusCode) else {
-            Loggers.network.error("Inbox unread count API returned status \(http.statusCode, privacy: .public)")
-            throw ATTNError.inboxRequestFailed(statusCode: http.statusCode)
-        }
-
-        do {
-            let decoded = try JSONDecoder().decode(InboxUnreadCountResponse.self, from: data)
-            Loggers.network.debug("Inbox unread count: \(decoded.unreadCount, privacy: .public)")
-            return decoded.unreadCount
-        } catch {
-            Loggers.network.error("Failed to decode inbox unread count response: \(error.localizedDescription, privacy: .public)")
-            throw ATTNError.inboxResponseDecodeFailed
-        }
+        let payload = inboxIdentityPayload(pushToken: pushToken, email: email, phone: phone, visitorId: visitorId)
+        let decoded: InboxUnreadCountResponse = try await postInboxJSON(
+            path: "/inbox/messages/unread/count",
+            payload: payload,
+            decoder: JSONDecoder()
+        )
+        Loggers.network.debug("Inbox unread count: \(decoded.unreadCount, privacy: .public)")
+        return decoded.unreadCount
     }
 
     /// Fetches a page of inbox messages. See the doc comment on `ATTNAPIProtocol.fetchInboxMessages`.
@@ -451,25 +412,53 @@ final class ATTNAPI: ATTNAPIProtocol {
         pageToken: String?
     ) async throws -> InboxResponse {
         Loggers.network.debug("Fetching inbox messages - Visitor ID: \(visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public), Page Size: \(pageSize, privacy: .public), Page Token: \(pageToken ?? "nil", privacy: .public)")
+        var payload = inboxIdentityPayload(pushToken: pushToken, email: email, phone: phone, visitorId: visitorId)
+        payload["page_size"] = pageSize
+        if let pageToken = pageToken, !pageToken.isEmpty {
+            payload["page_token"] = pageToken
+        }
+        let decoded: InboxResponse = try await postInboxJSON(
+            path: "/inbox/messages",
+            payload: payload,
+            decoder: Self.inboxJSONDecoder
+        )
+        Loggers.network.debug("Inbox messages fetched: count=\(decoded.messages.count, privacy: .public), hasNextPage=\(decoded.nextPageToken?.isEmpty == false, privacy: .public)")
+        return decoded
+    }
 
+    /// Builds the identifier fields shared by every inbox endpoint: `c` (domain), `visitor_id`,
+    /// and the optional `push_token` / `email` / `phone`. Push token is prefixed with `apns:`
+    /// so the server can route it to APNs (Android sends `fcm:...`).
+    private func inboxIdentityPayload(
+        pushToken: String,
+        email: String?,
+        phone: String?,
+        visitorId: String
+    ) -> [String: Any] {
         var payload: [String: Any] = [
             "c": domain,
-            "visitor_id": visitorId,
-            "page_size": pageSize
+            "visitor_id": visitorId
         ]
-        if !pushToken.isEmpty { payload["push_token"] = pushToken }
+        if !pushToken.isEmpty { payload["push_token"] = "apns:\(pushToken)" }
         if let email = email?.trimmingCharacters(in: .whitespacesAndNewlines), !email.isEmpty {
             payload["email"] = email
         }
         if let phone = phone?.trimmingCharacters(in: .whitespacesAndNewlines), !phone.isEmpty {
             payload["phone"] = phone
         }
-        if let pageToken = pageToken, !pageToken.isEmpty {
-            payload["page_token"] = pageToken
-        }
+        return payload
+    }
 
-        guard let url = URL(string: "https://mobile.attentivemobile.com/inbox/messages") else {
-            Loggers.network.error("Invalid inbox messages URL")
+    /// Shared POST + JSON-decode scaffolding for inbox endpoints. Maps non-2xx status to
+    /// `inboxRequestFailed`, non-HTTP responses and decode failures to `inboxResponseDecodeFailed`,
+    /// and bad URLs to `badURL`. All other transport errors propagate.
+    private func postInboxJSON<T: Decodable>(
+        path: String,
+        payload: [String: Any],
+        decoder: JSONDecoder
+    ) async throws -> T {
+        guard let url = URL(string: Self.inboxHost + path) else {
+            Loggers.network.error("Invalid inbox URL for path \(path, privacy: .public)")
             throw ATTNError.badURL
         }
 
@@ -480,33 +469,47 @@ final class ATTNAPI: ATTNAPIProtocol {
         request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
         request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
 
-        Loggers.network.debug("POST /inbox/messages")
-
+        Loggers.network.debug("POST \(path, privacy: .public)")
         let (data, response) = try await dataTask(with: request)
 
         guard let http = response as? HTTPURLResponse else {
-            Loggers.network.error("Inbox messages returned a non-HTTP response")
+            Loggers.network.error("Inbox \(path, privacy: .public) returned a non-HTTP response")
             throw ATTNError.inboxResponseDecodeFailed
         }
-        Loggers.network.debug("Inbox messages status code: \(http.statusCode, privacy: .public)")
+        Loggers.network.debug("Inbox \(path, privacy: .public) status: \(http.statusCode, privacy: .public)")
         guard (200..<300).contains(http.statusCode) else {
-            Loggers.network.error("Inbox messages API returned status \(http.statusCode, privacy: .public)")
+            Loggers.network.error("Inbox \(path, privacy: .public) returned status \(http.statusCode, privacy: .public)")
             throw ATTNError.inboxRequestFailed(statusCode: http.statusCode)
         }
 
         do {
-            let decoded = try Self.inboxJSONDecoder.decode(InboxResponse.self, from: data)
-            Loggers.network.debug("Inbox messages fetched: count=\(decoded.messages.count, privacy: .public), hasNextPage=\(decoded.nextPageToken?.isEmpty == false, privacy: .public)")
-            return decoded
+            return try decoder.decode(T.self, from: data)
         } catch {
-            Loggers.network.error("Failed to decode inbox messages response: \(error.localizedDescription, privacy: .public)")
+            Loggers.network.error("Failed to decode inbox \(path, privacy: .public) response: \(error.localizedDescription, privacy: .public)")
             throw ATTNError.inboxResponseDecodeFailed
         }
     }
 
     private static let inboxJSONDecoder: JSONDecoder = {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        // Accept ISO-8601 timestamps with or without fractional seconds. Foundation's built-in
+        // `.iso8601` strategy uses an ISO8601DateFormatter without `.withFractionalSeconds`, so
+        // a payload like `"2026-07-15T14:22:31.847Z"` would throw and fail the whole page.
+        let withFractional = ISO8601DateFormatter()
+        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let withoutFractional = ISO8601DateFormatter()
+        withoutFractional.formatOptions = [.withInternetDateTime]
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+            if let date = withFractional.date(from: string) ?? withoutFractional.date(from: string) {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Expected ISO-8601 date string, got \(string)"
+            )
+        }
         return decoder
     }()
 

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -441,6 +441,75 @@ final class ATTNAPI: ATTNAPIProtocol {
         }
     }
 
+    /// Fetches a page of inbox messages. See the doc comment on `ATTNAPIProtocol.fetchInboxMessages`.
+    func fetchInboxMessages(
+        pushToken: String,
+        email: String?,
+        phone: String?,
+        visitorId: String,
+        pageSize: Int,
+        pageToken: String?
+    ) async throws -> InboxResponse {
+        Loggers.network.debug("Fetching inbox messages - Visitor ID: \(visitorId, privacy: .public), Push Token: \(pushToken, privacy: .public), Page Size: \(pageSize, privacy: .public), Page Token: \(pageToken ?? "nil", privacy: .public)")
+
+        var payload: [String: Any] = [
+            "c": domain,
+            "visitor_id": visitorId,
+            "page_size": pageSize
+        ]
+        if !pushToken.isEmpty { payload["push_token"] = pushToken }
+        if let email = email?.trimmingCharacters(in: .whitespacesAndNewlines), !email.isEmpty {
+            payload["email"] = email
+        }
+        if let phone = phone?.trimmingCharacters(in: .whitespacesAndNewlines), !phone.isEmpty {
+            payload["phone"] = phone
+        }
+        if let pageToken = pageToken, !pageToken.isEmpty {
+            payload["page_token"] = pageToken
+        }
+
+        guard let url = URL(string: "https://mobile.attentivemobile.com/inbox/messages") else {
+            Loggers.network.error("Invalid inbox messages URL")
+            throw ATTNError.badURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 15
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("1", forHTTPHeaderField: "x-datadog-sampling-priority")
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+        Loggers.network.debug("POST /inbox/messages")
+
+        let (data, response) = try await dataTask(with: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            Loggers.network.error("Inbox messages returned a non-HTTP response")
+            throw ATTNError.inboxResponseDecodeFailed
+        }
+        Loggers.network.debug("Inbox messages status code: \(http.statusCode, privacy: .public)")
+        guard (200..<300).contains(http.statusCode) else {
+            Loggers.network.error("Inbox messages API returned status \(http.statusCode, privacy: .public)")
+            throw ATTNError.inboxRequestFailed(statusCode: http.statusCode)
+        }
+
+        do {
+            let decoded = try Self.inboxJSONDecoder.decode(InboxResponse.self, from: data)
+            Loggers.network.debug("Inbox messages fetched: count=\(decoded.messages.count, privacy: .public), hasNextPage=\(decoded.nextPageToken?.isEmpty == false, privacy: .public)")
+            return decoded
+        } catch {
+            Loggers.network.error("Failed to decode inbox messages response: \(error.localizedDescription, privacy: .public)")
+            throw ATTNError.inboxResponseDecodeFailed
+        }
+    }
+
+    private static let inboxJSONDecoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
     /// async bridge over `URLSession.dataTask(with:completionHandler:)` — `URLSession.data(for:)`
     /// is an extension method and can't be intercepted by `NSURLSessionMock`.
     private func dataTask(with request: URLRequest) async throws -> (Data, URLResponse) {

--- a/Sources/API/ATTNAPIProtocol.swift
+++ b/Sources/API/ATTNAPIProtocol.swift
@@ -82,4 +82,17 @@ protocol ATTNAPIProtocol {
         phone: String?,
         visitorId: String
     ) async throws -> Int
+
+    /// Fetches a page of inbox messages for the current user.
+    /// - Parameters:
+    ///   - pageSize: max number of messages to return; server clamps to its own upper bound.
+    ///   - pageToken: opaque cursor from a previous response's `next_page_token`; `nil` for the first page.
+    func fetchInboxMessages(
+        pushToken: String,
+        email: String?,
+        phone: String?,
+        visitorId: String,
+        pageSize: Int,
+        pageToken: String?
+    ) async throws -> InboxResponse
 }

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -66,7 +66,7 @@ actor InboxManager {
     var allMessages: [Message] {
         get async {
             await awaitInitialRefresh()
-            return messageOrder.compactMap { messagesByID[$0] }
+            return orderedMessagesSnapshot()
         }
     }
 
@@ -77,8 +77,8 @@ actor InboxManager {
         }
     }
 
-    /// True when the last successful fetch reported a `next_page_token`. Used by the UI to
-    /// decide whether to attempt a pull-up load.
+    /// True when the last successful fetch reported a `next_page_token`. Used by tests and any
+    /// caller that wants a cheap "can we page further" signal without calling `loadNextPage()`.
     var hasMore: Bool {
         nextPageToken?.isEmpty == false
     }
@@ -121,24 +121,28 @@ actor InboxManager {
         // `ATTNSDK.materializedInboxManager()`. Calls `performUnreadCountFetch` directly (not
         // `refreshUnreadCount`) so it doesn't try to coalesce with itself.
         initialRefreshTask = Task { [weak self] in
-            await self?.loadInitialMessagesAndUnreadCount()
+            await self?.performMessagesAndUnreadCountRefresh()
         }
     }
 
-    /// Fetches the first page of inbox messages, replacing any previously loaded messages.
-    /// Callers should invoke this on inbox open / pull-to-refresh / push open.
+    /// Fetches the first page of inbox messages and the latest unread count, replacing any
+    /// previously loaded messages. The two fetches run concurrently. Callers should invoke
+    /// this on inbox open / pull-to-refresh / push open.
     func refresh() async {
-        await performMessagesRefresh()
+        await performMessagesAndUnreadCountRefresh()
     }
 
     /// Fetches the next page of messages using the stored `nextPageToken` and appends them.
     /// Safe to call repeatedly — no-ops when no more pages are available or another fetch is in flight.
-    func loadNextPage() async {
+    /// Returns `true` when a network fetch was actually started; callers can use this to gate a
+    /// "loading more" indicator without needing a separate probe.
+    @discardableResult
+    func loadNextPage() async -> Bool {
         guard hasFetchedFirstPage, !isLoadingNextPage, let pageToken = nextPageToken, !pageToken.isEmpty else {
-            return
+            return false
         }
         let identity = identityProvider()
-        guard !identity.visitorId.isEmpty else { return }
+        guard !identity.visitorId.isEmpty else { return false }
 
         isLoadingNextPage = true
         let generation = messagesGeneration
@@ -155,7 +159,7 @@ actor InboxManager {
             guard generation == messagesGeneration else {
                 // Identity or refresh() moved on; discard this page.
                 isLoadingNextPage = false
-                return
+                return true
             }
             appendMessages(response.messages)
             nextPageToken = response.nextPageToken
@@ -166,6 +170,7 @@ actor InboxManager {
             isLoadingNextPage = false
             // Keep existing list; caller can retry by pulling up again.
         }
+        return true
     }
 
     /// Fetches the latest unread count from the server and stores it as the
@@ -183,12 +188,14 @@ actor InboxManager {
         await performUnreadCountFetch(skipNotify: false)
     }
 
-    /// Init-time seed: fetch the first page of messages and the server-authoritative unread
-    /// count. The count fetch runs with `skipNotify: false` so subscribers get a nudge to
-    /// re-read `unreadCount` when the server value arrives.
-    private func loadInitialMessagesAndUnreadCount() async {
-        await performMessagesRefresh()
-        await performUnreadCountFetch(skipNotify: false)
+    /// Fetches the first page of messages and the server-authoritative unread count concurrently.
+    /// Shared by init-time load and every `refresh()`. `skipNotify: false` lets subscribers get a
+    /// nudge to re-read `unreadCount` when the count arrives after the messages have already
+    /// emitted `.loaded` (order between the two `async let`s is non-deterministic).
+    private func performMessagesAndUnreadCountRefresh() async {
+        async let messages: Void = performMessagesRefresh()
+        async let count: Void = performUnreadCountFetch(skipNotify: false)
+        _ = await (messages, count)
     }
 
     /// Internal worker used by both the init task and the public `refresh()`. Fetches page 1,
@@ -202,9 +209,7 @@ actor InboxManager {
 
         messagesGeneration &+= 1
         let generation = messagesGeneration
-        // Reset pagination bookkeeping so a stale nextPageToken can't accidentally leak into
-        // this refresh's follow-up load.
-        nextPageToken = nil
+        // Cancel any in-flight page load; the bumped generation will make it a no-op on return.
         isLoadingNextPage = false
 
         // Only emit .loading on the very first refresh; on subsequent refreshes keep the last
@@ -230,8 +235,8 @@ actor InboxManager {
         } catch {
             guard generation == messagesGeneration else { return }
             Loggers.network.error("Failed to refresh inbox messages: \(error.localizedDescription, privacy: .public)")
-            // Preserve the previously loaded list on error; only surface `.error` if we
-            // never successfully loaded anything.
+            // Preserve the previously loaded list and its pagination cursor on error; only
+            // surface `.error` if we never successfully loaded anything.
             if hasFetchedFirstPage {
                 send(.loaded(orderedMessagesSnapshot()))
             } else {
@@ -275,11 +280,13 @@ actor InboxManager {
     }
 
     func markRead(_ messageID: Message.ID) {
+        guard messagesByID[messageID]?.isRead == false else { return }
         messagesByID[messageID]?.isRead = true
         send(.loaded(orderedMessagesSnapshot()))
     }
 
     func markUnread(_ messageID: Message.ID) {
+        guard messagesByID[messageID]?.isRead == true else { return }
         messagesByID[messageID]?.isRead = false
         send(.loaded(orderedMessagesSnapshot()))
     }
@@ -290,17 +297,23 @@ actor InboxManager {
         send(.loaded(orderedMessagesSnapshot()))
     }
 
-    /// Resets the cached unread count to 0 and bumps both generations so any in-flight
-    /// fetches from the previous identity are discarded when they return. Called on identity
-    /// changes (`clearUser`, `updateUser`) so a logged-out account's badge is not surfaced to
-    /// the next user.
-    func resetUnreadCount() {
+    /// Clears all cached inbox state (messages, unread count, pagination cursor) and bumps both
+    /// generations so any in-flight fetches from the previous identity are discarded when they
+    /// return. Called on identity changes (`clearUser`, `updateUser`) so a logged-out account's
+    /// messages and badge are not surfaced to the next user.
+    func resetForIdentityChange() {
         refreshGeneration &+= 1
         messagesGeneration &+= 1
-        guard storedUnreadCount != 0 else { return }
         storedUnreadCount = 0
+        messagesByID = [:]
+        messageOrder = []
+        nextPageToken = nil
+        hasFetchedFirstPage = false
+        isLoadingNextPage = false
+        // Only re-emit when we were already surfacing a loaded list — never override an
+        // in-flight .loading state, which would strand hosts that don't re-present InboxView.
         if case .loaded = currentState {
-            send(currentState)
+            send(.loaded([]))
         }
     }
 }
@@ -326,10 +339,7 @@ extension InboxManager {
     private func replaceMessages(with messages: [Message]) {
         messagesByID = [:]
         messageOrder = []
-        for message in messages where messagesByID[message.id] == nil {
-            messagesByID[message.id] = message
-            messageOrder.append(message.id)
-        }
+        appendMessages(messages)
     }
 
     private func appendMessages(_ messages: [Message]) {

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -34,6 +34,9 @@ actor InboxManager {
     private var messageOrder: [Message.ID] = []
     private var currentState: InboxState = .loading
     private var continuations: [UUID: AsyncStream<InboxState>.Continuation] = [:]
+    /// Broadcasts every `isLoadingNextPage` transition so the ViewModel can render a footer
+    /// spinner that tracks the manager's true fetch state, not an optimistic guess.
+    private var loadingMoreContinuations: [UUID: AsyncStream<Bool>.Continuation] = [:]
 
     /// Cursor from the most recent successful page fetch. `nil` means "no more pages" (or "haven't
     /// fetched yet"); use `hasMore` for the caller-facing "can we page further" signal.
@@ -42,6 +45,12 @@ actor InboxManager {
     /// Guards against overlapping `loadNextPage()` calls when the SwiftUI list rapidly reports
     /// the last row appearing.
     private var isLoadingNextPage: Bool = false
+    /// Set while a first-page refresh is in flight. `loadNextPage()` refuses to run during this
+    /// window: without the gate, a page load fired mid-refresh (e.g. last-row `.onAppear` during
+    /// a pull-to-refresh) would pass the guard, capture the refresh's generation, and clobber
+    /// `nextPageToken` when both settle. Distinct from `isLoadingNextPage` because a stale page
+    /// load returning inside the refresh window resets that flag but must not release this one.
+    private var isRefreshingFirstPage: Bool = false
 
     /// Server-authoritative unread count. Only `refreshUnreadCount()` writes it; local
     /// `markRead` / `markUnread` do not. Reads should go through the `unreadCount` accessor,
@@ -112,6 +121,23 @@ actor InboxManager {
         }
     }
 
+    /// Returns an AsyncStream that immediately emits the current `isLoadingNextPage`, then
+    /// emits every subsequent transition. Distinct from `stateStream` so a paging-in-flight
+    /// signal doesn't force the list to re-render just because a footer spinner is (dis)appearing.
+    var loadingMoreStream: AsyncStream<Bool> {
+        let current = self.isLoadingNextPage
+        return AsyncStream { continuation in
+            let id = UUID()
+            continuation.yield(current)
+            self.loadingMoreContinuations[id] = continuation
+            continuation.onTermination = { [weak self] _ in
+                Task { [weak self] in
+                    await self?.removeLoadingMoreContinuation(id: id)
+                }
+            }
+        }
+    }
+
     init(api: ATTNAPIProtocol, identityProvider: @escaping InboxIdentityProvider) {
         self.api = api
         self.identityProvider = identityProvider
@@ -141,19 +167,23 @@ actor InboxManager {
     }
 
     /// Fetches the next page of messages using the stored `nextPageToken` and appends them.
-    /// Safe to call repeatedly — no-ops when no more pages are available or another fetch is in flight.
-    /// Returns `true` when a network fetch was actually started; callers can use this to gate a
-    /// "loading more" indicator without needing a separate probe.
-    @discardableResult
-    func loadNextPage() async -> Bool {
-        guard hasFetchedFirstPage, !isLoadingNextPage, let pageToken = nextPageToken, !pageToken.isEmpty else {
-            return false
+    /// Safe to call repeatedly — no-ops when no more pages are available, another fetch is in
+    /// flight, or a first-page refresh is running. Subscribers to `loadingMoreStream` observe
+    /// the in-flight state; callers do not need to inspect a return value.
+    func loadNextPage() async {
+        guard hasFetchedFirstPage,
+              !isRefreshingFirstPage,
+              !isLoadingNextPage,
+              let pageToken = nextPageToken,
+              !pageToken.isEmpty else {
+            return
         }
         let identity = identityProvider()
-        guard !identity.visitorId.isEmpty else { return false }
+        guard !identity.visitorId.isEmpty else { return }
 
-        isLoadingNextPage = true
+        setLoadingNextPage(true)
         let generation = messagesGeneration
+        defer { setLoadingNextPage(false) }
 
         do {
             let response = try await api.fetchInboxMessages(
@@ -166,19 +196,15 @@ actor InboxManager {
             )
             guard generation == messagesGeneration else {
                 // Identity or refresh() moved on; discard this page.
-                isLoadingNextPage = false
-                return true
+                return
             }
             appendMessages(response.messages)
             nextPageToken = response.nextPageToken
-            isLoadingNextPage = false
             send(.loaded(orderedMessagesSnapshot()))
         } catch {
             Loggers.network.error("Failed to load next inbox page: \(error.localizedDescription, privacy: .public)")
-            isLoadingNextPage = false
             // Keep existing list; caller can retry by pulling up again.
         }
-        return true
     }
 
     /// Fetches the latest unread count from the server and stores it as the
@@ -218,7 +244,12 @@ actor InboxManager {
         messagesGeneration &+= 1
         let generation = messagesGeneration
         // Cancel any in-flight page load; the bumped generation will make it a no-op on return.
-        isLoadingNextPage = false
+        setLoadingNextPage(false)
+        // Block new page loads for the duration of this refresh — even one that fires between
+        // now and when the page-1 response arrives would otherwise race the refresh and clobber
+        // the fresh `nextPageToken` with a stale one.
+        isRefreshingFirstPage = true
+        defer { isRefreshingFirstPage = false }
 
         // Only emit .loading on the very first refresh; on subsequent refreshes keep the last
         // successful list visible until the new page arrives, mirroring iOS Mail behavior.
@@ -317,7 +348,8 @@ actor InboxManager {
         messageOrder = []
         nextPageToken = nil
         hasFetchedFirstPage = false
-        isLoadingNextPage = false
+        setLoadingNextPage(false)
+        isRefreshingFirstPage = false
         // Only re-emit when we were already surfacing a loaded list — never override an
         // in-flight .loading state, which would strand hosts that don't re-present InboxView.
         if case .loaded = currentState {
@@ -333,10 +365,24 @@ extension InboxManager {
         continuations.removeValue(forKey: id)
     }
 
+    private func removeLoadingMoreContinuation(id: UUID) {
+        loadingMoreContinuations.removeValue(forKey: id)
+    }
+
     private func send(_ state: InboxState) {
         currentState = state
         for continuation in continuations.values {
             continuation.yield(state)
+        }
+    }
+
+    /// Single write path for `isLoadingNextPage` so every transition also fans out on
+    /// `loadingMoreStream`. Skips the fan-out when the value hasn't actually changed.
+    private func setLoadingNextPage(_ newValue: Bool) {
+        guard isLoadingNextPage != newValue else { return }
+        isLoadingNextPage = newValue
+        for continuation in loadingMoreContinuations.values {
+            continuation.yield(newValue)
         }
     }
 

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -129,6 +129,14 @@ actor InboxManager {
     /// previously loaded messages. The two fetches run concurrently. Callers should invoke
     /// this on inbox open / pull-to-refresh / push open.
     func refresh() async {
+        // Coalesce with the init-time fetch. `InboxView.task` fires immediately after
+        // materializing the manager, so without this the first open would double-POST and race
+        // its own init generation.
+        if let task = initialRefreshTask {
+            initialRefreshTask = nil
+            await task.value
+            return
+        }
         await performMessagesAndUnreadCountRefresh()
     }
 

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -26,10 +26,22 @@ struct InboxIdentitySnapshot: Sendable {
 typealias InboxIdentityProvider = @Sendable () -> InboxIdentitySnapshot
 
 actor InboxManager {
+    /// Per RFC, the server clamps `page_size` to its own upper bound; this value is a client-side
+    /// hint that balances first-paint latency against round-trip count.
+    private static let defaultPageSize = 20
+
     private var messagesByID: [Message.ID: Message] = [:]
-    private var cachedSortedMessages: [Message]?
+    private var messageOrder: [Message.ID] = []
     private var currentState: InboxState = .loading
     private var continuations: [UUID: AsyncStream<InboxState>.Continuation] = [:]
+
+    /// Cursor from the most recent successful page fetch. `nil` means "no more pages" (or "haven't
+    /// fetched yet"); use `hasMore` for the caller-facing "can we page further" signal.
+    private var nextPageToken: String?
+    private var hasFetchedFirstPage: Bool = false
+    /// Guards against overlapping `loadNextPage()` calls when the SwiftUI list rapidly reports
+    /// the last row appearing.
+    private var isLoadingNextPage: Bool = false
 
     /// Server-authoritative unread count. Only `refreshUnreadCount()` writes it; local
     /// `markRead` / `markUnread` do not. Reads should go through the `unreadCount` accessor,
@@ -43,14 +55,18 @@ actor InboxManager {
     /// `allMessages` read returns.
     private var initialRefreshTask: Task<Void, Never>?
 
-    /// Monotonic counter used to discard responses from refresh calls that have been
+    /// Monotonic counter used to discard responses from unread-count fetches that have been
     /// superseded by a newer in-flight call or an identity reset.
     private var refreshGeneration: UInt = 0
+
+    /// Monotonic counter used to discard responses from message refresh/pagination calls that
+    /// have been superseded by a newer identity or a newer top-level `refresh()`.
+    private var messagesGeneration: UInt = 0
 
     var allMessages: [Message] {
         get async {
             await awaitInitialRefresh()
-            return sortedMessagesSnapshot()
+            return messageOrder.compactMap { messagesByID[$0] }
         }
     }
 
@@ -61,6 +77,17 @@ actor InboxManager {
         }
     }
 
+    /// True when the last successful fetch reported a `next_page_token`. Used by the UI to
+    /// decide whether to attempt a pull-up load.
+    var hasMore: Bool {
+        nextPageToken?.isEmpty == false
+    }
+
+    /// Test-only accessor for the current state, since we can't read `currentState` directly.
+    var currentInboxStateForTesting: InboxState {
+        currentState
+    }
+
     private func awaitInitialRefresh() async {
         // Drain the init-time refresh exactly once; subsequent reads are constant-time.
         if let task = initialRefreshTask {
@@ -69,27 +96,14 @@ actor InboxManager {
         }
     }
 
-    private func sortedMessagesSnapshot() -> [Message] {
-        if let cached = cachedSortedMessages {
-            return cached
-        }
-        let sorted = messagesByID.values.sorted { $0.timestamp > $1.timestamp }
-        cachedSortedMessages = sorted
-        return sorted
-    }
-
     /// Returns an AsyncStream that immediately emits the current state,
     /// then emits all subsequent state changes.
     var stateStream: AsyncStream<InboxState> {
         let currentState = self.currentState
         return AsyncStream { continuation in
             let id = UUID()
-            // Emit current state immediately
             continuation.yield(currentState)
-
-            // Register for future updates
             self.continuations[id] = continuation
-
             continuation.onTermination = { [weak self] _ in
                 Task { [weak self] in
                     await self?.removeContinuation(id: id)
@@ -101,13 +115,56 @@ actor InboxManager {
     init(api: ATTNAPIProtocol, identityProvider: @escaping InboxIdentityProvider) {
         self.api = api
         self.identityProvider = identityProvider
-        // Populate mock messages and fetch the unread count on construction so passive-badge
+        // Fetch the first page of messages and the unread count on construction so passive-badge
         // hosts (`sdk.unreadCount`) and stream/`allMessages` consumers both resolve without
         // needing to present `inboxView()`. Non-inbox hosts never construct the manager — see
         // `ATTNSDK.materializedInboxManager()`. Calls `performUnreadCountFetch` directly (not
         // `refreshUnreadCount`) so it doesn't try to coalesce with itself.
         initialRefreshTask = Task { [weak self] in
             await self?.loadInitialMessagesAndUnreadCount()
+        }
+    }
+
+    /// Fetches the first page of inbox messages, replacing any previously loaded messages.
+    /// Callers should invoke this on inbox open / pull-to-refresh / push open.
+    func refresh() async {
+        await performMessagesRefresh()
+    }
+
+    /// Fetches the next page of messages using the stored `nextPageToken` and appends them.
+    /// Safe to call repeatedly — no-ops when no more pages are available or another fetch is in flight.
+    func loadNextPage() async {
+        guard hasFetchedFirstPage, !isLoadingNextPage, let pageToken = nextPageToken, !pageToken.isEmpty else {
+            return
+        }
+        let identity = identityProvider()
+        guard !identity.visitorId.isEmpty else { return }
+
+        isLoadingNextPage = true
+        let generation = messagesGeneration
+
+        do {
+            let response = try await api.fetchInboxMessages(
+                pushToken: identity.pushToken,
+                email: identity.email,
+                phone: identity.phone,
+                visitorId: identity.visitorId,
+                pageSize: Self.defaultPageSize,
+                pageToken: pageToken
+            )
+            guard generation == messagesGeneration else {
+                // Identity or refresh() moved on; discard this page.
+                isLoadingNextPage = false
+                return
+            }
+            appendMessages(response.messages)
+            nextPageToken = response.nextPageToken
+            isLoadingNextPage = false
+            send(.loaded(orderedMessagesSnapshot()))
+        } catch {
+            Loggers.network.error("Failed to load next inbox page: \(error.localizedDescription, privacy: .public)")
+            isLoadingNextPage = false
+            // Keep existing list; caller can retry by pulling up again.
         }
     }
 
@@ -126,19 +183,66 @@ actor InboxManager {
         await performUnreadCountFetch(skipNotify: false)
     }
 
-    /// Init-time seed: populate mock messages so `allMessages` / `inboxStateStream` resolve
-    /// for hosts that never present `inboxView()`, then fetch the server-authoritative unread
-    /// count. `updateMessages` emits `.loaded` immediately; the count fetch runs with
-    /// `skipNotify: false` so subscribers get a nudge to re-read `unreadCount` when the
-    /// server value arrives.
+    /// Init-time seed: fetch the first page of messages and the server-authoritative unread
+    /// count. The count fetch runs with `skipNotify: false` so subscribers get a nudge to
+    /// re-read `unreadCount` when the server value arrives.
     private func loadInitialMessagesAndUnreadCount() async {
-        updateMessages(Self.getMockInbox().messages)
+        await performMessagesRefresh()
         await performUnreadCountFetch(skipNotify: false)
+    }
+
+    /// Internal worker used by both the init task and the public `refresh()`. Fetches page 1,
+    /// resets pagination bookkeeping, and updates state.
+    private func performMessagesRefresh() async {
+        let identity = identityProvider()
+        guard !identity.visitorId.isEmpty else {
+            Loggers.network.debug("Skipping inbox messages refresh: empty visitor ID")
+            return
+        }
+
+        messagesGeneration &+= 1
+        let generation = messagesGeneration
+        // Reset pagination bookkeeping so a stale nextPageToken can't accidentally leak into
+        // this refresh's follow-up load.
+        nextPageToken = nil
+        isLoadingNextPage = false
+
+        // Only emit .loading on the very first refresh; on subsequent refreshes keep the last
+        // successful list visible until the new page arrives, mirroring iOS Mail behavior.
+        if !hasFetchedFirstPage {
+            send(.loading)
+        }
+
+        do {
+            let response = try await api.fetchInboxMessages(
+                pushToken: identity.pushToken,
+                email: identity.email,
+                phone: identity.phone,
+                visitorId: identity.visitorId,
+                pageSize: Self.defaultPageSize,
+                pageToken: nil
+            )
+            guard generation == messagesGeneration else { return }
+            replaceMessages(with: response.messages)
+            nextPageToken = response.nextPageToken
+            hasFetchedFirstPage = true
+            send(.loaded(orderedMessagesSnapshot()))
+        } catch {
+            guard generation == messagesGeneration else { return }
+            Loggers.network.error("Failed to refresh inbox messages: \(error.localizedDescription, privacy: .public)")
+            // Preserve the previously loaded list on error; only surface `.error` if we
+            // never successfully loaded anything.
+            if hasFetchedFirstPage {
+                send(.loaded(orderedMessagesSnapshot()))
+            } else {
+                send(.error(error))
+            }
+        }
     }
 
     /// Internal worker. Always fires a network request — no coalesce check — so the init
     /// task can call this without deadlocking on itself. `skipNotify == true` when the
-    /// caller (e.g. `refresh()`) will emit its own `.loaded` after `updateMessages`.
+    /// caller (e.g. `refresh()`) will emit its own `.loaded` after updating messages.
     private func performUnreadCountFetch(skipNotify: Bool) async {
         let identity = identityProvider()
         // Without a visitor ID the server can't scope the request — skip rather than send
@@ -172,37 +276,27 @@ actor InboxManager {
 
     func markRead(_ messageID: Message.ID) {
         messagesByID[messageID]?.isRead = true
-        updateCachedMessage(messageID)
-        send(.loaded(sortedMessagesSnapshot()))
+        send(.loaded(orderedMessagesSnapshot()))
     }
 
     func markUnread(_ messageID: Message.ID) {
         messagesByID[messageID]?.isRead = false
-        updateCachedMessage(messageID)
-        send(.loaded(sortedMessagesSnapshot()))
+        send(.loaded(orderedMessagesSnapshot()))
     }
 
     func delete(_ messageID: Message.ID) {
         messagesByID.removeValue(forKey: messageID)
-        invalidateCache()
-        send(.loaded(sortedMessagesSnapshot()))
+        messageOrder.removeAll { $0 == messageID }
+        send(.loaded(orderedMessagesSnapshot()))
     }
 
-    /// Reloads inbox messages and re-fetches the server-authoritative unread count.
-    /// Called on inbox open, pull-to-refresh, and (indirectly, via the host app) push open.
-    /// Once the real messages endpoint replaces `getMockInbox()` this should switch to
-    /// `async let` so the two network calls run concurrently.
-    func refresh() async {
-        updateMessages(Self.getMockInbox().messages)
-        // skipNotify because updateMessages above already emitted `.loaded`.
-        await performUnreadCountFetch(skipNotify: true)
-    }
-
-    /// Resets the cached unread count to 0 and bumps the refresh generation so any in-flight
-    /// fetch from the previous identity is discarded when it returns. Called on identity changes
-    /// (`clearUser`, `updateUser`) so a logged-out account's badge is not surfaced to the next user.
+    /// Resets the cached unread count to 0 and bumps both generations so any in-flight
+    /// fetches from the previous identity are discarded when they return. Called on identity
+    /// changes (`clearUser`, `updateUser`) so a logged-out account's badge is not surfaced to
+    /// the next user.
     func resetUnreadCount() {
         refreshGeneration &+= 1
+        messagesGeneration &+= 1
         guard storedUnreadCount != 0 else { return }
         storedUnreadCount = 0
         if case .loaded = currentState {
@@ -225,62 +319,25 @@ extension InboxManager {
         }
     }
 
-    private func updateMessages(_ messages: [Message]) {
-        messagesByID = messages.reduce(into: [Message.ID: Message]()) {
-            $0[$1.id] = $1
-        }
-        invalidateCache()
-        send(.loaded(sortedMessagesSnapshot()))
+    private func orderedMessagesSnapshot() -> [Message] {
+        messageOrder.compactMap { messagesByID[$0] }
     }
 
-    private func invalidateCache() {
-        cachedSortedMessages = nil
+    private func replaceMessages(with messages: [Message]) {
+        messagesByID = [:]
+        messageOrder = []
+        for message in messages where messagesByID[message.id] == nil {
+            messagesByID[message.id] = message
+            messageOrder.append(message.id)
+        }
     }
 
-    private func updateCachedMessage(_ messageID: Message.ID) {
-        let cachedSortedMessageIndex = messagesByID[messageID].flatMap { message in
-            cachedSortedMessages?.firstIndex { cachedMessage in
-                cachedMessage.id == message.id
-            }
+    private func appendMessages(_ messages: [Message]) {
+        // Dedup on id; the server's contract is stable per (companyId, userId, messageId) but a
+        // retried page during a paginated fetch could still deliver a duplicate.
+        for message in messages where messagesByID[message.id] == nil {
+            messagesByID[message.id] = message
+            messageOrder.append(message.id)
         }
-        guard let updatedMessage = messagesByID[messageID], let cachedSortedMessageIndex else {
-            return
-        }
-        cachedSortedMessages?[cachedSortedMessageIndex] = updatedMessage
-    }
-}
-
-fileprivate extension InboxManager {
-    private static func getMockInbox() -> InboxResponse {
-        let messages: [Message] = [
-            Message(
-                id: "1",
-                style: .small,
-                title: "Welcome to Attentive!",
-                body: "Thanks for joining us. Check out our latest offers.",
-                timestamp: Date().advanced(by: -86400),
-                isRead: false,
-                imageURLString: "https://picsum.photos/200"
-            ),
-            Message(
-                id: "2",
-                style: .large,
-                title: "New Sale Alert",
-                body: "50% off on all items this weekend!",
-                timestamp: Date().advanced(by: -172800),
-                isRead: false,
-                imageURLString: "https://picsum.photos/200/120"
-            ),
-            Message(
-                id: "3",
-                style: .small,
-                title: "Your Order Has Shipped",
-                body: "Your order #12345 is on its way!",
-                timestamp: Date().advanced(by: -259200),
-                isRead: false,
-                actionURLString: "https://example.com/track/12345"
-            )
-        ]
-        return InboxResponse(messages: messages)
     }
 }

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -183,7 +183,14 @@ actor InboxManager {
 
         setLoadingNextPage(true)
         let generation = messagesGeneration
-        defer { setLoadingNextPage(false) }
+        // Guard the release on generation: a superseded page load returning after a newer
+        // refresh or another page load has bumped the counter must not clear the newer one's
+        // flag (would prematurely hide the spinner and re-open the guard for a duplicate fetch).
+        defer {
+            if generation == messagesGeneration {
+                setLoadingNextPage(false)
+            }
+        }
 
         do {
             let response = try await api.fetchInboxMessages(
@@ -249,7 +256,14 @@ actor InboxManager {
         // now and when the page-1 response arrives would otherwise race the refresh and clobber
         // the fresh `nextPageToken` with a stale one.
         isRefreshingFirstPage = true
-        defer { isRefreshingFirstPage = false }
+        // Guard the release on generation: if a newer refresh (or `resetForIdentityChange`)
+        // bumps the counter, it owns the flag and manages release itself — a superseded
+        // refresh clearing the gate would re-open the exact race this flag exists to prevent.
+        defer {
+            if generation == messagesGeneration {
+                isRefreshingFirstPage = false
+            }
+        }
 
         // Only emit .loading on the very first refresh; on subsequent refreshes keep the last
         // successful list visible until the new page arrives, mirroring iOS Mail behavior.

--- a/Sources/Inbox/InboxView.swift
+++ b/Sources/Inbox/InboxView.swift
@@ -50,6 +50,14 @@ struct InboxView: View {
                                 }
                             }
                     }
+                    if viewModel.isLoadingMore {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                            Spacer()
+                        }
+                        .listRowSeparator(.hidden)
+                    }
                 }
             }
         }
@@ -58,7 +66,7 @@ struct InboxView: View {
         }
     }
 
-    private func buildListView<Content: View>(content: () -> Content) -> some View {
+    private func buildListView<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         List(content: content)
             .listStyle(.plain)
             .navigationTitle(String.inbox)

--- a/Sources/Inbox/InboxView.swift
+++ b/Sources/Inbox/InboxView.swift
@@ -42,6 +42,13 @@ struct InboxView: View {
                                 }
                                 .tint(.blue)
                             }
+                            .onAppear {
+                                // Pull-up-to-load-more: when the last row scrolls into view, ask for
+                                // the next page. The manager is a no-op when nothing more is available.
+                                if message.id == messages.last?.id {
+                                    viewModel.loadNextPage()
+                                }
+                            }
                     }
                 }
             }

--- a/Sources/Inbox/InboxViewModel.swift
+++ b/Sources/Inbox/InboxViewModel.swift
@@ -19,6 +19,10 @@ class InboxViewModel: ObservableObject {
     @Published
     var state: State = .loading
 
+    /// True while a `loadNextPage()` call is in flight. Drives the footer spinner in `InboxView`.
+    @Published
+    var isLoadingMore: Bool = false
+
     let style: InboxStyle
 
     private let inboxManager: InboxManager
@@ -46,10 +50,18 @@ class InboxViewModel: ObservableObject {
     }
 
     /// Called by the view when the last row appears, triggering an infinite-scroll page fetch.
-    /// The manager guards against overlapping calls and no-ops when no more pages are available.
+    /// The manager guards against overlapping calls and no-ops when no more pages are available;
+    /// its `Bool` return tells us whether a fetch actually started so we can toggle the footer
+    /// spinner off only when there was one to hide.
     func loadNextPage() {
-        Task { [inboxManager] in
-            await inboxManager.loadNextPage()
+        // Optimistically show the spinner; the manager will either fetch (spinner stays until the
+        // fetch returns) or no-op (we clear it immediately below). A brief flash on no-op is
+        // preferable to two actor hops on every last-row `.onAppear`.
+        isLoadingMore = true
+        Task { [weak self] in
+            guard let self = self else { return }
+            _ = await self.inboxManager.loadNextPage()
+            self.isLoadingMore = false
         }
     }
 

--- a/Sources/Inbox/InboxViewModel.swift
+++ b/Sources/Inbox/InboxViewModel.swift
@@ -19,14 +19,17 @@ class InboxViewModel: ObservableObject {
     @Published
     var state: State = .loading
 
-    /// True while a `loadNextPage()` call is in flight. Drives the footer spinner in `InboxView`.
+    /// True while the manager reports a next-page fetch in flight. Driven by the manager's
+    /// `loadingMoreStream`, so a rapid `.onAppear` burst that no-ops in the manager never flips
+    /// this on, and the flag is only cleared once the real fetch settles.
     @Published
-    var isLoadingMore: Bool = false
+    private(set) var isLoadingMore: Bool = false
 
     let style: InboxStyle
 
     private let inboxManager: InboxManager
     private var stateStreamTask: Task<Void, Never>?
+    private var loadingMoreStreamTask: Task<Void, Never>?
 
     init(inboxManager: InboxManager, style: InboxStyle) {
         self.inboxManager = inboxManager
@@ -39,10 +42,18 @@ class InboxViewModel: ObservableObject {
                 self?.state = state.viewState
             }
         }
+        loadingMoreStreamTask = Task { [weak self] in
+            guard let stream = await self?.inboxManager.loadingMoreStream else { return }
+            for await isLoading in stream {
+                guard !Task.isCancelled else { return }
+                self?.isLoadingMore = isLoading
+            }
+        }
     }
 
     deinit {
         stateStreamTask?.cancel()
+        loadingMoreStreamTask?.cancel()
     }
 
     func refresh() async {
@@ -51,17 +62,10 @@ class InboxViewModel: ObservableObject {
 
     /// Called by the view when the last row appears, triggering an infinite-scroll page fetch.
     /// The manager guards against overlapping calls and no-ops when no more pages are available;
-    /// its `Bool` return tells us whether a fetch actually started so we can toggle the footer
-    /// spinner off only when there was one to hide.
+    /// spinner visibility is driven by its `loadingMoreStream` (see init), not this method.
     func loadNextPage() {
-        // Optimistically show the spinner; the manager will either fetch (spinner stays until the
-        // fetch returns) or no-op (we clear it immediately below). A brief flash on no-op is
-        // preferable to two actor hops on every last-row `.onAppear`.
-        isLoadingMore = true
-        Task { [weak self] in
-            guard let self = self else { return }
-            _ = await self.inboxManager.loadNextPage()
-            self.isLoadingMore = false
+        Task { [inboxManager] in
+            await inboxManager.loadNextPage()
         }
     }
 

--- a/Sources/Inbox/InboxViewModel.swift
+++ b/Sources/Inbox/InboxViewModel.swift
@@ -45,6 +45,14 @@ class InboxViewModel: ObservableObject {
         await inboxManager.refresh()
     }
 
+    /// Called by the view when the last row appears, triggering an infinite-scroll page fetch.
+    /// The manager guards against overlapping calls and no-ops when no more pages are available.
+    func loadNextPage() {
+        Task { [inboxManager] in
+            await inboxManager.loadNextPage()
+        }
+    }
+
     func markAsRead(_ messageID: Message.ID) {
         Task {
             await inboxManager.markRead(messageID)

--- a/Sources/Inbox/Models/InboxResponse.swift
+++ b/Sources/Inbox/Models/InboxResponse.swift
@@ -7,4 +7,11 @@
 
 struct InboxResponse: Codable {
     var messages: [Message]
+    /// Opaque cursor returned by the server. Absent (or empty) when there are no more pages.
+    var nextPageToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case messages
+        case nextPageToken = "next_page_token"
+    }
 }

--- a/Sources/Inbox/Models/Message.swift
+++ b/Sources/Inbox/Models/Message.swift
@@ -34,6 +34,7 @@ public struct Message: Codable, Identifiable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case id = "inbox_message_id"
+        case style
         case title
         case body
         case timestamp = "sent_at"
@@ -71,7 +72,9 @@ public struct Message: Codable, Identifiable, Sendable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(String.self, forKey: .id)
-        self.style = .small
+        // The server does not return `style` today; default to `.small` when absent so
+        // synthesized encode-decode round-trips (e.g. host-app persistence) preserve the field.
+        self.style = try container.decodeIfPresent(Style.self, forKey: .style) ?? .small
         self.title = try container.decode(String.self, forKey: .title)
         self.body = try container.decode(String.self, forKey: .body)
         self.timestamp = try container.decode(Date.self, forKey: .timestamp)

--- a/Sources/Inbox/Models/Message.swift
+++ b/Sources/Inbox/Models/Message.swift
@@ -12,28 +12,74 @@ public struct Message: Codable, Identifiable, Sendable {
         case small
         case large
     }
-    
+
     // swiftlint:disable:next type_name
     public typealias ID = String
 
     public var id: ID
+    /// Client-side rendering hint. The server does not return this today; every message
+    /// decoded from the API defaults to `.small`.
     public var style: Style
     public var title: String
     public var body: String
+    /// When the message was sent by the server. Server field: `sent_at`.
     public var timestamp: Date
     public var isRead: Bool
     public var imageURLString: String?
     public var actionURLString: String?
+    /// When the message expires and should no longer be shown. Absent means "never".
+    public var expiresAt: Date?
+    /// When the user last marked this message read. `nil` while unread.
+    public var readAt: Date?
 
     enum CodingKeys: String, CodingKey {
-        case id
-        case style
+        case id = "inbox_message_id"
         case title
         case body
-        case timestamp
+        case timestamp = "sent_at"
         case isRead = "is_read"
         case imageURLString = "image_url"
         case actionURLString = "action_url"
+        case expiresAt = "expires_at"
+        case readAt = "read_at"
+    }
+
+    public init(
+        id: ID,
+        style: Style = .small,
+        title: String,
+        body: String,
+        timestamp: Date,
+        isRead: Bool,
+        imageURLString: String? = nil,
+        actionURLString: String? = nil,
+        expiresAt: Date? = nil,
+        readAt: Date? = nil
+    ) {
+        self.id = id
+        self.style = style
+        self.title = title
+        self.body = body
+        self.timestamp = timestamp
+        self.isRead = isRead
+        self.imageURLString = imageURLString
+        self.actionURLString = actionURLString
+        self.expiresAt = expiresAt
+        self.readAt = readAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.style = .small
+        self.title = try container.decode(String.self, forKey: .title)
+        self.body = try container.decode(String.self, forKey: .body)
+        self.timestamp = try container.decode(Date.self, forKey: .timestamp)
+        self.isRead = try container.decode(Bool.self, forKey: .isRead)
+        self.imageURLString = try container.decodeIfPresent(String.self, forKey: .imageURLString)
+        self.actionURLString = try container.decodeIfPresent(String.self, forKey: .actionURLString)
+        self.expiresAt = try container.decodeIfPresent(Date.self, forKey: .expiresAt)
+        self.readAt = try container.decodeIfPresent(Date.self, forKey: .readAt)
     }
 
     public var imageURL: URL? {

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -223,11 +223,12 @@ public final class ATTNSDK: NSObject {
         let oldVisitorId = userIdentity.visitorId
         userIdentity.clearUser()
         publishIdentitySnapshot()
-        // Drop the previous user's cached unread count so the next user doesn't see their badge —
-        // but only if the manager has already been materialized. Constructing it here would issue
-        // an unread-count fetch for host apps that never touch the inbox surface.
+        // Drop the previous user's cached inbox state (messages + unread count + pagination
+        // cursor) so the next user doesn't see the wrong data — but only if the manager has
+        // already been materialized. Constructing it here would issue an unread-count fetch for
+        // host apps that never touch the inbox surface.
         if let manager = _inboxManager {
-            Task { await manager.resetUnreadCount() }
+            Task { await manager.resetForIdentityChange() }
         }
         Loggers.creative.debug("User cleared successfully - Old Visitor ID: \(oldVisitorId, privacy: .public), New Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
     }

--- a/Tests/Doubles/Mocks/NSURLSessionMock.swift
+++ b/Tests/Doubles/Mocks/NSURLSessionMock.swift
@@ -11,6 +11,7 @@ import Foundation
 class NSURLSessionMock: URLSession {
     var didCallEventsApi = false
     var didCallInboxUnreadCountApi = false
+    var didCallInboxMessagesApi = false
     var urlCalls: [URL] = []
     var requests: [URLRequest] = []
 
@@ -19,6 +20,12 @@ class NSURLSessionMock: URLSession {
     var inboxUnreadCountStatusCode: Int = 200
     var inboxUnreadCountResponseBody: Data = Data("{\"unread_count\": 5}".utf8)
     var inboxUnreadCountError: Error?
+
+    /// Override the response returned for the inbox messages endpoint.
+    /// Default: 200 with an empty message list and no next page.
+    var inboxMessagesStatusCode: Int = 200
+    var inboxMessagesResponseBody: Data = Data("{\"messages\": []}".utf8)
+    var inboxMessagesError: Error?
 
     override init() {
         super.init()
@@ -37,11 +44,23 @@ class NSURLSessionMock: URLSession {
                 }
             }
 
+            // Order matters: check the more specific `/inbox/messages/unread/count` before the
+            // `/inbox/messages` prefix so the general check doesn't shadow it.
             if url.absoluteString.contains("/inbox/messages/unread/count") {
                 didCallInboxUnreadCountApi = true
                 let body = inboxUnreadCountResponseBody
                 let status = inboxUnreadCountStatusCode
                 let error = inboxUnreadCountError
+                return NSURLSessionDataTaskMock { _, _, _ in
+                    completionHandler(body, HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil), error)
+                }
+            }
+
+            if url.absoluteString.hasSuffix("/inbox/messages") {
+                didCallInboxMessagesApi = true
+                let body = inboxMessagesResponseBody
+                let status = inboxMessagesStatusCode
+                let error = inboxMessagesError
                 return NSURLSessionDataTaskMock { _, _, _ in
                     completionHandler(body, HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil), error)
                 }

--- a/Tests/Doubles/Spies/ATTNAPISpy.swift
+++ b/Tests/Doubles/Spies/ATTNAPISpy.swift
@@ -188,6 +188,9 @@ final class ATTNAPISpy: ATTNAPIProtocol {
     /// Sequence of responses returned by successive `fetchInboxMessages` calls; the last entry is
     /// reused if more calls arrive than the array has entries.
     var stubbedInboxMessagesResponses: [InboxResponse] = [InboxResponse(messages: [], nextPageToken: nil)]
+    /// Invoked while a `fetchInboxMessages` call is "in flight" (after recording args, before
+    /// returning a response). Lets tests interleave a follow-up call to reproduce races.
+    var onFetchInboxMessages: (@Sendable (_ pageToken: String?) async -> Void)?
 
     func fetchInboxMessages(
         pushToken: String,
@@ -206,6 +209,7 @@ final class ATTNAPISpy: ATTNAPIProtocol {
         lastInboxMessagesVisitorId = visitorId
         lastInboxMessagesPageSize = pageSize
         lastInboxMessagesPageToken = pageToken
+        if let hook = onFetchInboxMessages { await hook(pageToken) }
         if let error = stubbedInboxMessagesError { throw error }
         let index = min(callIndex, stubbedInboxMessagesResponses.count - 1)
         return stubbedInboxMessagesResponses[index]

--- a/Tests/Doubles/Spies/ATTNAPISpy.swift
+++ b/Tests/Doubles/Spies/ATTNAPISpy.swift
@@ -174,4 +174,40 @@ final class ATTNAPISpy: ATTNAPIProtocol {
         if let error = stubbedInboxError { throw error }
         return stubbedUnreadCount
     }
+
+    // MARK: - Inbox Messages
+    private(set) var fetchInboxMessagesWasCalled = false
+    private(set) var fetchInboxMessagesCallCount = 0
+    private(set) var lastInboxMessagesPageSize: Int?
+    private(set) var lastInboxMessagesPageToken: String?
+    private(set) var lastInboxMessagesPushToken: String?
+    private(set) var lastInboxMessagesEmail: String?
+    private(set) var lastInboxMessagesPhone: String?
+    private(set) var lastInboxMessagesVisitorId: String?
+    var stubbedInboxMessagesError: Error?
+    /// Sequence of responses returned by successive `fetchInboxMessages` calls; the last entry is
+    /// reused if more calls arrive than the array has entries.
+    var stubbedInboxMessagesResponses: [InboxResponse] = [InboxResponse(messages: [], nextPageToken: nil)]
+
+    func fetchInboxMessages(
+        pushToken: String,
+        email: String?,
+        phone: String?,
+        visitorId: String,
+        pageSize: Int,
+        pageToken: String?
+    ) async throws -> InboxResponse {
+        fetchInboxMessagesWasCalled = true
+        let callIndex = fetchInboxMessagesCallCount
+        fetchInboxMessagesCallCount += 1
+        lastInboxMessagesPushToken = pushToken
+        lastInboxMessagesEmail = email
+        lastInboxMessagesPhone = phone
+        lastInboxMessagesVisitorId = visitorId
+        lastInboxMessagesPageSize = pageSize
+        lastInboxMessagesPageToken = pageToken
+        if let error = stubbedInboxMessagesError { throw error }
+        let index = min(callIndex, stubbedInboxMessagesResponses.count - 1)
+        return stubbedInboxMessagesResponses[index]
+    }
 }

--- a/Tests/TestCases/ATTNInboxMessagesAPITests.swift
+++ b/Tests/TestCases/ATTNInboxMessagesAPITests.swift
@@ -1,0 +1,165 @@
+//
+//  ATTNInboxMessagesAPITests.swift
+//  attentive-ios-sdk Tests
+//
+//  Created by Adela Gao on 7/6/26.
+//
+
+import XCTest
+@testable import ATTNSDKFramework
+
+final class ATTNInboxMessagesAPITests: XCTestCase {
+    private let testDomain = "some-domain"
+    private var sessionMock: NSURLSessionMock!
+    private var api: ATTNAPI!
+    private var userIdentity: ATTNUserIdentity!
+
+    override func setUp() {
+        super.setUp()
+        sessionMock = NSURLSessionMock()
+        api = ATTNAPI(domain: testDomain, urlSession: sessionMock)
+        userIdentity = ATTNTestEventUtils.buildUserIdentity()
+    }
+
+    override func tearDown() {
+        sessionMock = nil
+        api = nil
+        userIdentity = nil
+        super.tearDown()
+    }
+
+    private func fetch(
+        pushToken: String = "fcm:abc123",
+        email: String? = nil,
+        phone: String? = nil,
+        pageSize: Int = 20,
+        pageToken: String? = nil,
+        identity: ATTNUserIdentity? = nil
+    ) async throws -> InboxResponse {
+        try await api.fetchInboxMessages(
+            pushToken: pushToken,
+            email: email,
+            phone: phone,
+            visitorId: (identity ?? userIdentity).visitorId,
+            pageSize: pageSize,
+            pageToken: pageToken
+        )
+    }
+
+    private static let successBody = """
+    {
+      "messages": [
+        {
+          "inbox_message_id": "msg_abc123",
+          "title": "20% off today",
+          "body": "Use code SAVE20 at checkout",
+          "image_url": "https://cdn.example.com/promo.jpg",
+          "action_url": "myapp://products/sale",
+          "sent_at": "2026-05-01T12:00:00Z",
+          "expires_at": "2027-05-01T12:00:00Z",
+          "is_read": false,
+          "read_at": null
+        }
+      ],
+      "next_page_token": "xyz789"
+    }
+    """
+
+    func testFetchInboxMessages_success_decodesMessagesAndNextPageToken() async throws {
+        sessionMock.inboxMessagesResponseBody = Data(Self.successBody.utf8)
+
+        let response = try await fetch(email: "user@example.com", phone: "+15551234567")
+
+        XCTAssertEqual(response.messages.count, 1)
+        XCTAssertEqual(response.nextPageToken, "xyz789")
+        XCTAssertTrue(sessionMock.didCallInboxMessagesApi)
+        XCTAssertEqual(sessionMock.urlCalls.count, 1)
+        XCTAssertEqual(sessionMock.urlCalls[0].absoluteString, "https://mobile.attentivemobile.com/inbox/messages")
+
+        let message = try XCTUnwrap(response.messages.first)
+        XCTAssertEqual(message.id, "msg_abc123")
+        XCTAssertEqual(message.title, "20% off today")
+        XCTAssertEqual(message.body, "Use code SAVE20 at checkout")
+        XCTAssertEqual(message.imageURLString, "https://cdn.example.com/promo.jpg")
+        XCTAssertEqual(message.actionURLString, "myapp://products/sale")
+        XCTAssertFalse(message.isRead)
+        XCTAssertNil(message.readAt)
+        XCTAssertNotNil(message.expiresAt)
+        // Client-side default because the server response has no `style` field.
+        XCTAssertEqual(message.style, .small)
+    }
+
+    func testFetchInboxMessages_sendsExpectedRequestBody() async throws {
+        _ = try await fetch(email: "user@example.com", phone: "+15551234567", pageSize: 20, pageToken: "cursor-abc")
+
+        let request = try XCTUnwrap(sessionMock.requests.first)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        XCTAssertEqual(json["c"] as? String, testDomain)
+        XCTAssertEqual(json["visitor_id"] as? String, userIdentity.visitorId)
+        XCTAssertEqual(json["push_token"] as? String, "fcm:abc123")
+        XCTAssertEqual(json["email"] as? String, "user@example.com")
+        XCTAssertEqual(json["phone"] as? String, "+15551234567")
+        XCTAssertEqual(json["page_size"] as? Int, 20)
+        XCTAssertEqual(json["page_token"] as? String, "cursor-abc")
+    }
+
+    func testFetchInboxMessages_omitsEmptyOptionalFields() async throws {
+        let emptyIdentity = ATTNUserIdentity()
+        _ = try await fetch(pushToken: "", pageToken: nil, identity: emptyIdentity)
+
+        let request = try XCTUnwrap(sessionMock.requests.first)
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+
+        XCTAssertEqual(json["c"] as? String, testDomain)
+        XCTAssertEqual(json["visitor_id"] as? String, emptyIdentity.visitorId)
+        XCTAssertNil(json["push_token"])
+        XCTAssertNil(json["email"])
+        XCTAssertNil(json["phone"])
+        XCTAssertNil(json["page_token"])
+    }
+
+    func testFetchInboxMessages_serverError_throwsInboxRequestFailed() async {
+        sessionMock.inboxMessagesStatusCode = 500
+
+        do {
+            _ = try await fetch()
+            XCTFail("Expected request to throw")
+        } catch ATTNError.inboxRequestFailed(let status) {
+            XCTAssertEqual(status, 500)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testFetchInboxMessages_malformedBody_throwsDecodeFailed() async {
+        sessionMock.inboxMessagesResponseBody = Data("not json".utf8)
+
+        do {
+            _ = try await fetch()
+            XCTFail("Expected request to throw")
+        } catch ATTNError.inboxResponseDecodeFailed {
+            // expected
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testFetchInboxMessages_networkError_throwsUnderlyingError() async {
+        let stubError = NSError(domain: "test", code: -1, userInfo: nil)
+        sessionMock.inboxMessagesError = stubError
+
+        do {
+            _ = try await fetch()
+            XCTFail("Expected request to throw")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "test")
+            XCTAssertEqual(error.code, -1)
+        }
+    }
+}

--- a/Tests/TestCases/ATTNInboxMessagesAPITests.swift
+++ b/Tests/TestCases/ATTNInboxMessagesAPITests.swift
@@ -29,7 +29,7 @@ final class ATTNInboxMessagesAPITests: XCTestCase {
     }
 
     private func fetch(
-        pushToken: String = "fcm:abc123",
+        pushToken: String = "abc123",
         email: String? = nil,
         phone: String? = nil,
         pageSize: Int = 20,
@@ -101,7 +101,7 @@ final class ATTNInboxMessagesAPITests: XCTestCase {
 
         XCTAssertEqual(json["c"] as? String, testDomain)
         XCTAssertEqual(json["visitor_id"] as? String, userIdentity.visitorId)
-        XCTAssertEqual(json["push_token"] as? String, "fcm:abc123")
+        XCTAssertEqual(json["push_token"] as? String, "apns:abc123", "SDK must prefix the raw device token with the APNs transport scheme")
         XCTAssertEqual(json["email"] as? String, "user@example.com")
         XCTAssertEqual(json["phone"] as? String, "+15551234567")
         XCTAssertEqual(json["page_size"] as? Int, 20)

--- a/Tests/TestCases/InboxManagerTests.swift
+++ b/Tests/TestCases/InboxManagerTests.swift
@@ -169,12 +169,20 @@ final class InboxManagerTests: XCTestCase {
             self.apiSpy.onFetchInboxMessages = nil
         }
 
+        let callCountBeforeRefresh = apiSpy.fetchInboxMessagesCallCount
         await manager.refresh()
 
         let messages = await manager.allMessages
         XCTAssertEqual(messages.map(\.id), ["new-1"], "stale page load must not clobber the refresh's result")
         let hasMore = await manager.hasMore
         XCTAssertTrue(hasMore, "hasMore should reflect the refresh's fresh cursor, not a clobbered stale one")
+        // The discriminating check: on unfixed code, the racing loadNextPage would slip past
+        // the guard and hit the network (count +2). With the gate in place it must be blocked (+1).
+        XCTAssertEqual(
+            apiSpy.fetchInboxMessagesCallCount - callCountBeforeRefresh,
+            1,
+            "racing loadNextPage during refresh must be blocked, not fire a network call"
+        )
     }
 
     func testLoadingMoreStream_emitsTransitionsForRealFetchesOnly() async {
@@ -184,19 +192,23 @@ final class InboxManagerTests: XCTestCase {
         ]
         let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
         _ = await waitForLoadedState(manager)
+        let callCountBeforePaging = apiSpy.fetchInboxMessagesCallCount
 
-        // Collect stream values in the background so we can observe transitions.
-        var observed: [Bool] = []
+        // Collect stream values in the background for the full duration of both calls.
+        // Uses an actor-isolated box so the collector task can push values while the test
+        // reads them after cancellation.
+        actor Observed { var values: [Bool] = []; func append(_ v: Bool) { values.append(v) } }
+        let observed = Observed()
         let collectorReady = expectation(description: "collector subscribed")
         let collector = Task {
             let stream = await manager.loadingMoreStream
             var iter = stream.makeAsyncIterator()
             // First yield is the current value; consume it to prove subscription is live.
-            if let first = await iter.next() { observed.append(first) }
+            if let first = await iter.next() { await observed.append(first) }
             collectorReady.fulfill()
-            while let next = await iter.next() {
-                observed.append(next)
-                if !next && observed.count >= 3 { break } // saw true then false, done
+            // Keep collecting until the task is cancelled by the test.
+            while !Task.isCancelled, let next = await iter.next() {
+                await observed.append(next)
             }
         }
         await fulfillment(of: [collectorReady], timeout: 1)
@@ -206,8 +218,18 @@ final class InboxManagerTests: XCTestCase {
         // Final page reached — this call must no-op, i.e. not emit a new transition.
         await manager.loadNextPage()
 
-        _ = await collector.value
-        XCTAssertEqual(observed, [false, true, false], "loadingMoreStream must emit true→false only for real fetches, not no-op calls")
+        // Give the stream one runloop turn to deliver any pending emissions before we tear down.
+        await Task.yield()
+        collector.cancel()
+
+        let values = await observed.values
+        XCTAssertEqual(values, [false, true, false], "loadingMoreStream must emit true→false only for real fetches, not no-op calls")
+        // Discriminating check: the no-op second call must not fire a network request either.
+        XCTAssertEqual(
+            apiSpy.fetchInboxMessagesCallCount - callCountBeforePaging,
+            1,
+            "no-op loadNextPage after the last page must not hit the network"
+        )
     }
 
     func testLoadNextPage_updatesNextTokenAndHasMoreFlag() async {

--- a/Tests/TestCases/InboxManagerTests.swift
+++ b/Tests/TestCases/InboxManagerTests.swift
@@ -128,6 +128,22 @@ final class InboxManagerTests: XCTestCase {
         XCTAssertEqual(apiSpy.fetchInboxMessagesCallCount, callCountBefore, "loadNextPage should not fire when no next page is available")
     }
 
+    func testLoadNextPage_returnsWhetherFetchStarted() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: "cursor-2"),
+            InboxResponse(messages: [makeMessage(id: "2")], nextPageToken: nil)
+        ]
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        let didStartFirst = await manager.loadNextPage()
+        XCTAssertTrue(didStartFirst, "loadNextPage must report started when a page token is available")
+
+        let didStartSecond = await manager.loadNextPage()
+        XCTAssertFalse(didStartSecond, "loadNextPage must report no-op after the last page arrives")
+    }
+
     func testLoadNextPage_updatesNextTokenAndHasMoreFlag() async {
         apiSpy.stubbedInboxMessagesResponses = [
             InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: "cursor-2"),
@@ -217,5 +233,62 @@ final class InboxManagerTests: XCTestCase {
 
         let messages = await manager.allMessages
         XCTAssertEqual(messages.map(\.id), ["2"])
+    }
+
+    // MARK: - Identity change
+
+    func testResetForIdentityChange_clearsMessagesAndCount() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1"), makeMessage(id: "2")], nextPageToken: "cursor-2")
+        ]
+        apiSpy.stubbedUnreadCount = 5
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        await manager.resetForIdentityChange()
+
+        let messages = await manager.allMessages
+        let unread = await manager.unreadCount
+        let hasMore = await manager.hasMore
+        XCTAssertTrue(messages.isEmpty, "previous user's messages must not survive an identity reset")
+        XCTAssertEqual(unread, 0)
+        XCTAssertFalse(hasMore, "pagination cursor must be dropped so next user doesn't fetch prev user's next page")
+    }
+
+    // MARK: - Pull-to-refresh includes unread count
+
+    func testRefresh_alsoRefreshesUnreadCount() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: nil),
+            InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 1
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+
+        let countBefore = apiSpy.fetchInboxUnreadCountCallCount
+        await manager.refresh()
+
+        XCTAssertGreaterThan(apiSpy.fetchInboxUnreadCountCallCount, countBefore, "refresh() must also refresh the unread count")
+    }
+
+    // MARK: - Refresh error preserves pagination cursor
+
+    func testRefresh_errorAfterInitialSuccess_preservesNextPageToken() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: "cursor-2")
+        ]
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        // Stub the next refresh to throw.
+        apiSpy.stubbedInboxMessagesResponses = []
+        apiSpy.stubbedInboxMessagesError = NSError(domain: "test", code: -1)
+
+        await manager.refresh()
+
+        let hasMore = await manager.hasMore
+        XCTAssertTrue(hasMore, "refresh error must not wipe the pagination cursor from the last successful fetch")
     }
 }

--- a/Tests/TestCases/InboxManagerTests.swift
+++ b/Tests/TestCases/InboxManagerTests.swift
@@ -86,6 +86,21 @@ final class InboxManagerTests: XCTestCase {
         XCTAssertNil(apiSpy.lastInboxMessagesPageToken)
     }
 
+    func testRefresh_immediatelyAfterInit_coalescesWithInitTask() async {
+        // InboxView.task calls viewModel.refresh() immediately after materializing the manager;
+        // without coalescing, that races the init fetch and double-POSTs /inbox/messages.
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 1
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        await manager.refresh()
+
+        XCTAssertEqual(apiSpy.fetchInboxMessagesCallCount, 1, "refresh() called during init must coalesce, not double-POST")
+        XCTAssertEqual(apiSpy.fetchInboxUnreadCountCallCount, 1, "refresh() called during init must not fire an extra unread-count POST")
+    }
+
     func testRefresh_emptyVisitorId_skipsNetworkCall() async {
         let manager = InboxManager(api: apiSpy, identityProvider: identityProvider(visitorId: ""))
         // Give the init Task a chance to run — no state transition expected since it should skip.
@@ -171,7 +186,8 @@ final class InboxManagerTests: XCTestCase {
         ]
 
         let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
-        _ = await waitForLoadedState(manager)
+        // Drain the init task so refresh() below is a real second fetch, not a coalesce.
+        _ = await manager.unreadCount
 
         await manager.refresh()
 
@@ -264,8 +280,9 @@ final class InboxManagerTests: XCTestCase {
         ]
         apiSpy.stubbedUnreadCount = 1
         let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
-        _ = await waitForLoadedState(manager)
-        await waitForUnreadCountFetch()
+        // Awaiting `unreadCount` drains `initialRefreshTask` so the subsequent refresh()
+        // does real work instead of coalescing with the init fetch.
+        _ = await manager.unreadCount
 
         let countBefore = apiSpy.fetchInboxUnreadCountCallCount
         await manager.refresh()
@@ -280,7 +297,8 @@ final class InboxManagerTests: XCTestCase {
             InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: "cursor-2")
         ]
         let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
-        _ = await waitForLoadedState(manager)
+        // Drain the init task so refresh() below is a real second fetch, not a coalesce.
+        _ = await manager.unreadCount
 
         // Stub the next refresh to throw.
         apiSpy.stubbedInboxMessagesResponses = []

--- a/Tests/TestCases/InboxManagerTests.swift
+++ b/Tests/TestCases/InboxManagerTests.swift
@@ -1,0 +1,221 @@
+//
+//  InboxManagerTests.swift
+//  attentive-ios-sdk Tests
+//
+//  Created by Adela Gao on 7/6/26.
+//
+
+import XCTest
+@testable import ATTNSDKFramework
+
+final class InboxManagerTests: XCTestCase {
+    private var apiSpy: ATTNAPISpy!
+
+    override func setUp() {
+        super.setUp()
+        apiSpy = ATTNAPISpy(domain: "test-domain")
+    }
+
+    override func tearDown() {
+        apiSpy = nil
+        super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeMessage(id: String, isRead: Bool = false) -> Message {
+        Message(
+            id: id,
+            title: "Title \(id)",
+            body: "Body \(id)",
+            timestamp: Date(),
+            isRead: isRead
+        )
+    }
+
+    private func identityProvider(
+        visitorId: String = "v_test",
+        pushToken: String = "fcm:abc",
+        email: String? = nil,
+        phone: String? = nil
+    ) -> InboxIdentityProvider {
+        return {
+            InboxIdentitySnapshot(visitorId: visitorId, pushToken: pushToken, email: email, phone: phone)
+        }
+    }
+
+    /// Wait for the manager's state to transition to `.loaded` (i.e. init-time refresh() completed).
+    /// Times out after 1s so a bad wire-up fails loudly instead of hanging CI.
+    @discardableResult
+    private func waitForLoadedState(_ manager: InboxManager, timeout: TimeInterval = 1.0) async -> [Message]? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let state = await manager.currentInboxStateForTesting
+            if case .loaded(let messages) = state { return messages }
+            if case .error = state { return nil }
+            try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        }
+        return nil
+    }
+
+    /// Wait for the init-time refreshUnreadCount() to settle (or timeout).
+    private func waitForUnreadCountFetch(timeout: TimeInterval = 1.0) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline, apiSpy.fetchInboxUnreadCountCallCount == 0 {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+
+    // MARK: - Initial load
+
+    func testInit_loadsFirstPageAndUnreadCount() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1"), makeMessage(id: "2")], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 3
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+
+        let messages = await manager.allMessages
+        let unread = await manager.unreadCount
+        XCTAssertEqual(messages.count, 2)
+        XCTAssertEqual(unread, 3)
+        XCTAssertEqual(apiSpy.fetchInboxMessagesCallCount, 1)
+        XCTAssertNil(apiSpy.lastInboxMessagesPageToken)
+    }
+
+    func testRefresh_emptyVisitorId_skipsNetworkCall() async {
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider(visitorId: ""))
+        // Give the init Task a chance to run — no state transition expected since it should skip.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        _ = manager
+
+        XCTAssertEqual(apiSpy.fetchInboxMessagesCallCount, 0)
+        XCTAssertEqual(apiSpy.fetchInboxUnreadCountCallCount, 0)
+    }
+
+    // MARK: - Pagination
+
+    func testLoadNextPage_appendsWithoutDuplicates() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1"), makeMessage(id: "2")], nextPageToken: "cursor-2"),
+            InboxResponse(messages: [makeMessage(id: "2"), makeMessage(id: "3")], nextPageToken: nil)
+        ]
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        await manager.loadNextPage()
+
+        let messages = await manager.allMessages
+        let ids = messages.map(\.id)
+        XCTAssertEqual(ids, ["1", "2", "3"], "Duplicate message 2 must not be added twice")
+        XCTAssertEqual(apiSpy.lastInboxMessagesPageToken, "cursor-2")
+    }
+
+    func testLoadNextPage_noNextToken_isNoOp() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: nil)
+        ]
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        let callCountBefore = apiSpy.fetchInboxMessagesCallCount
+        await manager.loadNextPage()
+        XCTAssertEqual(apiSpy.fetchInboxMessagesCallCount, callCountBefore, "loadNextPage should not fire when no next page is available")
+    }
+
+    func testLoadNextPage_updatesNextTokenAndHasMoreFlag() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: "cursor-2"),
+            InboxResponse(messages: [makeMessage(id: "2")], nextPageToken: nil)
+        ]
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        var hasMore = await manager.hasMore
+        XCTAssertTrue(hasMore)
+
+        await manager.loadNextPage()
+
+        hasMore = await manager.hasMore
+        XCTAssertFalse(hasMore)
+    }
+
+    // MARK: - Refresh behavior
+
+    func testRefresh_resetsMessagesAndPagination() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1"), makeMessage(id: "2")], nextPageToken: "cursor-2"),
+            InboxResponse(messages: [makeMessage(id: "9")], nextPageToken: nil)
+        ]
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        await manager.refresh()
+
+        let messages = await manager.allMessages
+        XCTAssertEqual(messages.map(\.id), ["9"], "refresh must replace the list, not append")
+        let hasMore = await manager.hasMore
+        XCTAssertFalse(hasMore)
+    }
+
+    // MARK: - Error handling
+
+    func testRefresh_errorOnFirstLoad_emitsErrorState() async {
+        apiSpy.stubbedInboxMessagesError = NSError(domain: "test", code: -1)
+
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+
+        // Wait for the init Task to run through refresh() and update state.
+        let deadline = Date().addingTimeInterval(1.0)
+        var observed: InboxState?
+        while Date() < deadline {
+            let state = await manager.currentInboxStateForTesting
+            if case .error = state {
+                observed = state
+                break
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        if case .error = observed {
+            // expected
+        } else {
+            XCTFail("Expected .error state after init failure, got \(String(describing: observed))")
+        }
+    }
+
+    // MARK: - Local mutations
+
+    func testMarkRead_updatesLocalMessageState() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
+        ]
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        await manager.markRead("1")
+
+        let messages = await manager.allMessages
+        XCTAssertTrue(messages.first?.isRead == true)
+    }
+
+    func testDelete_removesMessageFromList() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1"), makeMessage(id: "2")], nextPageToken: nil)
+        ]
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+
+        await manager.delete("1")
+
+        let messages = await manager.allMessages
+        XCTAssertEqual(messages.map(\.id), ["2"])
+    }
+}

--- a/Tests/TestCases/InboxManagerTests.swift
+++ b/Tests/TestCases/InboxManagerTests.swift
@@ -143,20 +143,71 @@ final class InboxManagerTests: XCTestCase {
         XCTAssertEqual(apiSpy.fetchInboxMessagesCallCount, callCountBefore, "loadNextPage should not fire when no next page is available")
     }
 
-    func testLoadNextPage_returnsWhetherFetchStarted() async {
+    func testLoadNextPage_firedDuringRefresh_isBlocked() async {
+        // Reproduce the race the reviewer flagged: a last-row `.onAppear` fires during a
+        // pull-to-refresh's in-flight window and captures the stale nextPageToken.
+        apiSpy.stubbedInboxMessagesResponses = [
+            // Initial page 1 (init-time)
+            InboxResponse(messages: [makeMessage(id: "old-1")], nextPageToken: "stale-cursor"),
+            // Refresh's page-1 response — set below via onFetchInboxMessages
+            InboxResponse(messages: [makeMessage(id: "new-1")], nextPageToken: "fresh-cursor"),
+            // Would-be stale page from the racing loadNextPage
+            InboxResponse(messages: [makeMessage(id: "STALE")], nextPageToken: "should-not-clobber")
+        ]
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        // Drain init so refresh() below actually fires a new fetch.
+        _ = await manager.unreadCount
+
+        // On the refresh's fetch, interleave a loadNextPage before returning the response.
+        apiSpy.onFetchInboxMessages = { [weak self] pageToken in
+            guard let self = self else { return }
+            // Only interleave on the refresh (nil pageToken), not the racing loadNextPage.
+            guard pageToken == nil else { return }
+            // Fire the racing page load. It should be blocked by isRefreshingFirstPage.
+            await manager.loadNextPage()
+            // Clear the hook so it doesn't re-fire recursively.
+            self.apiSpy.onFetchInboxMessages = nil
+        }
+
+        await manager.refresh()
+
+        let messages = await manager.allMessages
+        XCTAssertEqual(messages.map(\.id), ["new-1"], "stale page load must not clobber the refresh's result")
+        let hasMore = await manager.hasMore
+        XCTAssertTrue(hasMore, "hasMore should reflect the refresh's fresh cursor, not a clobbered stale one")
+    }
+
+    func testLoadingMoreStream_emitsTransitionsForRealFetchesOnly() async {
         apiSpy.stubbedInboxMessagesResponses = [
             InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: "cursor-2"),
             InboxResponse(messages: [makeMessage(id: "2")], nextPageToken: nil)
         ]
-
         let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
         _ = await waitForLoadedState(manager)
 
-        let didStartFirst = await manager.loadNextPage()
-        XCTAssertTrue(didStartFirst, "loadNextPage must report started when a page token is available")
+        // Collect stream values in the background so we can observe transitions.
+        var observed: [Bool] = []
+        let collectorReady = expectation(description: "collector subscribed")
+        let collector = Task {
+            let stream = await manager.loadingMoreStream
+            var iter = stream.makeAsyncIterator()
+            // First yield is the current value; consume it to prove subscription is live.
+            if let first = await iter.next() { observed.append(first) }
+            collectorReady.fulfill()
+            while let next = await iter.next() {
+                observed.append(next)
+                if !next && observed.count >= 3 { break } // saw true then false, done
+            }
+        }
+        await fulfillment(of: [collectorReady], timeout: 1)
 
-        let didStartSecond = await manager.loadNextPage()
-        XCTAssertFalse(didStartSecond, "loadNextPage must report no-op after the last page arrives")
+        // Real fetch — expect true then false.
+        await manager.loadNextPage()
+        // Final page reached — this call must no-op, i.e. not emit a new transition.
+        await manager.loadNextPage()
+
+        _ = await collector.value
+        XCTAssertEqual(observed, [false, true, false], "loadingMoreStream must emit true→false only for real fetches, not no-op calls")
     }
 
     func testLoadNextPage_updatesNextTokenAndHasMoreFlag() async {

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		FB2984062C0FA2DA0039759C /* ATTNEventTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2984052C0FA2DA0039759C /* ATTNEventTrackerTests.swift */; };
 		FB2984082C0FAE040039759C /* ATTNAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2984072C0FAE040039759C /* ATTNAPITests.swift */; };
 		0AE0001C377A1AAC00563599 /* ATTNInboxAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE0001B377A1AAC00563599 /* ATTNInboxAPITests.swift */; };
+		0A413001413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A413000413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift */; };
+		0A413003413A1AAA00563599 /* InboxManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A413002413A1AAA00563599 /* InboxManagerTests.swift */; };
 		FB2F35B12C18CFFA0016CAE8 /* ATTNSDKFramework.podspec in Resources */ = {isa = PBXBuildFile; fileRef = FB2F35AF2C18CFFA0016CAE8 /* ATTNSDKFramework.podspec */; };
 		FB35C1792C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1782C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift */; };
 		FB35C17B2C0E0353009FA048 /* ATTNIdentifierType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */; };
@@ -182,6 +184,8 @@
 		FB2984052C0FA2DA0039759C /* ATTNEventTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNEventTrackerTests.swift; sourceTree = "<group>"; };
 		FB2984072C0FAE040039759C /* ATTNAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNAPITests.swift; sourceTree = "<group>"; };
 		0AE0001B377A1AAC00563599 /* ATTNInboxAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxAPITests.swift; sourceTree = "<group>"; };
+		0A413000413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxMessagesAPITests.swift; sourceTree = "<group>"; };
+		0A413002413A1AAA00563599 /* InboxManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxManagerTests.swift; sourceTree = "<group>"; };
 		FB2F35AF2C18CFFA0016CAE8 /* ATTNSDKFramework.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ATTNSDKFramework.podspec; sourceTree = "<group>"; };
 		FB35C1782C0E030E009FA048 /* ATTNCreativeTriggerStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNCreativeTriggerStatus.swift; sourceTree = "<group>"; };
 		FB35C17A2C0E0353009FA048 /* ATTNIdentifierType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNIdentifierType.swift; sourceTree = "<group>"; };
@@ -432,6 +436,8 @@
 				FB2984052C0FA2DA0039759C /* ATTNEventTrackerTests.swift */,
 				FB2984072C0FAE040039759C /* ATTNAPITests.swift */,
 				0AE0001B377A1AAC00563599 /* ATTNInboxAPITests.swift */,
+				0A413000413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift */,
+				0A413002413A1AAA00563599 /* InboxManagerTests.swift */,
 				FB90EF0A2C109CB4004DFC4A /* ATTNAPIITTests.swift */,
 				FB6553692C1B72D4008DB3B1 /* ATTNSDKTests.swift */,
 				FB86C03D2C40611A00E35580 /* ATTNAddToCartEventTests.swift */,
@@ -842,6 +848,8 @@
 				FB2983E52C0F73990039759C /* ATTNUserAgentBuilderMock.swift in Sources */,
 				FB2984082C0FAE040039759C /* ATTNAPITests.swift in Sources */,
 				0AE0001C377A1AAC00563599 /* ATTNInboxAPITests.swift in Sources */,
+				0A413001413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift in Sources */,
+				0A413003413A1AAA00563599 /* InboxManagerTests.swift in Sources */,
 				FB65536A2C1B72D4008DB3B1 /* ATTNSDKTests.swift in Sources */,
 				FB90EF0D2C10A7F7004DFC4A /* NSURLSessionDataTaskMock.swift in Sources */,
 				FB2983FE2C0F85770039759C /* ATTNCustomEventTests.swift in Sources */,


### PR DESCRIPTION
## Summary

Wires the SDK's inbox to the real `POST /inbox/messages` endpoint, replacing the in-memory mock generator. Adds pull-up-to-load-more infinite scroll with a footer spinner and dedup across pages.

- **Endpoint:** `ATTNAPI.fetchInboxMessages` mirrors `fetchInboxUnreadCount` (same host, `c` domain + visitor_id + `apns:`-prefixed push_token + email + phone). Payload also carries `page_size` and optional `page_token`. Both endpoints now share a `postInboxJSON<T:>` + `inboxIdentityPayload()` scaffolding.
- **Manager (`InboxManager`):** first-page fetch on init, `loadNextPage()` for infinite scroll (returns `Bool` so the ViewModel can gate the spinner without a probe hop), dedup on message id, generation counters that discard stale-identity responses, `resetForIdentityChange()` clears messages+cursor+count on `clearUser`/`updateUser`. Init + `refresh()` fire messages and unread-count fetches concurrently via `async let`.
- **UI (`InboxView` / `InboxViewModel`):** `.onAppear` on the last row triggers `loadNextPage()`; footer `ProgressView` shows while `isLoadingMore == true`.
- **Message model:** decodes `inbox_message_id`, `sent_at`, `expires_at`, `read_at`, `is_read`, `image_url`, `action_url`; `style` defaults to `.small` when absent so encode-decode round-trips preserve the field. Inbox JSON decoder tolerates ISO-8601 with or without fractional seconds.

## Test plan

- [x] Unit tests: 24 inbox tests pass locally (API payload assembly, error mapping, decode failures, pagination dedup, identity reset clears messages, refresh error preserves cursor, `apns:` prefix asserted).
- [ ] Manual: open Bonni inbox, verify first page loads, scroll to bottom to trigger next page (footer spinner appears), pull to refresh, mark read/unread, `clearUser` from settings and confirm inbox empties before next identity's messages load.
- [ ] CI: SwiftLint + framework build green.
<img width="1206" height="2622" alt="simulator_screenshot_456F5B13-05F2-48C9-817A-65FDE5D95356" src="https://github.com/user-attachments/assets/7dbd6cb1-6744-4f23-9ca8-cfb9f3db6918" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)