### PR TITLE
MSDK-434: replace live incrementing inbox timestamp with static rounded relative time

### DIFF
--- a/Sources/Inbox/Inbox+Date.swift
+++ b/Sources/Inbox/Inbox+Date.swift
@@ -1,0 +1,28 @@
+//
+//  Inbox+Date.swift
+//  attentive-ios-sdk
+//
+//  Created by Umair Sharif on 7/23/26.
+//
+
+import Foundation
+
+extension Date {
+    func inboxRelativeString(now: Date = Date(), calendar: Calendar = .current) -> String {
+        guard self <= now else { return String(localized: "Just now") }
+
+        let elapsed = calendar.dateComponents([.day, .hour, .minute], from: self, to: now)
+        switch (elapsed.day ?? 0, elapsed.hour ?? 0, elapsed.minute ?? 0) {
+        case (7..., _, _):
+            return formatted(.dateTime.month(.abbreviated).day())
+        case (let days, _, _) where days >= 1:
+            return String(localized: "\(days)d ago")
+        case (_, let hours, _) where hours >= 1:
+            return String(localized: "\(hours)h ago")
+        case (_, _, let minutes) where minutes >= 1:
+            return String(localized: "\(minutes)m ago")
+        default:
+            return String(localized: "Just now")
+        }
+    }
+}

--- a/Sources/Inbox/InboxMessageRowView.swift
+++ b/Sources/Inbox/InboxMessageRowView.swift
@@ -56,10 +56,9 @@ struct InboxMessageRowView: View {
                 .foregroundColor(style.body.color)
                 .lineLimit(2)
 
-            Text(message.timestamp, style: .relative)
+            Text(message.timestamp.inboxRelativeString())
                 .font(style.timestamp.font)
                 .foregroundColor(style.timestamp.color)
-                .foregroundColor(.gray)
         }
     }
 }

--- a/Tests/TestCases/InboxDateTests.swift
+++ b/Tests/TestCases/InboxDateTests.swift
@@ -1,0 +1,62 @@
+//
+//  InboxDateTests.swift
+//  attentive-ios-sdk Tests
+//
+//  Created by Umair Sharif on 7/23/26.
+//
+
+import Foundation
+import Testing
+@testable import ATTNSDKFramework
+
+struct InboxDateTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }()
+
+    private func relativeString(secondsAgo: TimeInterval) -> String {
+        now.addingTimeInterval(-secondsAgo).inboxRelativeString(now: now, calendar: calendar)
+    }
+
+    @Test(arguments: [0, 59, -120] as [TimeInterval])
+    func underOneMinuteOrFuture_isJustNow(secondsAgo: TimeInterval) {
+        #expect(relativeString(secondsAgo: secondsAgo) == "Just now")
+    }
+
+    @Test(arguments: [
+        (60, "1m ago"),
+        (31 * 60, "31m ago"),
+        (3599, "59m ago")
+    ] as [(TimeInterval, String)])
+    func minutes(secondsAgo: TimeInterval, expected: String) {
+        #expect(relativeString(secondsAgo: secondsAgo) == expected)
+    }
+
+    @Test(arguments: [
+        (3600, "1h ago"),
+        (5 * 3600, "5h ago"),
+        (86_399, "23h ago")
+    ] as [(TimeInterval, String)])
+    func hours(secondsAgo: TimeInterval, expected: String) {
+        #expect(relativeString(secondsAgo: secondsAgo) == expected)
+    }
+
+    @Test(arguments: [
+        (86_400, "1d ago"),
+        (3 * 86_400, "3d ago"),
+        (604_799, "6d ago")
+    ] as [(TimeInterval, String)])
+    func days(secondsAgo: TimeInterval, expected: String) {
+        #expect(relativeString(secondsAgo: secondsAgo) == expected)
+    }
+
+    @Test
+    func oneWeekOrOlder_usesAbbreviatedMonthDay() {
+        let date = now.addingTimeInterval(-604_800)
+        #expect(date.inboxRelativeString(now: now, calendar: calendar) == date.formatted(.dateTime.month(.abbreviated).day()))
+    }
+}

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		0AC4361D2F9E01AD00563599 /* InboxAsyncImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC4361C2F9E01AC00563599 /* InboxAsyncImageView.swift */; };
 		0AC4361F2F9E01AF00563599 /* InboxAnimatedImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC4361E2F9E01AE00563599 /* InboxAnimatedImageTests.swift */; };
 		0A8BDC8E2F29975400138567 /* Inbox+Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8BDC8D2F29974F00138567 /* Inbox+Strings.swift */; };
+		0A8BDC922F29C00000138567 /* Inbox+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8BDC912F29C00000138567 /* Inbox+Date.swift */; };
 		0A8BDC902F29B8EC00138567 /* InboxStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8BDC8F2F29B8E900138567 /* InboxStyle.swift */; };
 		0AE51BF12F7D8138004CC16E /* ATTNSnapshotTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE51BF02F7D8138004CC16E /* ATTNSnapshotTestCase.swift */; };
 		0AE51BF22F7D8200004CC16E /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 0AE51BF32F7D8200004CC16E /* SnapshotTesting */; };
@@ -59,6 +60,7 @@
 		0A413001413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A413000413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift */; };
 		0A413005412A1AAA00563599 /* ATTNInboxClickAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A413004412A1AAA00563599 /* ATTNInboxClickAPITests.swift */; };
 		0A413007412A1AAA00563599 /* InboxViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A413006412A1AAA00563599 /* InboxViewModelTests.swift */; };
+		0A8BDC942F29C00000138567 /* InboxDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8BDC932F29C00000138567 /* InboxDateTests.swift */; };
 		0A413003413A1AAA00563599 /* InboxManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A413002413A1AAA00563599 /* InboxManagerTests.swift */; };
 		0AE00021410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE00022410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift */; };
 		0AE0001F411A1AAC00563599 /* ATTNInboxMarkUnreadAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE00020411A1AAC00563599 /* ATTNInboxMarkUnreadAPITests.swift */; };
@@ -150,6 +152,7 @@
 		0AC4361C2F9E01AC00563599 /* InboxAsyncImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxAsyncImageView.swift; sourceTree = "<group>"; };
 		0AC4361E2F9E01AE00563599 /* InboxAnimatedImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxAnimatedImageTests.swift; sourceTree = "<group>"; };
 		0A8BDC8D2F29974F00138567 /* Inbox+Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox+Strings.swift"; sourceTree = "<group>"; };
+		0A8BDC912F29C00000138567 /* Inbox+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox+Date.swift"; sourceTree = "<group>"; };
 		0A8BDC8F2F29B8E900138567 /* InboxStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxStyle.swift; sourceTree = "<group>"; };
 		0AE51BF02F7D8138004CC16E /* ATTNSnapshotTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNSnapshotTestCase.swift; sourceTree = "<group>"; };
 		58332EC3292EC18800B1ECF3 /* ATTNSDKFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ATTNSDKFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -204,6 +207,7 @@
 		0A413000413A1AAA00563599 /* ATTNInboxMessagesAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxMessagesAPITests.swift; sourceTree = "<group>"; };
 		0A413004412A1AAA00563599 /* ATTNInboxClickAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxClickAPITests.swift; sourceTree = "<group>"; };
 		0A413006412A1AAA00563599 /* InboxViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxViewModelTests.swift; sourceTree = "<group>"; };
+		0A8BDC932F29C00000138567 /* InboxDateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxDateTests.swift; sourceTree = "<group>"; };
 		0AE00024414A1AAC00563599 /* ATTNInboxDeleteAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxDeleteAPITests.swift; sourceTree = "<group>"; };
 		0A413002413A1AAA00563599 /* InboxManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxManagerTests.swift; sourceTree = "<group>"; };
 		0AE00022410A1AAC00563599 /* ATTNInboxMarkReadAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNInboxMarkReadAPITests.swift; sourceTree = "<group>"; };
@@ -319,6 +323,7 @@
 				0A411B452F31E13400563599 /* View */,
 				0A8BDC8F2F29B8E900138567 /* InboxStyle.swift */,
 				0A8BDC8D2F29974F00138567 /* Inbox+Strings.swift */,
+				0A8BDC912F29C00000138567 /* Inbox+Date.swift */,
 				0A8BDC8B2F298C4800138567 /* InboxMessageRowView.swift */,
 				0AC4361A2F9E01AA00563599 /* InboxAnimatedImage.swift */,
 				0AC4361C2F9E01AC00563599 /* InboxAsyncImageView.swift */,
@@ -471,6 +476,7 @@
 				0AE00024414A1AAC00563599 /* ATTNInboxDeleteAPITests.swift */,
 				0A413002413A1AAA00563599 /* InboxManagerTests.swift */,
 				0A413006412A1AAA00563599 /* InboxViewModelTests.swift */,
+				0A8BDC932F29C00000138567 /* InboxDateTests.swift */,
 				0AC4361E2F9E01AE00563599 /* InboxAnimatedImageTests.swift */,
 				FB90EF0A2C109CB4004DFC4A /* ATTNAPIITTests.swift */,
 				FB6553692C1B72D4008DB3B1 /* ATTNSDKTests.swift */,
@@ -847,6 +853,7 @@
 				0AC4361D2F9E01AD00563599 /* InboxAsyncImageView.swift in Sources */,
 				FB35C17B2C0E0353009FA048 /* ATTNIdentifierType.swift in Sources */,
 				0A8BDC8E2F29975400138567 /* Inbox+Strings.swift in Sources */,
+				0A8BDC922F29C00000138567 /* Inbox+Date.swift in Sources */,
 				FB4E3FE72C372C54004B8FF0 /* ATTNWebViewProviding.swift in Sources */,
 				FBA9FA0A2C0A77AB00C65024 /* ATTNCreativeUrlProvider.swift in Sources */,
 				F9CED4B42DF263E600780536 /* Notification+Extension.swift in Sources */,
@@ -897,6 +904,7 @@
 				0AE00023414A1AAC00563599 /* ATTNInboxDeleteAPITests.swift in Sources */,
 				0A413003413A1AAA00563599 /* InboxManagerTests.swift in Sources */,
 				0A413007412A1AAA00563599 /* InboxViewModelTests.swift in Sources */,
+				0A8BDC942F29C00000138567 /* InboxDateTests.swift in Sources */,
 				0AC4361F2F9E01AF00563599 /* InboxAnimatedImageTests.swift in Sources */,
 				FB65536A2C1B72D4008DB3B1 /* ATTNSDKTests.swift in Sources */,
 				FB90EF0D2C10A7F7004DFC4A /* NSURLSessionDataTaskMock.swift in Sources */,

--- a/attentive-ios-sdk.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/attentive-ios-sdk.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,40 @@
 {
-  "originHash" : "62dc5f9606142e259275d938027b59c944959560f934dd2210d0e0cc4420a08d",
+  "originHash" : "09b08963887ce6eac26952e8acb25256a8ec102f2b5528ae68a97fa296723712",
   "pins" : [
     {
-      "identity" : "attentive-ios-sdk",
+      "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/attentive-mobile/attentive-ios-sdk",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "6f6d281e63eee0e7a894524d5d461a74ab8837f0",
-        "version" : "1.0.0"
+        "revision" : "a8cd6c976f335ed361dcecddb0dc39ebda51bc3e",
+        "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "1bc16f430d8410e7f087d4c787767b26fd32fe30",
+        "version" : "1.19.3"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "8f6abcf4c8950e2679d5b2fee4ca284fd7c34886",
+        "version" : "1.11.0"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Replaces the inbox message row's live-incrementing timestamp (SwiftUI's self-updating `.relative` text style) with a static rounded relative time, matching Android. Resolves [MSDK-434](https://attentivemobile.atlassian.net/browse/MSDK-434).

## Key Changes

- Timestamps now render as "Just now" / "31m ago" / "5h ago" / "3d ago", falling back to an absolute date ("Jan 27") for messages a week or older — the same bucketing Android uses. The value is computed once per render via `Calendar.dateComponents` rather than a timer, so it holds still while the inbox is visible and refreshes when the inbox is re-presented.
- Because the math is calendar-aware, values near a DST transition may differ from Android's raw-millisecond division by an hour (e.g. "1d ago" vs "23h ago") — deliberate trade-off for calendar-correct semantics.
- Strings go through `String(localized:)`, consistent with the rest of the Inbox module.
- Drive-by: removes a dead duplicate `.foregroundColor(.gray)` on the timestamp text, and commits the re-resolved workspace `Package.resolved`, which had been stale since the snapshot-testing dependency was added and gets rewritten by any workspace build.

## Public API Impact

None — the formatter is an internal `Date` extension; no public surface changes.

## Verification

- New `InboxDateTests` (Swift Testing, 13 parameterized cases) cover every bucket and its boundaries (59s → "Just now", 3599s → "59m ago", 23h59m → "23h ago", 6d23h → "6d ago", exactly 7d → absolute date, future timestamps → "Just now"), with a fixed injected clock and UTC calendar for determinism.
- Full unit suite passes: 268 tests, iPhone 17 simulator.
- Verified visually in the Example app: inbox timestamps render statically and no longer tick while the screen is open.

## Risk / Rollback

Low — internal, view-layer-only change to one label; no API, network, persistence, or threading changes. Purely visual regression surface. No kill-switch; rollback is a follow-up release, acceptable given the blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MSDK-434]: https://attentivemobile.atlassian.net/browse/MSDK-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ