### PR TITLE
MSDK-437: make full inbox cell width tappable

### DIFF
--- a/Sources/Inbox/InboxView.swift
+++ b/Sources/Inbox/InboxView.swift
@@ -27,6 +27,7 @@ struct InboxView: View {
                 buildListView {
                     ForEach(messages) { message in
                         InboxMessageRowView(message: message, style: viewModel.style)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                             .contentShape(Rectangle())
                             .onTapGesture {
                                 // Fires click tracking + local read flip, and broadcasts


### PR DESCRIPTION
## Summary

Fixes [MSDK-437](https://attentivemobile.atlassian.net/browse/MSDK-437): tapping an Inbox message cell did nothing unless the tap landed directly on the text/image. Taps now register anywhere in the cell.

## Key Changes

The row's tap gesture used `.contentShape(Rectangle())`, which only extends the hit area to the modified view's bounds — and since the row's `HStack` hugs its content, the trailing empty space in the cell was a dead zone. The fix expands the row to fill the available width (`.frame(maxWidth: .infinity, alignment: .leading)`) before applying the content shape, so the full cell triggers click tracking, mark-as-read, and the `ATTNSDKInboxMessageTapped` broadcast.

Chose the frame approach over wrapping the row in a `Button` to avoid any interaction with the leading/trailing swipe actions, which are unchanged.

## Verification

- Verified manually on an iPhone 14 Pro simulator (iOS 16): tapping the empty area of a cell now marks the message read and fires the tap behavior, same as tapping the text.
- Applies to both `.small` and `.large` message styles (the fix is in the shared row wrapper, not style-specific code).
- Full unit test suite passes; framework builds with no new warnings.

## Risk / Rollback

Low. One-line layout change internal to the Inbox SwiftUI view — no public API change, no behavior change other than the enlarged tap target. If something regresses, rollback is a follow-up release reverting the single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MSDK-437]: https://attentivemobile.atlassian.net/browse/MSDK-437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ