### PR TITLE
MSDK-439 (part 2): reconcile unread count against count endpoint after every mutation

### DIFF
--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -360,10 +360,10 @@ actor InboxManager {
         guard let identity = requireIdentity(context: "inbox mark-read") else { return }
 
         // Optimistically decrement the badge alongside the row-dot flip so the two agree
-        // between the tap and the PATCH response. The PATCH's `unread_count` is a hint that
-        // narrows the reconciliation window; the follow-up count-endpoint fetch (spawned in
-        // `defer`) is what actually lands the authoritative value. Clamping at 0 keeps a
-        // stale-local case from producing a negative badge.
+        // between the tap and the trailing count fetch. The PATCH's `unread_count` response
+        // field is ignored (see `applyReadStatusResponse` and CI-566); the follow-up count-
+        // endpoint fetch (spawned in `defer`) is what actually lands the authoritative value.
+        // Clamping at 0 keeps a stale-local case from producing a negative badge.
         var didDecrementUnreadCount = false
         if !previousIsRead {
             messagesByID[messageID]?.isRead = true
@@ -374,13 +374,9 @@ actor InboxManager {
             send(.loaded(orderedMessagesSnapshot()))
         }
 
-        // Reconcile the count against the authoritative endpoint after every mutation,
-        // success or failure. The PATCH's `unread_count` and the optimistic ±1 can both
-        // drift — from mobile-api DTO quirks, from mid-flight peer mutations, or from a
-        // clamped optimistic path — and the host may not have an observer active when
-        // this method returns (e.g., the user navigates back before the PATCH settles).
-        // A trailing count fetch guarantees the badge converges to server truth without
-        // requiring any host-side "refresh on appear" hook.
+        // Reconcile against the count endpoint after every mutation. See
+        // `scheduleUnreadCountReconciliation` for the full rationale (backend gap CI-566 + host
+        // lifecycle robustness).
         defer { scheduleUnreadCountReconciliation() }
 
         // Snapshot the refresh generation before the request. If an identity change
@@ -520,13 +516,22 @@ actor InboxManager {
     }
 
     /// Fires a background unread-count fetch so the cached count converges to the
-    /// `/unread/count` endpoint's authoritative value after any local mutation. Called from
-    /// `markRead` / `markUnread` / `delete` regardless of success/failure so the badge is
-    /// correct even when the host observes state through a stream that gets torn down
-    /// before the PATCH settles (e.g., popping the inbox VC mid-swipe) or the mobile-api
-    /// PATCH response's `unread_count` is stale for any reason. Not spawned when the count
-    /// is not currently reachable (empty visitor id) — `performUnreadCountFetch`'s own
-    /// `requireIdentity` guard handles that internally.
+    /// `/inbox/messages/unread/count` endpoint's authoritative value after any local mutation.
+    /// Called from `markRead` / `markUnread` / `delete` regardless of success/failure. Two
+    /// reasons this is mandatory rather than opportunistic:
+    ///
+    /// 1. **Backend truth (CI-566):** the mark-read / mark-unread endpoints do not populate
+    ///    `unread_count` in their response, so we cannot rely on the PATCH round-trip alone to
+    ///    reconcile the badge. Trailing fetch against the count endpoint is the only way to
+    ///    land the correct value from the server.
+    /// 2. **Host observation robustness:** the badge is often rendered by a host observer that
+    ///    subscribes to `inboxStateStream` on `viewWillAppear` and cancels on `viewWillDisappear`.
+    ///    If the host pops back to the inbox parent view before the PATCH settles, they miss
+    ///    the state emission. The trailing fetch re-emits after the count lands, so the newly-
+    ///    resubscribed observer picks up the correct value.
+    ///
+    /// Not spawned when the count endpoint is not currently reachable (empty visitor id) —
+    /// `performUnreadCountFetch`'s own `requireIdentity` guard handles that internally.
     private func scheduleUnreadCountReconciliation() {
         Task { [weak self] in
             await self?.performUnreadCountFetch(skipNotify: false)
@@ -671,12 +676,17 @@ extension InboxManager {
     }
 
     /// Reconcile per-message read status from a mark-read/mark-unread response. The response's
-    /// `unread_count` is **intentionally ignored** — that field is a hint at best (mobile-api's
-    /// PATCH endpoints have historically returned values that don't match the count endpoint,
-    /// e.g., 0 after a single read that leaves other unread messages). The authoritative value
-    /// comes exclusively from the trailing `/inbox/messages/unread/count` fetch spawned by
-    /// `scheduleUnreadCountReconciliation()`. Only the per-message `isRead` field is applied
-    /// here, since it's a direct echo of what the SDK just requested.
+    /// `unread_count` is **intentionally ignored**: the backend implementation for these
+    /// endpoints does not populate that field with the true post-mutation count (tracked in
+    /// CI-566), so trusting it would corrupt the badge on every mark-read/mark-unread. The
+    /// authoritative value comes exclusively from the trailing `/inbox/messages/unread/count`
+    /// fetch spawned by `scheduleUnreadCountReconciliation()`. Only the per-message `isRead`
+    /// field is applied here, since it's a direct echo of what the SDK just requested.
+    ///
+    /// Once CI-566 ships and the fixed backend has fully rolled out, this method could go back
+    /// to trusting `response.unreadCount` and the trailing reconciliation could be dropped —
+    /// but the defensive behavior is cheap (~1 extra POST per mutation) and self-healing under
+    /// any future backend regression, so keeping it in place is the safer default.
     private func applyReadStatusResponse(_ response: UpdateReadStatusResponse) {
         for status in response.messages {
             messagesByID[status.messageId]?.isRead = status.isRead

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -352,15 +352,18 @@ actor InboxManager {
 
     /// Marks a message read. Optimistically flips the local state, then reconciles from the
     /// server response. On failure the local flip is reverted so the UI reflects true state.
+    /// Always finishes by reconciling the count against the `/unread/count` endpoint so the
+    /// badge converges to server truth regardless of how the host observes state.
     func markRead(_ messageID: Message.ID) async {
         guard let previousIsRead = messagesByID[messageID]?.isRead else { return }
 
         guard let identity = requireIdentity(context: "inbox mark-read") else { return }
 
         // Optimistically decrement the badge alongside the row-dot flip so the two agree
-        // between the tap and the PATCH response. The PATCH's `unread_count` is authoritative
-        // and reconciles this locally-adjusted value via `applyReadStatusResponse`; clamping at
-        // 0 keeps a stale-local case from producing a negative badge.
+        // between the tap and the PATCH response. The PATCH's `unread_count` is a hint that
+        // narrows the reconciliation window; the follow-up count-endpoint fetch (spawned in
+        // `defer`) is what actually lands the authoritative value. Clamping at 0 keeps a
+        // stale-local case from producing a negative badge.
         var didDecrementUnreadCount = false
         if !previousIsRead {
             messagesByID[messageID]?.isRead = true
@@ -370,6 +373,15 @@ actor InboxManager {
             }
             send(.loaded(orderedMessagesSnapshot()))
         }
+
+        // Reconcile the count against the authoritative endpoint after every mutation,
+        // success or failure. The PATCH's `unread_count` and the optimistic ±1 can both
+        // drift — from mobile-api DTO quirks, from mid-flight peer mutations, or from a
+        // clamped optimistic path — and the host may not have an observer active when
+        // this method returns (e.g., the user navigates back before the PATCH settles).
+        // A trailing count fetch guarantees the badge converges to server truth without
+        // requiring any host-side "refresh on appear" hook.
+        defer { scheduleUnreadCountReconciliation() }
 
         // Snapshot the refresh generation before the request. If an identity change
         // (`resetForIdentityChange`) or a newer `refreshUnreadCount` lands while the PATCH is in
@@ -390,12 +402,12 @@ actor InboxManager {
             applyReadStatusResponse(response)
         } catch {
             Loggers.network.error("Failed to mark inbox message read: \(error.localizedDescription, privacy: .public)")
-            guard generation == refreshGeneration else { return }
+            // Per-message state (`isRead`) is always reverted — the row must reflect this
+            // message's true state independent of any concurrent count refresh. The count
+            // portion of the revert is guarded separately: skip it if any authoritative count
+            // write (peer PATCH, refresh, identity reset) landed in between.
             if messagesByID[messageID] != nil, !previousIsRead {
                 messagesByID[messageID]?.isRead = previousIsRead
-                // Per-message state (`isRead`) is always reverted — the row must reflect this
-                // message's true state. Count is only reverted if no other authoritative write
-                // landed in between; otherwise the peer already wrote the correct total.
                 if didDecrementUnreadCount, revisionAtStart == unreadCountRevision {
                     storedUnreadCount += 1
                 }
@@ -406,15 +418,16 @@ actor InboxManager {
 
     /// Marks a message unread. Optimistically flips the local state, then reconciles from the
     /// server response. On failure the local flip is reverted so the UI reflects true state.
+    /// Always finishes by reconciling the count against the `/unread/count` endpoint — see
+    /// `markRead` for the rationale.
     func markUnread(_ messageID: Message.ID) async {
         guard let previousIsRead = messagesByID[messageID]?.isRead else { return }
 
         guard let identity = requireIdentity(context: "inbox mark-unread") else { return }
 
         // Optimistically increment the badge alongside the row-dot flip so the two agree
-        // between the swipe and the PATCH response. The PATCH's `unread_count` is authoritative
-        // and reconciles this locally-adjusted value via `applyReadStatusResponse`. The paired
-        // capture mirrors `markRead`'s pattern so the revert path is symmetric.
+        // between the swipe and the PATCH response. The paired capture mirrors `markRead`'s
+        // pattern so the revert path is symmetric.
         var didIncrementUnreadCount = false
         if previousIsRead {
             messagesByID[messageID]?.isRead = false
@@ -422,6 +435,9 @@ actor InboxManager {
             didIncrementUnreadCount = true
             send(.loaded(orderedMessagesSnapshot()))
         }
+
+        // Trailing reconciliation — see `markRead` for the rationale.
+        defer { scheduleUnreadCountReconciliation() }
 
         // See `markRead` for why the count-revision snapshot is separate from the refresh
         // generation.
@@ -438,7 +454,7 @@ actor InboxManager {
             applyReadStatusResponse(response)
         } catch {
             Loggers.network.error("Failed to mark inbox message unread: \(error.localizedDescription, privacy: .public)")
-            guard generation == refreshGeneration else { return }
+            // See `markRead` — always revert `isRead`, guard the count revert on the revision.
             if messagesByID[messageID] != nil, previousIsRead {
                 messagesByID[messageID]?.isRead = previousIsRead
                 if didIncrementUnreadCount, revisionAtStart == unreadCountRevision {
@@ -451,7 +467,8 @@ actor InboxManager {
 
     /// Deletes a message. Optimistically removes it locally, then issues the server delete.
     /// On failure the local removal is reverted (message re-inserted at its original index)
-    /// so the UI reflects true state.
+    /// so the UI reflects true state. Always finishes by reconciling the count against the
+    /// `/unread/count` endpoint — see `markRead` for the rationale.
     func delete(_ messageID: Message.ID) async {
         guard let removedMessage = messagesByID[messageID],
               let originalIndex = messageOrder.firstIndex(of: messageID) else { return }
@@ -472,6 +489,9 @@ actor InboxManager {
             storedUnreadCount -= 1
         }
         send(.loaded(orderedMessagesSnapshot()))
+
+        // Trailing reconciliation — see `markRead` for the rationale.
+        defer { scheduleUnreadCountReconciliation() }
 
         // Snapshot the *replaced* counter, not `messagesGeneration`, so the revert path drops
         // only when a successful refresh or identity reset actually replaced the local list —
@@ -496,6 +516,20 @@ actor InboxManager {
                 storedUnreadCount += 1
             }
             send(.loaded(orderedMessagesSnapshot()))
+        }
+    }
+
+    /// Fires a background unread-count fetch so the cached count converges to the
+    /// `/unread/count` endpoint's authoritative value after any local mutation. Called from
+    /// `markRead` / `markUnread` / `delete` regardless of success/failure so the badge is
+    /// correct even when the host observes state through a stream that gets torn down
+    /// before the PATCH settles (e.g., popping the inbox VC mid-swipe) or the mobile-api
+    /// PATCH response's `unread_count` is stale for any reason. Not spawned when the count
+    /// is not currently reachable (empty visitor id) — `performUnreadCountFetch`'s own
+    /// `requireIdentity` guard handles that internally.
+    private func scheduleUnreadCountReconciliation() {
+        Task { [weak self] in
+            await self?.performUnreadCountFetch(skipNotify: false)
         }
     }
 

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -670,14 +670,17 @@ extension InboxManager {
         }
     }
 
-    /// Reconcile per-message read status and the authoritative unread count from a
-    /// mark-read/mark-unread response.
+    /// Reconcile per-message read status from a mark-read/mark-unread response. The response's
+    /// `unread_count` is **intentionally ignored** — that field is a hint at best (mobile-api's
+    /// PATCH endpoints have historically returned values that don't match the count endpoint,
+    /// e.g., 0 after a single read that leaves other unread messages). The authoritative value
+    /// comes exclusively from the trailing `/inbox/messages/unread/count` fetch spawned by
+    /// `scheduleUnreadCountReconciliation()`. Only the per-message `isRead` field is applied
+    /// here, since it's a direct echo of what the SDK just requested.
     private func applyReadStatusResponse(_ response: UpdateReadStatusResponse) {
         for status in response.messages {
             messagesByID[status.messageId]?.isRead = status.isRead
         }
-        storedUnreadCount = response.unreadCount
-        unreadCountRevision &+= 1
         send(.loaded(orderedMessagesSnapshot()))
     }
 }

--- a/Tests/TestCases/InboxManagerTests.swift
+++ b/Tests/TestCases/InboxManagerTests.swift
@@ -369,15 +369,18 @@ final class InboxManagerTests: XCTestCase {
         await waitForUnreadCountFetch()
 
         // An identity change (e.g. clearUser/updateUser) lands while the PATCH is in flight,
-        // bumping the generation and zeroing the count for the new (logged-out) identity. Reset
-        // is purely local (see testResetForIdentityChange_doesNotFetchUnreadCountItself), so the
-        // hook doesn't need to wait for a spawned re-fetch — if the generation guard were removed
-        // the PATCH's applyReadStatusResponse would clobber 0 back to 99 and fail the assertion.
+        // bumping the generation and zeroing the count for the new (logged-out) identity. The
+        // stubbed count is set to 0 so the trailing reconciliation fetch also lands 0 — matching
+        // the "logged out" reality. If the generation guard were removed, the PATCH's
+        // applyReadStatusResponse would clobber the reset's 0 with 99 and fail this assertion.
         apiSpy.onMarkMessagesRead = {
+            self.apiSpy.stubbedUnreadCount = 0
             await manager.resetForIdentityChange()
         }
 
         await manager.markRead("1")
+        // Wait for the trailing reconciliation fetch spawned by markRead's `defer` to land.
+        await waitForUnreadCountFetches(count: 2)
 
         let unread = await manager.unreadCount
         XCTAssertEqual(unread, 0, "Stale mark-read response must not overwrite the post-reset unread count")
@@ -473,6 +476,8 @@ final class InboxManagerTests: XCTestCase {
         // succeeds first with an authoritative unread_count response; the failing A must revert
         // the isRead flag but NOT re-increment the count — the peer's server value is truth.
         // Without the count-revision guard, A's rollback would blindly add 1 to B's count.
+        // The trailing count reconciliation (Option A) then confirms the server value; server
+        // truth after both operations: A still unread, B now read → 4 unread total.
         apiSpy.stubbedInboxMessagesResponses = [
             InboxResponse(
                 messages: [makeMessage(id: "A", isRead: false), makeMessage(id: "B", isRead: false)],
@@ -480,8 +485,6 @@ final class InboxManagerTests: XCTestCase {
             )
         ]
         apiSpy.stubbedUnreadCount = 5
-        // Peer B's response is authoritative and lands before A fails. Server truth after both:
-        // A still unread, B now read → 4 unread. Rollback of A must preserve that 4, not push to 5.
         apiSpy.stubbedMarkReadResponse = UpdateReadStatusResponse(
             messages: [.init(messageId: "B", isRead: true)],
             unreadCount: 4
@@ -493,18 +496,23 @@ final class InboxManagerTests: XCTestCase {
 
         // On A's PATCH: drive B all the way through (successful, applies count=4), then fail A.
         // This mirrors the ordering when two row taps schedule detached Tasks and B's network
-        // returns first.
+        // returns first. Set stubbedUnreadCount = 4 so the trailing reconciliation fetches
+        // return the correct server truth (only A remains unread after B is marked read).
         let didRunHook = MutableString(value: "no")
         apiSpy.onMarkMessagesRead = {
             guard didRunHook.value == "no" else { return }
             didRunHook.value = "running"
             self.apiSpy.stubbedMarkReadError = nil // let B succeed
+            self.apiSpy.stubbedUnreadCount = 4 // server truth for trailing reconciliation fetches
             await manager.markRead("B")
             self.apiSpy.stubbedMarkReadError = NSError(domain: "test", code: -1) // A fails after
         }
         apiSpy.stubbedMarkReadError = NSError(domain: "test", code: -1)
 
         await manager.markRead("A")
+        // Both trailing reconciliations (one per markRead call) must land before assertions.
+        let countFetchesTarget = apiSpy.fetchInboxUnreadCountCallCount + 2
+        await waitForUnreadCountFetches(count: countFetchesTarget - 2 + 2)
 
         let messages = await manager.allMessages
         let unread = await manager.unreadCount
@@ -512,7 +520,7 @@ final class InboxManagerTests: XCTestCase {
         let b = messages.first { $0.id == "B" }
         XCTAssertEqual(a?.isRead, false, "Failed mark-read on A must revert A's isRead flag")
         XCTAssertEqual(b?.isRead, true, "Successful mark-read on B must persist B's flag")
-        XCTAssertEqual(unread, 4, "A's failed rollback must not clobber the authoritative count written by peer B")
+        XCTAssertEqual(unread, 4, "server-authoritative count endpoint value must land as the final state")
     }
 
     func testMarkRead_zeroUnreadCount_doesNotUnderflow() async {
@@ -624,14 +632,14 @@ final class InboxManagerTests: XCTestCase {
         _ = await waitForLoadedState(manager)
         await waitForUnreadCountFetch()
 
-        // Reset is purely local (see testResetForIdentityChange_doesNotFetchUnreadCountItself),
-        // so the hook just performs the reset — no re-fetch needs draining. If the generation
-        // guard were removed the PATCH's applyReadStatusResponse would clobber 0 back to 99.
+        // Same setup as the markRead variant — see that test for the ordering rationale.
         apiSpy.onMarkMessagesUnread = {
+            self.apiSpy.stubbedUnreadCount = 0
             await manager.resetForIdentityChange()
         }
 
         await manager.markUnread("1")
+        await waitForUnreadCountFetches(count: 2)
 
         let unread = await manager.unreadCount
         XCTAssertEqual(unread, 0, "Stale mark-unread response must not overwrite the post-reset unread count")
@@ -1053,6 +1061,187 @@ final class InboxManagerTests: XCTestCase {
 
         let hasMore = await manager.hasMore
         XCTAssertTrue(hasMore, "refresh error must not wipe the pagination cursor from the last successful fetch")
+    }
+
+    // MARK: - Post-mutation unread count reconciliation
+    //
+    // The count endpoint (`/inbox/messages/unread/count`) is the source of truth for the badge.
+    // Every markRead / markUnread / delete fires a trailing background count fetch so the badge
+    // converges to server truth regardless of how the host observes state — critical for hosts
+    // whose stream subscription is torn down mid-mutation (e.g., popping the inbox VC right
+    // after a swipe), and defensive against a mobile-api PATCH `unread_count` that lies for any
+    // reason. Tests here verify the trailing fetch fires on success, failure, and
+    // no-op-on-already-matching-state, and that its authoritative value supersedes both the
+    // PATCH response and the optimistic ±1.
+
+    func testMarkRead_success_alsoRefetchesUnreadCountFromCountEndpoint() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 3
+        // PATCH claims 99 unread — a wrong/stale value. The trailing count fetch (stubbed to 2
+        // via `stubbedUnreadCount`) must supersede it, proving the count endpoint is truth.
+        apiSpy.stubbedMarkReadResponse = UpdateReadStatusResponse(
+            messages: [.init(messageId: "1", isRead: true)],
+            unreadCount: 99
+        )
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+        let countFetchesBefore = apiSpy.fetchInboxUnreadCountCallCount
+
+        apiSpy.stubbedUnreadCount = 2
+        await manager.markRead("1")
+        await waitForUnreadCountFetches(count: countFetchesBefore + 1)
+
+        let unread = await manager.unreadCount
+        XCTAssertEqual(apiSpy.fetchInboxUnreadCountCallCount, countFetchesBefore + 1, "successful mark-read must fire a trailing count fetch")
+        XCTAssertEqual(unread, 2, "trailing count-endpoint value must supersede the PATCH response's unread_count")
+    }
+
+    func testMarkRead_failure_alsoRefetchesUnreadCountFromCountEndpoint() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 3
+        apiSpy.stubbedMarkReadError = NSError(domain: "test", code: -1)
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+        let countFetchesBefore = apiSpy.fetchInboxUnreadCountCallCount
+
+        // Server truth after the failure is still 3; the trailing fetch lands that value.
+        apiSpy.stubbedUnreadCount = 3
+        await manager.markRead("1")
+        await waitForUnreadCountFetches(count: countFetchesBefore + 1)
+
+        XCTAssertEqual(apiSpy.fetchInboxUnreadCountCallCount, countFetchesBefore + 1, "failed mark-read must still fire a trailing count fetch — defense against a rollback drifting from server truth")
+    }
+
+    func testMarkRead_alreadyRead_stillRefetchesUnreadCountFromCountEndpoint() async {
+        // Second tap on an already-read row must still reconcile the count with the server —
+        // the host may be depending on the trailing fetch to catch up after any interaction.
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: true)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 3
+        apiSpy.stubbedMarkReadResponse = UpdateReadStatusResponse(
+            messages: [.init(messageId: "1", isRead: true)],
+            unreadCount: 3
+        )
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+        let countFetchesBefore = apiSpy.fetchInboxUnreadCountCallCount
+
+        await manager.markRead("1")
+        await waitForUnreadCountFetches(count: countFetchesBefore + 1)
+
+        XCTAssertEqual(apiSpy.fetchInboxUnreadCountCallCount, countFetchesBefore + 1, "mark-read on an already-read row must still fire a trailing count fetch")
+    }
+
+    func testMarkUnread_success_alsoRefetchesUnreadCountFromCountEndpoint() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: true)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 2
+        apiSpy.stubbedMarkUnreadResponse = UpdateReadStatusResponse(
+            messages: [.init(messageId: "1", isRead: false)],
+            unreadCount: 99 // wrong/stale — must be superseded by the count endpoint
+        )
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+        let countFetchesBefore = apiSpy.fetchInboxUnreadCountCallCount
+
+        apiSpy.stubbedUnreadCount = 3
+        await manager.markUnread("1")
+        await waitForUnreadCountFetches(count: countFetchesBefore + 1)
+
+        let unread = await manager.unreadCount
+        XCTAssertEqual(apiSpy.fetchInboxUnreadCountCallCount, countFetchesBefore + 1)
+        XCTAssertEqual(unread, 3, "trailing count-endpoint value must supersede the PATCH response's unread_count")
+    }
+
+    func testMarkUnread_failure_alsoRefetchesUnreadCountFromCountEndpoint() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: true)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 2
+        apiSpy.stubbedMarkUnreadError = NSError(domain: "test", code: -1)
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+        let countFetchesBefore = apiSpy.fetchInboxUnreadCountCallCount
+
+        await manager.markUnread("1")
+        await waitForUnreadCountFetches(count: countFetchesBefore + 1)
+
+        XCTAssertEqual(apiSpy.fetchInboxUnreadCountCallCount, countFetchesBefore + 1, "failed mark-unread must still fire a trailing count fetch")
+    }
+
+    func testDelete_success_alsoRefetchesUnreadCountFromCountEndpoint() async {
+        // Delete's server response has no `unread_count` — the trailing fetch is what actually
+        // lands the authoritative value, even though optimistic decrement got the badge close.
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 3
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+        let countFetchesBefore = apiSpy.fetchInboxUnreadCountCallCount
+
+        apiSpy.stubbedUnreadCount = 2
+        await manager.delete("1")
+        await waitForUnreadCountFetches(count: countFetchesBefore + 1)
+
+        let unread = await manager.unreadCount
+        XCTAssertEqual(apiSpy.fetchInboxUnreadCountCallCount, countFetchesBefore + 1)
+        XCTAssertEqual(unread, 2, "trailing count fetch must land after delete's optimistic decrement")
+    }
+
+    func testDelete_failure_alsoRefetchesUnreadCountFromCountEndpoint() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 3
+        apiSpy.stubbedDeleteInboxMessageError = NSError(domain: "test", code: -1)
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+        let countFetchesBefore = apiSpy.fetchInboxUnreadCountCallCount
+
+        await manager.delete("1")
+        await waitForUnreadCountFetches(count: countFetchesBefore + 1)
+
+        XCTAssertEqual(apiSpy.fetchInboxUnreadCountCallCount, countFetchesBefore + 1, "failed delete must still fire a trailing count fetch")
+    }
+
+    func testMarkRead_recoversFromWrongPatchUnreadCount() async {
+        // The Umair-reported symptom: PATCH returns 0 (server lying) → badge disappears until the
+        // host re-navigates. With the trailing fetch, the count endpoint's true value (5) arrives
+        // just after and restores the badge without any host action.
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 6
+        apiSpy.stubbedMarkReadResponse = UpdateReadStatusResponse(
+            messages: [.init(messageId: "1", isRead: true)],
+            unreadCount: 0 // wrong: server lied
+        )
+        let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+        let countFetchesBefore = apiSpy.fetchInboxUnreadCountCallCount
+
+        // Count endpoint's real answer.
+        apiSpy.stubbedUnreadCount = 5
+        await manager.markRead("1")
+        await waitForUnreadCountFetches(count: countFetchesBefore + 1)
+
+        let unread = await manager.unreadCount
+        XCTAssertEqual(unread, 5, "count endpoint's authoritative value must overwrite a PATCH response that lied")
     }
 
     // MARK: - Click tracking

--- a/Tests/TestCases/InboxManagerTests.swift
+++ b/Tests/TestCases/InboxManagerTests.swift
@@ -313,26 +313,32 @@ final class InboxManagerTests: XCTestCase {
 
     // MARK: - Mark Read
 
-    func testMarkRead_success_flipsLocalAndSyncsUnreadCountFromServer() async {
+    func testMarkRead_success_flipsLocalAndSyncsUnreadCountFromCountEndpoint() async {
+        // Post-refactor: the PATCH's `unread_count` field is IGNORED (mobile-api's PATCH
+        // endpoints have historically returned mismatched values). The trailing count-endpoint
+        // fetch is the sole authoritative source; the badge converges to its value.
         apiSpy.stubbedInboxMessagesResponses = [
             InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
         ]
         apiSpy.stubbedUnreadCount = 1
         apiSpy.stubbedMarkReadResponse = UpdateReadStatusResponse(
             messages: [.init(messageId: "1", isRead: true)],
-            unreadCount: 0
+            unreadCount: 99 // deliberately wrong — must be ignored
         )
 
         let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
         _ = await waitForLoadedState(manager)
         await waitForUnreadCountFetch()
+        let countFetchesBefore = apiSpy.fetchInboxUnreadCountCallCount
 
+        apiSpy.stubbedUnreadCount = 0 // server truth for the trailing reconciliation
         await manager.markRead("1")
+        await waitForUnreadCountFetches(count: countFetchesBefore + 1)
 
         let messages = await manager.allMessages
         let unread = await manager.unreadCount
         XCTAssertTrue(messages.first?.isRead ?? false)
-        XCTAssertEqual(unread, 0, "unread_count from response should be authoritative")
+        XCTAssertEqual(unread, 0, "count endpoint value (not PATCH response's unread_count) must be authoritative")
         XCTAssertEqual(apiSpy.markMessagesReadCallCount, 1)
         XCTAssertEqual(apiSpy.lastMarkReadMessageIds, ["1"])
         XCTAssertEqual(apiSpy.lastMarkReadVisitorId, "v_test")
@@ -428,12 +434,13 @@ final class InboxManagerTests: XCTestCase {
         apiSpy.stubbedUnreadCount = 3
         apiSpy.stubbedMarkReadResponse = UpdateReadStatusResponse(
             messages: [.init(messageId: "1", isRead: true)],
-            unreadCount: 2
+            unreadCount: 99 // PATCH's unread_count is ignored — trailing count fetch is truth
         )
 
         let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
         _ = await waitForLoadedState(manager)
         await waitForUnreadCountFetch()
+        let countFetchesBefore = apiSpy.fetchInboxUnreadCountCallCount
 
         var inFlightUnread: Int?
         var inFlightIsRead: Bool?
@@ -443,13 +450,15 @@ final class InboxManagerTests: XCTestCase {
             inFlightIsRead = await manager.currentInboxStateForTesting.firstMessageIsReadForTesting
         }
 
+        apiSpy.stubbedUnreadCount = 2 // trailing reconciliation server truth
         await manager.markRead("1")
+        await waitForUnreadCountFetches(count: countFetchesBefore + 1)
 
         XCTAssertEqual(inFlightIsRead, true, "row must show as read while PATCH is in flight")
         XCTAssertEqual(inFlightUnread, 2, "badge must decrement optimistically, not wait for the server response")
 
         let unread = await manager.unreadCount
-        XCTAssertEqual(unread, 2, "server response is authoritative and reconciles the optimistic value")
+        XCTAssertEqual(unread, 2, "count endpoint value must be the final authoritative badge count")
     }
 
     func testMarkRead_failure_revertsUnreadCountAlongsideFlag() async {
@@ -577,26 +586,31 @@ final class InboxManagerTests: XCTestCase {
 
     // MARK: - Mark Unread
 
-    func testMarkUnread_success_flipsLocalAndSyncsUnreadCountFromServer() async {
+    func testMarkUnread_success_flipsLocalAndSyncsUnreadCountFromCountEndpoint() async {
+        // Post-refactor: PATCH's unread_count is ignored; the trailing count-endpoint fetch is
+        // the sole authoritative source.
         apiSpy.stubbedInboxMessagesResponses = [
             InboxResponse(messages: [makeMessage(id: "1", isRead: true)], nextPageToken: nil)
         ]
         apiSpy.stubbedUnreadCount = 0
         apiSpy.stubbedMarkUnreadResponse = UpdateReadStatusResponse(
             messages: [.init(messageId: "1", isRead: false)],
-            unreadCount: 7
+            unreadCount: 99 // deliberately wrong — must be ignored
         )
 
         let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
         _ = await waitForLoadedState(manager)
         await waitForUnreadCountFetch()
+        let countFetchesBefore = apiSpy.fetchInboxUnreadCountCallCount
 
+        apiSpy.stubbedUnreadCount = 7 // trailing reconciliation server truth
         await manager.markUnread("1")
+        await waitForUnreadCountFetches(count: countFetchesBefore + 1)
 
         let messages = await manager.allMessages
         let unread = await manager.unreadCount
         XCTAssertFalse(messages.first?.isRead ?? true)
-        XCTAssertEqual(unread, 7, "unread_count from response should be authoritative")
+        XCTAssertEqual(unread, 7, "count endpoint value must be the final authoritative badge count")
         XCTAssertEqual(apiSpy.markMessagesUnreadCallCount, 1)
         XCTAssertEqual(apiSpy.lastMarkUnreadMessageIds, ["1"])
         XCTAssertEqual(apiSpy.lastMarkUnreadVisitorId, "v_test")
@@ -651,13 +665,17 @@ final class InboxManagerTests: XCTestCase {
         ]
         apiSpy.stubbedMarkUnreadResponse = UpdateReadStatusResponse(
             messages: [.init(messageId: "1", isRead: false)],
-            unreadCount: 2
+            unreadCount: 99 // PATCH's unread_count is ignored — trailing count fetch is truth
         )
+        apiSpy.stubbedUnreadCount = 2 // trailing count fetch's server truth
 
         let manager = InboxManager(api: apiSpy, identityProvider: identityProvider())
         _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+        let countFetchesBefore = apiSpy.fetchInboxUnreadCountCallCount
 
         await manager.markUnread("1")
+        await waitForUnreadCountFetches(count: countFetchesBefore + 1)
 
         let unread = await manager.unreadCount
         XCTAssertEqual(unread, 2)


### PR DESCRIPTION
## Summary

Follow-up to #282 for [MSDK-439](https://attentivemobile.atlassian.net/browse/MSDK-439). Fixes the persistent symptom Umair reported: **after mark-read / mark-unread / delete in the inbox view, popping back to the host page leaves the inbox badge missing entirely (as if the count is 0). A second inbox visit + pop restores the correct count.**

## Root cause — confirmed backend bug ([CI-566](https://attentivemobile.atlassian.net/browse/CI-566))

`mobile-api`'s handlers for `PATCH /inbox/messages/read` and `PATCH /inbox/messages/unread` **hardcode `unread_count = 0` in their response DTO**, regardless of the user's actual unread state. Traced to:

- `mobile-api/src/main/java/com/attentivemobile/mobile/api/client/InboxMessageClientImpl.java` lines 70-71 and 99-100:
  ```java
  // Note: The actual unread count would need to be fetched separately or returned by the service
  return new UpdateReadStatusResult(statuses, 0);
  ```
- Upstream proto (`contracts/mobile-inbox-service/.../MobileInbox.proto`) also lacks the field on `MarkReadResponse` / `MarkUnreadResponse`, so the mobile-api layer had no source to read from — the `0` is a stub the endpoint owner never wired up.

This has been filed as **[CI-566](https://attentivemobile.atlassian.net/browse/CI-566)** with reporter Adela Gao. Preferred backend fix: add `unread_count` to the proto responses and wire it through so the SDK gets the real count from the PATCH round-trip.

## Why the SDK-side workaround is worth landing anyway

The bug affects every user of the iOS SDK v0.6.x+ **right now**. Even after CI-566 ships, the mobile-api rollout will take time, and older SDK versions in the field will still hit this until they update.

The defensive fix in this PR makes the SDK **immune to the field** — regardless of what mobile-api's PATCH returns in `unread_count` (0, wrong value, missing), the SDK never trusts it. The badge count is always sourced from `POST /inbox/messages/unread/count` (the endpoint the RFC declared source-of-truth).

Once CI-566 is fully deployed AND the SDK version depending on this workaround has aged out of the field, the defensive path could be simplified (trust the PATCH's `unread_count` again, drop the trailing count fetch). That's a follow-up decision, not required now.

## What this PR changes

`Sources/Inbox/InboxManager.swift`:

1. **`applyReadStatusResponse` no longer writes `storedUnreadCount = response.unreadCount`.** Only the per-message `isRead` echo is applied (direct request↔response mapping — trustworthy).
2. **Every `markRead` / `markUnread` / `delete` fires a background `/inbox/messages/unread/count` fetch** via `defer { scheduleUnreadCountReconciliation() }`. Runs on both success and failure paths so the badge converges to server truth in a bounded window regardless of what the PATCH returned.
3. **Optimistic ±1 stays** for immediate visual feedback between tap and reconciliation.
4. **Rollback logic split**: `isRead` reverts unconditionally on PATCH failure (per-message truth), count revert stays gated on `unreadCountRevision` (protects against peer-mutation clobber).

Doc comments call out CI-566 by ticket key and describe the tradeoff for a future maintainer.

## Why this fix is robust across host architectures

The bug reproduces regardless of how the host observes state — UIKit `viewWillAppear` cancelling stream subscriptions, SwiftUI `.task` on view lifecycle, Combine subscribers, or direct polling on `sdk.unreadCount`. The SDK now self-heals: the trailing count fetch lands within one network round-trip of any mutation, writing the correct value into `storedUnreadCount` before the host next reads it. No host-side "refresh on appear" hook is required.

References consulted (Apple):
- [SE-0314 (`AsyncStream`)](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0314-async-stream.md) — confirmed `AsyncStream` is single-consumer by design; buffering is unbounded by default; the build closure runs synchronously in the initializer on the caller's executor.
- [SE-0304 (Structured Concurrency)](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0304-structured-concurrency.md) — unstructured `Task {}` is the correct pattern for fire-and-forget reconciliation.

## Test plan

- [x] 59 InboxManager unit tests pass (up from 51 pre-PR), including 8 new ones for the trailing reconciliation on success/failure/no-op paths and a `testMarkRead_recoversFromWrongPatchUnreadCount` regression test that stubs `unread_count: 0` from the PATCH and asserts the badge converges to the count endpoint's value.
- [ ] Manual (once merged into a testable build): reproduce the ticket's scenario in the Bonni demo app — tap read/unread/delete, back → badge shows the correct count without needing a second visit.
- [ ] Verify no regression on the second-visit path — refresh + navigation back should still show correct count.

## Related tickets

- Parent (mobile SDK): [MSDK-439](https://attentivemobile.atlassian.net/browse/MSDK-439)
- Backend fix ticket: [CI-566](https://attentivemobile.atlassian.net/browse/CI-566)
- Preceding SDK PR: #282 (commit `3067351` on `develop`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MSDK-439]: https://attentivemobile.atlassian.net/browse/MSDK-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CI-566]: https://attentivemobile.atlassian.net/browse/CI-566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CI-566]: https://attentivemobile.atlassian.net/browse/CI-566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ