### PR TITLE
MSDK-436: support animated GIFs in inbox message images

### DIFF
--- a/Sources/Inbox/InboxAnimatedImage.swift
+++ b/Sources/Inbox/InboxAnimatedImage.swift
@@ -1,0 +1,153 @@
+//
+//  InboxAnimatedImage.swift
+//  attentive-ios-sdk
+//
+//  Created by Umair Sharif on 7/23/26.
+//
+
+import ImageIO
+import UIKit
+
+/// Decodes animated GIF data into a playable `UIImage` using only ImageIO/UIKit — the SDK
+/// must stay dependency-free, so no SDWebImage/Kingfisher. Non-GIF data is rejected so
+/// callers can fall back to `UIImage(data:)`.
+enum InboxAnimatedImage {
+    /// Frames larger than this on their longest side are downsampled while decoding.
+    static let defaultMaxPixelSize: CGFloat = 720
+    /// Hard cap on unique decoded frames, independent of the byte budget.
+    static let defaultMaxFrameCount = 120
+    /// Budget for total decoded bitmap bytes per GIF. Combined with the frame cap this
+    /// bounds the memory one GIF can pin; GIFs over budget are frame-sampled to fit.
+    static let defaultMaxDecodedBytes = 64 * 1024 * 1024
+
+    /// Entries in the expanded `UIImage.animatedImage` frame array are references to the
+    /// unique decoded frames, so this caps array length, not bitmap memory.
+    private static let maxExpandedFrameEntries = 1_024
+
+    static func isGIF(_ data: Data) -> Bool {
+        guard data.count >= 6 else { return false }
+        let header = [UInt8](data.prefix(6))
+        // "GIF87a" / "GIF89a"
+        return header[0...3].elementsEqual([0x47, 0x49, 0x46, 0x38])
+            && (header[4] == 0x37 || header[4] == 0x39)
+            && header[5] == 0x61
+    }
+
+    static func image(
+        from data: Data,
+        maxPixelSize: CGFloat = defaultMaxPixelSize,
+        maxFrameCount: Int = defaultMaxFrameCount,
+        maxDecodedBytes: Int = defaultMaxDecodedBytes
+    ) -> UIImage? {
+        guard isGIF(data), let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        let frameCount = CGImageSourceGetCount(source)
+        guard frameCount > 1 else {
+            return decodeFrame(source, at: 0, maxPixelSize: maxPixelSize).map { UIImage(cgImage: $0) }
+        }
+
+        let delays = (0..<frameCount).map { frameDelay(source, at: $0) }
+        let stride = frameStride(
+            source,
+            frameCount: frameCount,
+            maxPixelSize: maxPixelSize,
+            maxFrameCount: maxFrameCount,
+            maxDecodedBytes: maxDecodedBytes
+        )
+
+        var frames: [UIImage] = []
+        var frameDelays: [TimeInterval] = []
+        var index = 0
+        while index < frameCount {
+            if let cgImage = decodeFrame(source, at: index, maxPixelSize: maxPixelSize) {
+                frames.append(UIImage(cgImage: cgImage))
+                // Fold the delays of any skipped frames into the kept one so sampling
+                // preserves the GIF's overall duration.
+                frameDelays.append(delays[index..<min(index + stride, frameCount)].reduce(0, +))
+            }
+            index += stride
+        }
+
+        guard frames.count > 1 else { return frames.first }
+        return animatedImage(frames: frames, delays: frameDelays)
+    }
+
+    // MARK: - Private
+
+    /// Every `stride`-th frame is decoded so the unique-frame count fits both the frame
+    /// cap and the byte budget.
+    private static func frameStride(
+        _ source: CGImageSource,
+        frameCount: Int,
+        maxPixelSize: CGFloat,
+        maxFrameCount: Int,
+        maxDecodedBytes: Int
+    ) -> Int {
+        let bytesPerFrame = estimatedBytesPerFrame(source, maxPixelSize: maxPixelSize)
+        let allowedFrames = max(1, min(maxFrameCount, maxDecodedBytes / bytesPerFrame))
+        return max(1, Int((Double(frameCount) / Double(allowedFrames)).rounded(.up)))
+    }
+
+    private static func estimatedBytesPerFrame(_ source: CGImageSource, maxPixelSize: CGFloat) -> Int {
+        guard let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let width = properties[kCGImagePropertyPixelWidth] as? CGFloat,
+              let height = properties[kCGImagePropertyPixelHeight] as? CGFloat,
+              width > 0, height > 0 else {
+            return max(1, Int(maxPixelSize * maxPixelSize) * 4)
+        }
+        let scale = min(1, maxPixelSize / max(width, height))
+        return max(1, Int(width * scale * height * scale) * 4)
+    }
+
+    private static func decodeFrame(_ source: CGImageSource, at index: Int, maxPixelSize: CGFloat) -> CGImage? {
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize
+        ]
+        return CGImageSourceCreateThumbnailAtIndex(source, index, options as CFDictionary)
+    }
+
+    private static func frameDelay(_ source: CGImageSource, at index: Int) -> TimeInterval {
+        let defaultDelay = 0.1
+        guard let properties = CGImageSourceCopyPropertiesAtIndex(source, index, nil) as? [CFString: Any],
+              let gifProperties = properties[kCGImagePropertyGIFDictionary] as? [CFString: Any] else {
+            return defaultDelay
+        }
+        let delay = (gifProperties[kCGImagePropertyGIFUnclampedDelayTime] as? TimeInterval)
+            ?? (gifProperties[kCGImagePropertyGIFDelayTime] as? TimeInterval)
+            ?? defaultDelay
+        // Browsers render near-zero delays at 100ms; match that so such GIFs don't spin.
+        return delay < 0.011 ? defaultDelay : delay
+    }
+
+    /// `UIImage.animatedImage(with:duration:)` spaces frames evenly, but GIF frames carry
+    /// individual delays. GIF delays are centisecond-based, so expanding frames onto their
+    /// common centisecond grid reproduces per-frame timing exactly — repeated entries
+    /// reference the same decoded frame, costing pointers rather than bitmaps.
+    private static func animatedImage(frames: [UIImage], delays: [TimeInterval]) -> UIImage? {
+        let centiseconds = delays.map { max(1, Int(($0 * 100).rounded())) }
+        let totalDuration = Double(centiseconds.reduce(0, +)) / 100
+        let unit = centiseconds.reduce(centiseconds[0], gcd)
+        let expandedCount = centiseconds.reduce(0) { $0 + $1 / unit }
+        guard expandedCount <= maxExpandedFrameEntries else {
+            // Pathological delay mix; give up per-frame timing and space frames evenly.
+            return UIImage.animatedImage(with: frames, duration: totalDuration)
+        }
+
+        var expanded: [UIImage] = []
+        expanded.reserveCapacity(expandedCount)
+        for (frame, duration) in zip(frames, centiseconds) {
+            expanded.append(contentsOf: repeatElement(frame, count: duration / unit))
+        }
+        return UIImage.animatedImage(with: expanded, duration: totalDuration)
+    }
+
+    private static func gcd(_ lhs: Int, _ rhs: Int) -> Int {
+        var (first, second) = (lhs, rhs)
+        while second != 0 {
+            (first, second) = (second, first % second)
+        }
+        return first
+    }
+}

--- a/Sources/Inbox/InboxAsyncImageView.swift
+++ b/Sources/Inbox/InboxAsyncImageView.swift
@@ -1,0 +1,106 @@
+//
+//  InboxAsyncImageView.swift
+//  attentive-ios-sdk
+//
+//  Created by Umair Sharif on 7/23/26.
+//
+
+import SwiftUI
+
+/// Replacement for `AsyncImage` in inbox rows that additionally plays animated GIFs
+/// (`AsyncImage` decodes only a GIF's first frame). Static formats render exactly as
+/// before, and the placeholder shows while loading and on failure, matching
+/// `AsyncImage(url:content:placeholder:)` behavior.
+struct InboxAsyncImageView: View {
+    let url: URL?
+
+    @State private var image: UIImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                if image.images != nil {
+                    InboxAnimatedImageView(image: image)
+                        .aspectRatio(image.size, contentMode: .fit)
+                } else {
+                    Image(uiImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                }
+            } else {
+                Image(systemName: "photo")
+                    .aspectRatio(contentMode: .fit)
+            }
+        }
+        .task(id: url) {
+            guard let url else {
+                image = nil
+                return
+            }
+            image = await InboxImageLoader.shared.image(for: url)
+        }
+    }
+}
+
+/// Hosts a `UIImageView` because SwiftUI's `Image` has no animation support; assigning an
+/// animated `UIImage` to `UIImageView.image` plays it automatically. Sizing is left to
+/// SwiftUI via the `aspectRatio`/`frame` modifiers applied by the caller.
+private struct InboxAnimatedImageView: UIViewRepresentable {
+    let image: UIImage
+
+    func makeUIView(context: Context) -> UIImageView {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFit
+        view.clipsToBounds = true
+        // Defer to the SwiftUI-proposed size instead of the image's intrinsic size.
+        view.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        view.setContentHuggingPriority(.defaultLow, for: .vertical)
+        view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        return view
+    }
+
+    func updateUIView(_ uiView: UIImageView, context: Context) {
+        guard uiView.image !== image else { return }
+        uiView.image = image
+    }
+}
+
+/// Fetches and decodes inbox message images, keeping decoded results in memory so
+/// scrolling doesn't re-download or re-decode (animated GIFs are expensive to decode).
+final class InboxImageLoader {
+    static let shared = InboxImageLoader()
+
+    private let cache = NSCache<NSURL, UIImage>()
+    private let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+        cache.totalCostLimit = 100 * 1024 * 1024
+    }
+
+    func image(for url: URL) async -> UIImage? {
+        if let cached = cache.object(forKey: url as NSURL) {
+            return cached
+        }
+        guard let (data, _) = try? await session.data(from: url),
+              let image = await Self.decode(data) else {
+            return nil
+        }
+        cache.setObject(image, forKey: url as NSURL, cost: Self.decodedCost(of: image))
+        return image
+    }
+
+    static func decode(_ data: Data) async -> UIImage? {
+        await Task.detached(priority: .userInitiated) {
+            InboxAnimatedImage.isGIF(data) ? InboxAnimatedImage.image(from: data) : UIImage(data: data)
+        }.value
+    }
+
+    /// Approximate decoded bitmap footprint: unique frames × RGBA bytes per frame.
+    private static func decodedCost(of image: UIImage) -> Int {
+        let uniqueFrames = image.images.map { Set($0.map(ObjectIdentifier.init)).count } ?? 1
+        let pixels = image.size.width * image.scale * image.size.height * image.scale
+        return Int(pixels) * 4 * uniqueFrames
+    }
+}

--- a/Sources/Inbox/InboxMessageRowView.swift
+++ b/Sources/Inbox/InboxMessageRowView.swift
@@ -33,14 +33,8 @@ struct InboxMessageRowView: View {
     @ViewBuilder
     private func buildAsyncImageView() -> some View {
         if let imageURL = message.imageURL {
-            let asyncImage = AsyncImage(url: imageURL) { image in
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-            } placeholder: {
-                Image(systemName: "photo")
-                    .aspectRatio(contentMode: .fit)
-            }.clipShape(RoundedRectangle(cornerRadius: 8))
+            let asyncImage = InboxAsyncImageView(url: imageURL)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
 
             switch message.style {
             case .large: asyncImage.frame(maxWidth: .infinity)
@@ -48,7 +42,7 @@ struct InboxMessageRowView: View {
             }
         }
     }
-    
+
     private func buildTextStackView() -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(message.title)

--- a/Tests/TestCases/InboxAnimatedImageTests.swift
+++ b/Tests/TestCases/InboxAnimatedImageTests.swift
@@ -1,0 +1,154 @@
+//
+//  InboxAnimatedImageTests.swift
+//  attentive-ios-sdk Tests
+//
+//  Created by Umair Sharif on 7/23/26.
+//
+
+import ImageIO
+import UniformTypeIdentifiers
+import XCTest
+@testable import ATTNSDKFramework
+
+final class InboxAnimatedImageTests: XCTestCase {
+
+    // MARK: - GIF detection
+
+    func testIsGIFAcceptsBothGIFHeaderVersions() {
+        XCTAssertTrue(InboxAnimatedImage.isGIF(Data("GIF89a".utf8)))
+        XCTAssertTrue(InboxAnimatedImage.isGIF(Data("GIF87a".utf8)))
+    }
+
+    func testIsGIFAcceptsGeneratedGIFData() {
+        XCTAssertTrue(InboxAnimatedImage.isGIF(makeGIFData(frameDelays: [0.1, 0.1])))
+    }
+
+    func testIsGIFRejectsNonGIFData() {
+        XCTAssertFalse(InboxAnimatedImage.isGIF(Data()))
+        XCTAssertFalse(InboxAnimatedImage.isGIF(Data("GIF89".utf8)))
+        XCTAssertFalse(InboxAnimatedImage.isGIF(Data("GIF99a".utf8)))
+        XCTAssertFalse(InboxAnimatedImage.isGIF(makePNGData()))
+    }
+
+    // MARK: - Decoding
+
+    func testDecodesMultiFrameGIFAsAnimatedImage() throws {
+        let image = try XCTUnwrap(InboxAnimatedImage.image(from: makeGIFData(frameDelays: [0.1, 0.1, 0.1])))
+        XCTAssertNotNil(image.images)
+        XCTAssertEqual(uniqueFrameCount(of: image), 3)
+        XCTAssertEqual(image.duration, 0.3, accuracy: 0.001)
+    }
+
+    func testDecodesSingleFrameGIFAsStaticImage() throws {
+        let image = try XCTUnwrap(InboxAnimatedImage.image(from: makeGIFData(frameDelays: [0.1])))
+        XCTAssertNil(image.images)
+    }
+
+    func testVariableFrameDelaysPreserveRelativeTiming() throws {
+        let image = try XCTUnwrap(InboxAnimatedImage.image(from: makeGIFData(frameDelays: [0.1, 0.2])))
+        // Delays expand onto their common 0.1s grid: one entry for the first frame, two
+        // (references to the same decoded frame) for the second.
+        XCTAssertEqual(image.images?.count, 3)
+        XCTAssertEqual(uniqueFrameCount(of: image), 2)
+        XCTAssertEqual(image.duration, 0.3, accuracy: 0.001)
+    }
+
+    func testFrameCapSamplesFramesAndPreservesDuration() throws {
+        let data = makeGIFData(frameDelays: Array(repeating: 0.1, count: 20))
+        let image = try XCTUnwrap(InboxAnimatedImage.image(from: data, maxFrameCount: 5))
+        XCTAssertLessThanOrEqual(uniqueFrameCount(of: image), 5)
+        XCTAssertEqual(image.duration, 2.0, accuracy: 0.001)
+    }
+
+    func testByteBudgetSamplesFrames() throws {
+        // 10×10 RGBA frames are 400 bytes each; a 1KB budget allows at most 2 of the 8.
+        let data = makeGIFData(frameDelays: Array(repeating: 0.1, count: 8))
+        let image = try XCTUnwrap(InboxAnimatedImage.image(from: data, maxDecodedBytes: 1_024))
+        XCTAssertLessThanOrEqual(uniqueFrameCount(of: image), 2)
+        XCTAssertEqual(image.duration, 0.8, accuracy: 0.001)
+    }
+
+    func testOversizedFramesAreDownsampled() throws {
+        let data = makeGIFData(frameDelays: [0.1, 0.1], size: CGSize(width: 100, height: 100))
+        let image = try XCTUnwrap(InboxAnimatedImage.image(from: data, maxPixelSize: 50))
+        XCTAssertLessThanOrEqual(max(image.size.width, image.size.height), 50)
+    }
+
+    func testSmallFramesAreNotUpsampled() throws {
+        let data = makeGIFData(frameDelays: [0.1, 0.1], size: CGSize(width: 10, height: 10))
+        let image = try XCTUnwrap(InboxAnimatedImage.image(from: data))
+        XCTAssertEqual(max(image.size.width, image.size.height), 10)
+    }
+
+    func testDecodeRejectsNonGIFData() {
+        XCTAssertNil(InboxAnimatedImage.image(from: makePNGData()))
+        XCTAssertNil(InboxAnimatedImage.image(from: Data()))
+    }
+
+    func testDecodeReturnsNilForCorruptGIFData() {
+        XCTAssertNil(InboxAnimatedImage.image(from: Data("GIF89a".utf8) + Data(repeating: 0xFF, count: 32)))
+    }
+
+    // MARK: - Loader decode routing
+
+    func testLoaderDecodesGIFAsAnimatedAndPNGAsStatic() async throws {
+        let decodedGIF = await InboxImageLoader.decode(makeGIFData(frameDelays: [0.1, 0.1]))
+        let gif = try XCTUnwrap(decodedGIF)
+        XCTAssertNotNil(gif.images)
+
+        let decodedPNG = await InboxImageLoader.decode(makePNGData())
+        let png = try XCTUnwrap(decodedPNG)
+        XCTAssertNil(png.images)
+    }
+
+    // MARK: - Helpers
+
+    private func makeGIFData(frameDelays: [TimeInterval], size: CGSize = CGSize(width: 10, height: 10)) -> Data {
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data as CFMutableData,
+            UTType.gif.identifier as CFString,
+            frameDelays.count,
+            nil
+        ) else {
+            XCTFail("Failed to create GIF destination")
+            return Data()
+        }
+        for delay in frameDelays {
+            let properties = [kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFDelayTime: delay]] as CFDictionary
+            CGImageDestinationAddImage(destination, makeCGImage(size: size), properties)
+        }
+        CGImageDestinationFinalize(destination)
+        return data as Data
+    }
+
+    private func makeCGImage(size: CGSize) -> CGImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        let image = UIGraphicsImageRenderer(size: size, format: format).image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+        guard let cgImage = image.cgImage else {
+            XCTFail("Failed to render CGImage")
+            return UIGraphicsImageRenderer(size: size, format: format).image { _ in }.cgImage!
+        }
+        return cgImage
+    }
+
+    private func makePNGData() -> Data {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        return UIGraphicsImageRenderer(size: CGSize(width: 10, height: 10), format: format).pngData { context in
+            UIColor.blue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+        }
+    }
+
+    /// Animated images repeat frame references to express per-frame delays; count the
+    /// distinct decoded bitmaps.
+    private func uniqueFrameCount(of image: UIImage) -> Int {
+        guard let frames = image.images else { return 1 }
+        return Set(frames.map(ObjectIdentifier.init)).count
+    }
+}

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		0A83DEB22F22C309003FD456 /* InboxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83DEB12F22C2F9003FD456 /* InboxView.swift */; };
 		0A83DEB42F22C48C003FD456 /* InboxViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83DEB32F22C488003FD456 /* InboxViewModel.swift */; };
 		0A8BDC8C2F298C5D00138567 /* InboxMessageRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8BDC8B2F298C4800138567 /* InboxMessageRowView.swift */; };
+		0AC4361B2F9E01AB00563599 /* InboxAnimatedImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC4361A2F9E01AA00563599 /* InboxAnimatedImage.swift */; };
+		0AC4361D2F9E01AD00563599 /* InboxAsyncImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC4361C2F9E01AC00563599 /* InboxAsyncImageView.swift */; };
+		0AC4361F2F9E01AF00563599 /* InboxAnimatedImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AC4361E2F9E01AE00563599 /* InboxAnimatedImageTests.swift */; };
 		0A8BDC8E2F29975400138567 /* Inbox+Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8BDC8D2F29974F00138567 /* Inbox+Strings.swift */; };
 		0A8BDC902F29B8EC00138567 /* InboxStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8BDC8F2F29B8E900138567 /* InboxStyle.swift */; };
 		0AE51BF12F7D8138004CC16E /* ATTNSnapshotTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE51BF02F7D8138004CC16E /* ATTNSnapshotTestCase.swift */; };
@@ -143,6 +146,9 @@
 		0A83DEB12F22C2F9003FD456 /* InboxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxView.swift; sourceTree = "<group>"; };
 		0A83DEB32F22C488003FD456 /* InboxViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxViewModel.swift; sourceTree = "<group>"; };
 		0A8BDC8B2F298C4800138567 /* InboxMessageRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageRowView.swift; sourceTree = "<group>"; };
+		0AC4361A2F9E01AA00563599 /* InboxAnimatedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxAnimatedImage.swift; sourceTree = "<group>"; };
+		0AC4361C2F9E01AC00563599 /* InboxAsyncImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxAsyncImageView.swift; sourceTree = "<group>"; };
+		0AC4361E2F9E01AE00563599 /* InboxAnimatedImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxAnimatedImageTests.swift; sourceTree = "<group>"; };
 		0A8BDC8D2F29974F00138567 /* Inbox+Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inbox+Strings.swift"; sourceTree = "<group>"; };
 		0A8BDC8F2F29B8E900138567 /* InboxStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxStyle.swift; sourceTree = "<group>"; };
 		0AE51BF02F7D8138004CC16E /* ATTNSnapshotTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNSnapshotTestCase.swift; sourceTree = "<group>"; };
@@ -314,6 +320,8 @@
 				0A8BDC8F2F29B8E900138567 /* InboxStyle.swift */,
 				0A8BDC8D2F29974F00138567 /* Inbox+Strings.swift */,
 				0A8BDC8B2F298C4800138567 /* InboxMessageRowView.swift */,
+				0AC4361A2F9E01AA00563599 /* InboxAnimatedImage.swift */,
+				0AC4361C2F9E01AC00563599 /* InboxAsyncImageView.swift */,
 				0A83DEB32F22C488003FD456 /* InboxViewModel.swift */,
 				0A83DEB12F22C2F9003FD456 /* InboxView.swift */,
 				0A83DEAB2F21A1AA003FD456 /* InboxManager.swift */,
@@ -463,6 +471,7 @@
 				0AE00024414A1AAC00563599 /* ATTNInboxDeleteAPITests.swift */,
 				0A413002413A1AAA00563599 /* InboxManagerTests.swift */,
 				0A413006412A1AAA00563599 /* InboxViewModelTests.swift */,
+				0AC4361E2F9E01AE00563599 /* InboxAnimatedImageTests.swift */,
 				FB90EF0A2C109CB4004DFC4A /* ATTNAPIITTests.swift */,
 				FB6553692C1B72D4008DB3B1 /* ATTNSDKTests.swift */,
 				FB86C03D2C40611A00E35580 /* ATTNAddToCartEventTests.swift */,
@@ -834,6 +843,8 @@
 				FBA9FA112C0A77AB00C65024 /* ATTNCart.swift in Sources */,
 				FBA9FA102C0A77AB00C65024 /* ATTNAddToCartEvent.swift in Sources */,
 				0A8BDC8C2F298C5D00138567 /* InboxMessageRowView.swift in Sources */,
+				0AC4361B2F9E01AB00563599 /* InboxAnimatedImage.swift in Sources */,
+				0AC4361D2F9E01AD00563599 /* InboxAsyncImageView.swift in Sources */,
 				FB35C17B2C0E0353009FA048 /* ATTNIdentifierType.swift in Sources */,
 				0A8BDC8E2F29975400138567 /* Inbox+Strings.swift in Sources */,
 				FB4E3FE72C372C54004B8FF0 /* ATTNWebViewProviding.swift in Sources */,
@@ -886,6 +897,7 @@
 				0AE00023414A1AAC00563599 /* ATTNInboxDeleteAPITests.swift in Sources */,
 				0A413003413A1AAA00563599 /* InboxManagerTests.swift in Sources */,
 				0A413007412A1AAA00563599 /* InboxViewModelTests.swift in Sources */,
+				0AC4361F2F9E01AF00563599 /* InboxAnimatedImageTests.swift in Sources */,
 				FB65536A2C1B72D4008DB3B1 /* ATTNSDKTests.swift in Sources */,
 				FB90EF0D2C10A7F7004DFC4A /* NSURLSessionDataTaskMock.swift in Sources */,
 				FB2983FE2C0F85770039759C /* ATTNCustomEventTests.swift in Sources */,


### PR DESCRIPTION
## Summary

Inbox message images attached as animated GIFs rendered as static first frames because SwiftUI's `AsyncImage` doesn't support GIF animation. This replaces the inbox row's image rendering with a custom loader that detects and plays GIFs, built entirely on ImageIO/UIKit — no new dependencies. [MSDK-436](https://attentivemobile.atlassian.net/browse/MSDK-436)

## Key Changes

- **GIF decoding via ImageIO** (`InboxAnimatedImage`): detects GIFs by magic bytes, decodes frames with `CGImageSource`, and reproduces per-frame GIF timing exactly by expanding frames onto their common centisecond grid (repeated entries are references, not bitmap copies — `UIImage.animatedImage` only supports even spacing otherwise).
- **`AsyncImage` drop-in** (`InboxAsyncImageView`): fetches image data, routes GIFs to a `UIImageView` bridged via `UIViewRepresentable` (which plays animated images natively), and renders everything else as a static `Image` with identical layout/placeholder semantics to the previous `AsyncImage` implementation.
- **Memory guardrails**: frames downsample to 720 px max; unique decoded frames are capped at 120 with a 64 MB per-GIF budget (oversized GIFs are frame-sampled, preserving total duration); decoded images live in an `NSCache` with a 100 MB cost limit so scrolling doesn't re-download or re-decode.

## Public API Impact

None. All new types are internal; `InboxMessageRowView` swaps its image implementation internally.

## Out of Scope

Android parity — Coil needs an extra GIF decoder; tracked separately per the ticket.

## Verification

- 13 new unit tests (`InboxAnimatedImageTests`) covering GIF detection (header variants, PNG/corrupt/truncated rejection), animated vs. single-frame decoding, per-frame timing preservation, frame-cap/byte-budget sampling with duration preservation, downsampling (no upscaling), and loader routing — passing on iPhone 17 Pro simulator (iOS 26.5), alongside existing `InboxManagerTests`/`InboxViewModelTests`.
- Manual verification in the Bonni demo app (same simulator): animated GIF plays in both small (60×60) and large (full-width) row styles — confirmed via screenshots at different rotation frames and a screen recording; static PNG renders unchanged (aspect fit, corner radius, unread indicator); placeholder shows while loading and on failed loads, matching `AsyncImage` semantics.

## Verification

https://github.com/user-attachments/assets/bcaacf00-34d4-4346-a6bc-aebc66ac1fdf

## Risk

Medium. No public API change, but this replaces the rendering path for **all** inbox message images, not just GIFs:

- **Static image regressions** — mitigated by keeping the same `Image`/placeholder semantics; verified visually.
- **Memory** — animated GIFs decode to many frames; bounded by the downsampling/frame-cap/cache limits above. A pathological GIF is capped at ~64 MB decoded.
- **Behavior difference from `AsyncImage`**: loads now go through `URLSession.shared` + in-memory `NSCache` rather than `AsyncImage`'s internal loading. Functionally equivalent from the UI; HTTP-level caching still applies via the shared `URLCache`.

## Observability

No SDK-side telemetry for image rendering. Regressions would surface through host-app crash reporters (e.g. OOM from GIF decoding) and customer reports of blank/static images.

## Rollback

Follow-up release only — no feature flag or remote kill-switch. Reverting is a clean single-commit revert restoring `AsyncImage`, but host apps must adopt the fixed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MSDK-436]: https://attentivemobile.atlassian.net/browse/MSDK-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ