### PR TITLE
MSDK-213: open push and inbox deeplinks on tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+### Features
+- **The SDK now opens push deep links on the host app's behalf** (MSDK-213), matching the Android SDK: custom-scheme URLs route into your app's URL handlers, http(s) URLs open as universal links only (never the browser). **⚠️ Behavior change if you upgrade:** if your app already navigates in response to the `ATTNSDKDeepLinkReceived` broadcast or `consumeDeepLink()`, set `automaticallyOpensPushDeepLinks = false` to avoid handling the same URL twice. This applies to foreground banner taps too. The URL is always broadcast and stored regardless of the setting.
+- The built-in inbox UI now opens a tapped message's `actionURL` (unclaimed http(s) links fall back to the browser). Opt out with `automaticallyOpensInboxDeepLinks = false`, or pass `onMessageTap` to `inboxView()` / `inboxViewController()` to replace the routing entirely; click tracking and the `ATTNSDKInboxMessageTapped` broadcast fire either way.
+- Server-supplied deep-link URLs are validated before the SDK opens them: scriptable schemes (`javascript:`, `file:`, `data:`, `about:`, `vbscript:`) and privileged system-action schemes (`tel:`, `sms:`, `mailto:`, `facetime:`, `itms-*`, …) are never opened, though they are still broadcast for host visibility.
+
 ## [2.0.13](https://github.com/attentive-mobile/attentive-ios-sdk/compare/2.0.12...2.0.13) (2026-02-27)
 Bug Fixes & Improvements
 - Push token events are now sent on every app foreground, ensuring more reliable push notification delivery (#197)

--- a/README.md
+++ b/README.md
@@ -523,6 +523,8 @@ When a notification is tapped, the SDK extracts the deep-link URL (`attentive_op
 
 This means that if your app already handles its URL schemes or universal links, push deep links work with no additional wiring — matching the behavior of our Android SDK.
 
+> **⚠️ Upgrading from an earlier version?** Previous SDK versions never opened the URL — they only broadcast it. If your app already navigates in response to the `ATTNSDKDeepLinkReceived` notification or `consumeDeepLink()`, set `automaticallyOpensPushDeepLinks = false` when you upgrade, or the same URL will be handled twice (once by your code, once by the SDK).
+
 If you prefer to handle navigation yourself (e.g. navigate later, or wait until the user is logged in), disable automatic opening and use one of the options below. The SDK always broadcasts and stores the URL regardless of this setting.
 
 ```

--- a/README.md
+++ b/README.md
@@ -516,7 +516,18 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
 
 ### Deep Link Support
 
-Our SDK does not open URLs directly. Instead, it extracts and broadcasts a valid deep-link URL whenever a notification is tapped. Your app can then decide when and how to handle it (e.g. navigate immediately, or store it if the user is logged out).
+When a notification is tapped, the SDK extracts the deep-link URL (`attentive_open_action_url`) and opens it on your app's behalf:
+
+- **Custom-scheme URLs** (e.g. `myapp://cart`) are handed to the system, which routes them into your app's existing URL handlers (`application(_:open:options:)` / `scene(_:openURLContexts:)`).
+- **Http(s) URLs** are opened as [universal links](https://developer.apple.com/documentation/xcode/allowing-apps-and-websites-to-link-to-your-content) only. If your app has registered for the link's domain, it is delivered through your app's `NSUserActivity` handlers; the user is never sent to the browser.
+
+This means that if your app already handles its URL schemes or universal links, push deep links work with no additional wiring — matching the behavior of our Android SDK.
+
+If you prefer to handle navigation yourself (e.g. navigate later, or wait until the user is logged in), disable automatic opening and use one of the options below. The SDK always broadcasts and stores the URL regardless of this setting.
+
+```
+attentiveSdk.automaticallyOpensPushDeepLinks = false
+```
 
 #### Option 1: Observe the ATTNSDKDeepLinkReceived notification
 ```

--- a/Sources/Helpers/Protocols/ATTNURLOpening.swift
+++ b/Sources/Helpers/Protocols/ATTNURLOpening.swift
@@ -1,0 +1,22 @@
+//
+//  ATTNURLOpening.swift
+//  attentive-ios-sdk-framework
+//
+//  Created by Umair Sharif on 7/24/26.
+//
+
+import UIKit
+
+/// Abstraction over `UIApplication`'s URL opening so deep-link handling can be unit tested.
+protocol ATTNURLOpening {
+    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler: ((Bool) -> Void)?)
+}
+
+/// Default `ATTNURLOpening` backed by `UIApplication.shared`.
+struct ATTNApplicationURLOpener: ATTNURLOpening {
+    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler: ((Bool) -> Void)?) {
+        Task { @MainActor in
+            UIApplication.shared.open(url, options: options, completionHandler: completionHandler)
+        }
+    }
+}

--- a/Sources/Helpers/Protocols/ATTNURLOpening.swift
+++ b/Sources/Helpers/Protocols/ATTNURLOpening.swift
@@ -23,20 +23,37 @@ struct ATTNApplicationURLOpener: ATTNURLOpening {
 
 extension URL {
     /// Schemes the SDK refuses to hand to `UIApplication.open` for server-driven deeplinks —
-    /// none of these are legitimate campaign destinations, and `javascript:`/`data:` are
-    /// script-injection vectors if a message payload is ever misconfigured or attacker-shaped.
-    private static let blockedDeepLinkSchemes: Set<String> = ["javascript", "file", "data", "about", "vbscript"]
+    /// none of these are legitimate campaign destinations. `javascript:`/`data:` are
+    /// script-injection vectors if a message payload is ever misconfigured or attacker-shaped;
+    /// the rest trigger system actions or prompts (dialer, SMS/mail composer, FaceTime call,
+    /// App Store / mobileconfig install) — an escalation a push tap must never cause without
+    /// host consent. Blocked URLs are still broadcast; hosts decide for themselves.
+    private static let blockedDeepLinkSchemes: Set<String> = [
+        // Scriptable / local-content schemes
+        "javascript", "file", "data", "about", "vbscript",
+        // Privileged system-action schemes
+        "tel", "telprompt", "sms", "mailto", "facetime", "facetime-audio",
+        "itms", "itms-apps", "itms-services",
+    ]
+
+    /// True when `scheme` is a shape the SDK will hand to `UIApplication.open`: non-empty,
+    /// scheme-shaped, and not on the blocked list. The shape check is deliberately looser than
+    /// RFC 3986 (which requires a leading letter and forbids `_`): underscores and leading
+    /// digits are registrable in Info.plist and the lenient pre-iOS 17 `URL(string:)` parses
+    /// them, so schemes like `my_app` or `1password` must not be dropped on iOS 15/16.
+    static func attnIsOpenableDeepLinkScheme(_ scheme: String?) -> Bool {
+        guard let scheme = scheme?.lowercased(),
+              scheme.range(of: "^[a-z0-9][a-z0-9_+.-]*$", options: .regularExpression) != nil else {
+            return false
+        }
+        return !blockedDeepLinkSchemes.contains(scheme)
+    }
 
     /// True when the URL is safe for the SDK to open as a deeplink. `URL(string:)` alone is too
     /// permissive for server-supplied strings: it accepts empty schemes (`"://foo"` parses with
-    /// `scheme == ""`) and scriptable schemes (`javascript:…`). Requires an RFC 3986-shaped
-    /// scheme (letter, then letters/digits/`+`/`-`/`.`) that is not on the blocked list;
-    /// `http(s)` and app custom schemes all pass.
+    /// `scheme == ""`), scriptable schemes (`javascript:…`), and privileged system-action
+    /// schemes (`tel:…`). `http(s)` and app custom schemes all pass.
     var attnIsOpenableDeepLink: Bool {
-        guard let scheme = scheme?.lowercased(),
-              scheme.range(of: "^[a-z][a-z0-9+.-]*$", options: .regularExpression) != nil else {
-            return false
-        }
-        return !Self.blockedDeepLinkSchemes.contains(scheme)
+        Self.attnIsOpenableDeepLinkScheme(scheme)
     }
 }

--- a/Sources/Helpers/Protocols/ATTNURLOpening.swift
+++ b/Sources/Helpers/Protocols/ATTNURLOpening.swift
@@ -20,3 +20,23 @@ struct ATTNApplicationURLOpener: ATTNURLOpening {
         }
     }
 }
+
+extension URL {
+    /// Schemes the SDK refuses to hand to `UIApplication.open` for server-driven deeplinks —
+    /// none of these are legitimate campaign destinations, and `javascript:`/`data:` are
+    /// script-injection vectors if a message payload is ever misconfigured or attacker-shaped.
+    private static let blockedDeepLinkSchemes: Set<String> = ["javascript", "file", "data", "about", "vbscript"]
+
+    /// True when the URL is safe for the SDK to open as a deeplink. `URL(string:)` alone is too
+    /// permissive for server-supplied strings: it accepts empty schemes (`"://foo"` parses with
+    /// `scheme == ""`) and scriptable schemes (`javascript:…`). Requires an RFC 3986-shaped
+    /// scheme (letter, then letters/digits/`+`/`-`/`.`) that is not on the blocked list;
+    /// `http(s)` and app custom schemes all pass.
+    var attnIsOpenableDeepLink: Bool {
+        guard let scheme = scheme?.lowercased(),
+              scheme.range(of: "^[a-z][a-z0-9+.-]*$", options: .regularExpression) != nil else {
+            return false
+        }
+        return !Self.blockedDeepLinkSchemes.contains(scheme)
+    }
+}

--- a/Sources/Inbox/InboxView.swift
+++ b/Sources/Inbox/InboxView.swift
@@ -29,10 +29,10 @@ struct InboxView: View {
                         InboxMessageRowView(message: message, style: viewModel.style)
                             .contentShape(Rectangle())
                             .onTapGesture {
-                                // Fires click tracking + local read flip, and broadcasts
-                                // `ATTNSDKInboxMessageTapped` (userInfo carries the actionURL).
-                                // The SDK does not open the URL itself — host apps route it.
-                                viewModel.click(id: message.id, actionURL: message.actionURL)
+                                // The VM owns tap routing: click tracking + read flip, the
+                                // `ATTNSDKInboxMessageTapped` broadcast, then the host's
+                                // `onMessageTap` handler or the default `actionURL` open.
+                                viewModel.click(message)
                             }
                             .swipeActions(edge: .trailing) {
                                 Button(role: .destructive) {

--- a/Sources/Inbox/InboxViewModel.swift
+++ b/Sources/Inbox/InboxViewModel.swift
@@ -97,11 +97,14 @@ class InboxViewModel: ObservableObject {
         }
     }
 
-    /// Called from `InboxView` when the user taps a row. In order: fires the click-tracking
-    /// POST + read flip, broadcasts `ATTNSDKInboxMessageTapped` (userInfo carries the
-    /// actionURL), then routes the tap — to the host's `onMessageTap` handler when one was
-    /// provided, otherwise by opening `actionURL` via `UIApplication`. Unclaimed http(s) links
-    /// fall back to the browser; a custom scheme no app claims is logged and dropped.
+    /// Called from `InboxView` when the user taps a row. Dispatches the click-tracking POST +
+    /// read flip to the manager (async — navigation must not wait on the network, matching the
+    /// Android SDK), broadcasts `ATTNSDKInboxMessageTapped` (userInfo carries the actionURL),
+    /// then routes the tap — to the host's `onMessageTap` handler when one was provided,
+    /// otherwise by opening `actionURL` via `UIApplication`. Unclaimed http(s) links fall back
+    /// to the browser; a custom scheme no app claims is logged and dropped. Note the tracking
+    /// runs concurrently with routing: an `onMessageTap` handler that reads inbox state
+    /// synchronously may still observe the message as unread.
     func click(_ message: Message) {
         Task {
             await inboxManager.markClicked(message.id)
@@ -124,6 +127,12 @@ class InboxViewModel: ObservableObject {
         }
 
         guard let actionURL = message.actionURL else { return }
+        // Server-supplied string: refuse empty-scheme and scriptable (javascript:/file:/data:)
+        // URLs. The broadcast above still carries the raw URL — hosts decide for themselves.
+        guard actionURL.attnIsOpenableDeepLink else {
+            Loggers.network.error("Refusing to open inbox action URL with unsupported scheme: \(actionURL, privacy: .public)")
+            return
+        }
         urlOpener.open(actionURL, options: [:]) { success in
             if !success {
                 Loggers.network.error("No app claimed inbox action URL: \(actionURL, privacy: .public)")

--- a/Sources/Inbox/InboxViewModel.swift
+++ b/Sources/Inbox/InboxViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 @MainActor
 class InboxViewModel: ObservableObject {
@@ -28,12 +29,21 @@ class InboxViewModel: ObservableObject {
     let style: InboxStyle
 
     private let inboxManager: InboxManager
+    private let onTap: ((Message) -> Void)?
+    private let urlOpener: ATTNURLOpening
     private var stateStreamTask: Task<Void, Never>?
     private var loadingMoreStreamTask: Task<Void, Never>?
 
-    init(inboxManager: InboxManager, style: InboxStyle) {
+    init(
+        inboxManager: InboxManager,
+        style: InboxStyle,
+        onTap: ((Message) -> Void)? = nil,
+        urlOpener: ATTNURLOpening = ATTNApplicationURLOpener()
+    ) {
         self.inboxManager = inboxManager
         self.style = style
+        self.onTap = onTap
+        self.urlOpener = urlOpener
         state = .loading
         stateStreamTask = Task { [weak self] in
             guard let stream = await self?.inboxManager.stateStream else { return }
@@ -87,15 +97,17 @@ class InboxViewModel: ObservableObject {
         }
     }
 
-    /// Called from `InboxView` when the user taps a row. Fires the click-tracking POST + flips
-    /// the row's read state, and broadcasts `ATTNSDKInboxMessageTapped` so host apps can route
-    /// to `actionURL`. The SDK intentionally does not open the URL itself.
-    func click(id: Message.ID, actionURL: URL?) {
+    /// Called from `InboxView` when the user taps a row. In order: fires the click-tracking
+    /// POST + read flip, broadcasts `ATTNSDKInboxMessageTapped` (userInfo carries the
+    /// actionURL), then routes the tap — to the host's `onMessageTap` handler when one was
+    /// provided, otherwise by opening `actionURL` via `UIApplication`. Unclaimed http(s) links
+    /// fall back to the browser; a custom scheme no app claims is logged and dropped.
+    func click(_ message: Message) {
         Task {
-            await inboxManager.markClicked(id)
+            await inboxManager.markClicked(message.id)
         }
-        var userInfo: [AnyHashable: Any] = ["attentiveInboxMessageId": id]
-        if let actionURL {
+        var userInfo: [AnyHashable: Any] = ["attentiveInboxMessageId": message.id]
+        if let actionURL = message.actionURL {
             userInfo["attentiveInboxActionUrl"] = actionURL
         }
         NotificationCenter.default.post(
@@ -103,6 +115,20 @@ class InboxViewModel: ObservableObject {
             object: nil,
             userInfo: userInfo
         )
+
+        // Host-provided handler replaces the SDK's routing entirely (matches the Android
+        // SDK's onMessageClick override) — it hears every tap, even URL-less ones.
+        if let onTap {
+            onTap(message)
+            return
+        }
+
+        guard let actionURL = message.actionURL else { return }
+        urlOpener.open(actionURL, options: [:]) { success in
+            if !success {
+                Loggers.network.error("No app claimed inbox action URL: \(actionURL, privacy: .public)")
+            }
+        }
     }
 }
 

--- a/Sources/Inbox/InboxViewModel.swift
+++ b/Sources/Inbox/InboxViewModel.swift
@@ -31,6 +31,10 @@ class InboxViewModel: ObservableObject {
     private let inboxManager: InboxManager
     private let onTap: ((Message) -> Void)?
     private let urlOpener: ATTNURLOpening
+    /// Read at tap time (not captured at init) so hosts can toggle
+    /// `ATTNSDK.automaticallyOpensInboxDeepLinks` after the inbox view is created,
+    /// matching the push flag's read-on-tap semantics.
+    private let shouldOpenDeepLink: () -> Bool
     private var stateStreamTask: Task<Void, Never>?
     private var loadingMoreStreamTask: Task<Void, Never>?
 
@@ -38,12 +42,14 @@ class InboxViewModel: ObservableObject {
         inboxManager: InboxManager,
         style: InboxStyle,
         onTap: ((Message) -> Void)? = nil,
-        urlOpener: ATTNURLOpening = ATTNApplicationURLOpener()
+        urlOpener: ATTNURLOpening = ATTNApplicationURLOpener(),
+        shouldOpenDeepLink: @escaping () -> Bool = { true }
     ) {
         self.inboxManager = inboxManager
         self.style = style
         self.onTap = onTap
         self.urlOpener = urlOpener
+        self.shouldOpenDeepLink = shouldOpenDeepLink
         state = .loading
         stateStreamTask = Task { [weak self] in
             guard let stream = await self?.inboxManager.stateStream else { return }
@@ -101,7 +107,8 @@ class InboxViewModel: ObservableObject {
     /// read flip to the manager (async — navigation must not wait on the network, matching the
     /// Android SDK), broadcasts `ATTNSDKInboxMessageTapped` (userInfo carries the actionURL),
     /// then routes the tap — to the host's `onMessageTap` handler when one was provided,
-    /// otherwise by opening `actionURL` via `UIApplication`. Unclaimed http(s) links fall back
+    /// otherwise by opening `actionURL` via `UIApplication` (unless the host disabled
+    /// `automaticallyOpensInboxDeepLinks`). Unclaimed http(s) links fall back
     /// to the browser; a custom scheme no app claims is logged and dropped. Note the tracking
     /// runs concurrently with routing: an `onMessageTap` handler that reads inbox state
     /// synchronously may still observe the message as unread.
@@ -123,6 +130,13 @@ class InboxViewModel: ObservableObject {
         // SDK's onMessageClick override) — it hears every tap, even URL-less ones.
         if let onTap {
             onTap(message)
+            return
+        }
+
+        // Host opted out of SDK-initiated navigation (`automaticallyOpensInboxDeepLinks`) —
+        // click tracking and the broadcast above still ran; routing is the host's job.
+        guard shouldOpenDeepLink() else {
+            Loggers.network.debug("Automatic inbox deep link opening is disabled; host app is expected to handle the tap via the ATTNSDKInboxMessageTapped broadcast.")
             return
         }
 

--- a/Sources/Inbox/InboxViewModel.swift
+++ b/Sources/Inbox/InboxViewModel.swift
@@ -127,8 +127,9 @@ class InboxViewModel: ObservableObject {
         }
 
         guard let actionURL = message.actionURL else { return }
-        // Server-supplied string: refuse empty-scheme and scriptable (javascript:/file:/data:)
-        // URLs. The broadcast above still carries the raw URL — hosts decide for themselves.
+        // Server-supplied string: refuse empty-scheme, scriptable (javascript:/file:/data:),
+        // and privileged system-action (tel:/sms:/itms-*) URLs. The broadcast above still
+        // carries the raw URL — hosts decide for themselves.
         guard actionURL.attnIsOpenableDeepLink else {
             Loggers.network.error("Refusing to open inbox action URL with unsupported scheme: \(actionURL, privacy: .public)")
             return

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -309,14 +309,20 @@ public final class ATTNSDK: NSObject {
         await materializedInboxManager().refreshUnreadCount()
     }
 
+    /// Returns the SDK's default inbox UI. On row tap the SDK fires click tracking, broadcasts
+    /// `ATTNSDKInboxMessageTapped`, and opens the message's `actionURL` — universal links
+    /// resolve into their app, other http(s) links fall back to the browser. Pass
+    /// `onMessageTap` to replace that default URL routing with your own navigation; click
+    /// tracking still fires first.
     @MainActor
-    public func inboxView(style: InboxStyle = InboxStyle()) -> some View {
-        InboxView(viewModel: InboxViewModel(inboxManager: materializedInboxManager(), style: style))
+    public func inboxView(style: InboxStyle = InboxStyle(), onMessageTap: ((Message) -> Void)? = nil) -> some View {
+        InboxView(viewModel: InboxViewModel(inboxManager: materializedInboxManager(), style: style, onTap: onMessageTap))
     }
 
+    /// UIKit wrapper for `inboxView(style:onMessageTap:)` — see that method for tap semantics.
     @MainActor
-    public func inboxViewController(style: InboxStyle = InboxStyle()) -> UIViewController {
-        UIHostingController(rootView: inboxView(style: style))
+    public func inboxViewController(style: InboxStyle = InboxStyle(), onMessageTap: ((Message) -> Void)? = nil) -> UIViewController {
+        UIHostingController(rootView: inboxView(style: style, onMessageTap: onMessageTap))
     }
 
     public func markRead(for messageID: Message.ID) async {

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -939,16 +939,12 @@ extension ATTNSDK {
     /// host app's behalf when `automaticallyOpensPushDeepLinks` is enabled.
     func normalizeAndBroadcast(_ rawString: String) {
         let trimmed = rawString.trimmingCharacters(in: .whitespacesAndNewlines)
-        var candidateURL: URL?
 
-        // `attnIsOpenableDeepLink` rejects empty-scheme ("://foo") and scriptable
-        // (javascript:/file:/data:) URLs — this string is server-supplied campaign data, so it
-        // must be validated before it is stored, broadcast, or handed to UIApplication.
-        if let trimmedURL = URL(string: trimmed), trimmedURL.attnIsOpenableDeepLink {
-            candidateURL = trimmedURL
-        }
-
-        guard let validURL = candidateURL else {
+        // Any URL that parses with a non-empty scheme is stored and broadcast so hosts
+        // observing ATTNSDKDeepLinkReceived (or polling consumeDeepLink()) keep visibility
+        // into every campaign URL, matching the inbox path. Only the SDK-initiated open
+        // below is gated on the scheme safety check.
+        guard let validURL = URL(string: trimmed), validURL.scheme?.isEmpty == false else {
             Loggers.network.error("Failed to parse deep link URL from string: '\(trimmed, privacy: .public)' - Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
             return
         }
@@ -961,6 +957,14 @@ extension ATTNSDK {
             userInfo: ["attentivePushDeeplinkUrl": validURL]
         )
         Loggers.network.debug("Deep link notification posted successfully - URL: \(validURL, privacy: .public)")
+
+        // Server-supplied string: refuse to hand scriptable (javascript:/file:/data:) and
+        // privileged system-action (tel:/sms:/itms-*) schemes to UIApplication. The broadcast
+        // above still carries the raw URL — hosts decide for themselves.
+        guard validURL.attnIsOpenableDeepLink else {
+            Loggers.network.error("Refusing to open push deep link with unsupported scheme: \(validURL, privacy: .public)")
+            return
+        }
 
         openDeepLink(validURL)
     }

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -80,8 +80,14 @@ public final class ATTNSDK: NSObject {
     /// registered for them they are never sent to the browser; the URL stays available through
     /// the `ATTNSDKDeepLinkReceived` broadcast and `consumeDeepLink()`.
     ///
+    /// This applies to foreground taps too: when a push banner arrives while the app is active
+    /// and the user taps it, the SDK navigates immediately — previously it only broadcast the
+    /// URL. Hosts that treat in-app banner taps as log-only should opt out.
+    ///
     /// Set to false if the host app navigates on its own via the `ATTNSDKDeepLinkReceived`
-    /// broadcast or `consumeDeepLink()`, to avoid handling the same URL twice.
+    /// broadcast or `consumeDeepLink()`, to avoid handling the same URL twice. Set it once
+    /// during SDK setup on the main thread — it is read on the main thread when a tap is
+    /// handled, and mutation from other threads is not synchronized.
     @objc public var automaticallyOpensPushDeepLinks: Bool = true
 
     var urlOpener: ATTNURLOpening = ATTNApplicationURLOpener()
@@ -313,7 +319,8 @@ public final class ATTNSDK: NSObject {
     /// `ATTNSDKInboxMessageTapped`, and opens the message's `actionURL` — universal links
     /// resolve into their app, other http(s) links fall back to the browser. Pass
     /// `onMessageTap` to replace that default URL routing with your own navigation; click
-    /// tracking still fires first.
+    /// tracking still fires first. To keep tracking and the broadcast but suppress all
+    /// SDK-initiated navigation, pass an empty closure: `onMessageTap: { _ in }`.
     @MainActor
     public func inboxView(style: InboxStyle = InboxStyle(), onMessageTap: ((Message) -> Void)? = nil) -> some View {
         InboxView(viewModel: InboxViewModel(inboxManager: materializedInboxManager(), style: style, onTap: onMessageTap))
@@ -934,7 +941,10 @@ extension ATTNSDK {
         let trimmed = rawString.trimmingCharacters(in: .whitespacesAndNewlines)
         var candidateURL: URL?
 
-        if let trimmedURL = URL(string: trimmed), trimmedURL.scheme != nil {
+        // `attnIsOpenableDeepLink` rejects empty-scheme ("://foo") and scriptable
+        // (javascript:/file:/data:) URLs — this string is server-supplied campaign data, so it
+        // must be validated before it is stored, broadcast, or handed to UIApplication.
+        if let trimmedURL = URL(string: trimmed), trimmedURL.attnIsOpenableDeepLink {
             candidateURL = trimmedURL
         }
 

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -90,6 +90,19 @@ public final class ATTNSDK: NSObject {
     /// handled, and mutation from other threads is not synchronized.
     @objc public var automaticallyOpensPushDeepLinks: Bool = true
 
+    /// Determines if the built-in inbox UI opens a message's `actionURL` when the user taps a
+    /// row. Default value is true. Mirrors `automaticallyOpensPushDeepLinks` for the inbox
+    /// surface, with one difference: unclaimed http(s) links fall back to the browser.
+    ///
+    /// When disabled, a tap still fires click tracking and the `ATTNSDKInboxMessageTapped`
+    /// broadcast (userInfo carries the actionURL) — only the SDK-initiated open is suppressed.
+    /// Set to false if the host app navigates on its own via that broadcast, to avoid handling
+    /// the same URL twice. Ignored when an `onMessageTap` handler is passed to `inboxView()` /
+    /// `inboxViewController()`, which replaces the SDK's routing entirely. Set it once during
+    /// SDK setup on the main thread — it is read on the main thread when a tap is handled, and
+    /// mutation from other threads is not synchronized.
+    @objc public var automaticallyOpensInboxDeepLinks: Bool = true
+
     var urlOpener: ATTNURLOpening = ATTNApplicationURLOpener()
 
     public init(domain: String, mode: ATTNSDKMode) {
@@ -320,10 +333,15 @@ public final class ATTNSDK: NSObject {
     /// resolve into their app, other http(s) links fall back to the browser. Pass
     /// `onMessageTap` to replace that default URL routing with your own navigation; click
     /// tracking still fires first. To keep tracking and the broadcast but suppress all
-    /// SDK-initiated navigation, pass an empty closure: `onMessageTap: { _ in }`.
+    /// SDK-initiated navigation, set `automaticallyOpensInboxDeepLinks = false`.
     @MainActor
     public func inboxView(style: InboxStyle = InboxStyle(), onMessageTap: ((Message) -> Void)? = nil) -> some View {
-        InboxView(viewModel: InboxViewModel(inboxManager: materializedInboxManager(), style: style, onTap: onMessageTap))
+        InboxView(viewModel: InboxViewModel(
+            inboxManager: materializedInboxManager(),
+            style: style,
+            onTap: onMessageTap,
+            shouldOpenDeepLink: { [weak self] in self?.automaticallyOpensInboxDeepLinks ?? true }
+        ))
     }
 
     /// UIKit wrapper for `inboxView(style:onMessageTap:)` — see that method for tap semantics.

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -72,6 +72,20 @@ public final class ATTNSDK: NSObject {
     /// Determinates if fatigue rules evaluation will be skipped for Creative. Default value is false.
     @objc public var skipFatigueOnCreative: Bool = false
 
+    /// Determines if the SDK opens the deep link from a tapped push notification
+    /// (`attentive_open_action_url`) on the host app's behalf. Default value is true.
+    ///
+    /// Custom-scheme links are handed to `UIApplication`, which routes them back into the host
+    /// app's URL handlers. Http(s) links are opened as universal links only — if no app has
+    /// registered for them they are never sent to the browser; the URL stays available through
+    /// the `ATTNSDKDeepLinkReceived` broadcast and `consumeDeepLink()`.
+    ///
+    /// Set to false if the host app navigates on its own via the `ATTNSDKDeepLinkReceived`
+    /// broadcast or `consumeDeepLink()`, to avoid handling the same URL twice.
+    @objc public var automaticallyOpensPushDeepLinks: Bool = true
+
+    var urlOpener: ATTNURLOpening = ATTNApplicationURLOpener()
+
     public init(domain: String, mode: ATTNSDKMode) {
         Loggers.creative.debug("Initializing ATTNSDK v\(ATTNConstants.sdkVersion, privacy: .public), Mode: \(mode.rawValue, privacy: .public), Domain: \(domain, privacy: .public)")
 
@@ -510,15 +524,6 @@ public final class ATTNSDK: NSObject {
         normalizeAndBroadcast(linkString)
     }
 
-    /// If the client prefers polling instead of observing NotificationCenter, or if the NotificationCenter broadcast happens too early for listener to catch it,
-    /// call this to retrieve (and clear) the pending URL.
-    public func consumeDeepLink() -> URL? {
-        defer { pendingURL = nil }
-        let urlString = pendingURL?.absoluteString ?? ""
-        Loggers.network.debug("Consuming pending deep link: \(urlString, privacy: .public)")
-        return pendingURL
-    }
-
     // MARK: Marketing Subscriptions
 
     @objc(optInMarketingSubscriptionWithEmail:phone:callback:)
@@ -770,30 +775,6 @@ public final class ATTNSDK: NSObject {
         }
     }
 
-    /// Normalize a raw string into a URL, stash it, and immediately post a notification.
-    private func normalizeAndBroadcast(_ rawString: String) {
-        let trimmed = rawString.trimmingCharacters(in: .whitespacesAndNewlines)
-        var candidateURL: URL?
-
-        if let trimmedURL = URL(string: trimmed), trimmedURL.scheme != nil {
-            candidateURL = trimmedURL
-        }
-
-        guard let validURL = candidateURL else {
-            Loggers.network.error("Failed to parse deep link URL from string: '\(trimmed, privacy: .public)' - Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
-            return
-        }
-
-        pendingURL = validURL
-        Loggers.network.debug("Broadcasting ATTNSDKDeepLinkReceived with URL: \(validURL, privacy: .public)")
-        NotificationCenter.default.post(
-            name: .ATTNSDKDeepLinkReceived,
-            object: nil,
-            userInfo: ["attentivePushDeeplinkUrl": validURL]
-        )
-        Loggers.network.debug("Deep link notification posted successfully - URL: \(validURL, privacy: .public)")
-    }
-
     private func setupProvisionalPush() async {
         let center = UNUserNotificationCenter.current()
         do {
@@ -926,6 +907,65 @@ public final class ATTNSDK: NSObject {
                 return escapeJSONArray(nestedArray)
             }
             return value
+        }
+    }
+}
+
+// MARK: Push Deep Link Handling
+extension ATTNSDK {
+    /// If the client prefers polling instead of observing NotificationCenter, or if the NotificationCenter broadcast happens too early for listener to catch it,
+    /// call this to retrieve (and clear) the pending URL.
+    public func consumeDeepLink() -> URL? {
+        defer { pendingURL = nil }
+        let urlString = pendingURL?.absoluteString ?? ""
+        Loggers.network.debug("Consuming pending deep link: \(urlString, privacy: .public)")
+        return pendingURL
+    }
+
+    /// Normalize a raw string into a URL, stash it, post a notification, and open it on the
+    /// host app's behalf when `automaticallyOpensPushDeepLinks` is enabled.
+    func normalizeAndBroadcast(_ rawString: String) {
+        let trimmed = rawString.trimmingCharacters(in: .whitespacesAndNewlines)
+        var candidateURL: URL?
+
+        if let trimmedURL = URL(string: trimmed), trimmedURL.scheme != nil {
+            candidateURL = trimmedURL
+        }
+
+        guard let validURL = candidateURL else {
+            Loggers.network.error("Failed to parse deep link URL from string: '\(trimmed, privacy: .public)' - Visitor ID: \(self.userIdentity.visitorId, privacy: .public)")
+            return
+        }
+
+        pendingURL = validURL
+        Loggers.network.debug("Broadcasting ATTNSDKDeepLinkReceived with URL: \(validURL, privacy: .public)")
+        NotificationCenter.default.post(
+            name: .ATTNSDKDeepLinkReceived,
+            object: nil,
+            userInfo: ["attentivePushDeeplinkUrl": validURL]
+        )
+        Loggers.network.debug("Deep link notification posted successfully - URL: \(validURL, privacy: .public)")
+
+        openDeepLink(validURL)
+    }
+
+    /// Opens a push deep link on the host app's behalf so a notification tap navigates without
+    /// any host-side wiring, matching the Android SDK's notification tap behavior.
+    private func openDeepLink(_ url: URL) {
+        guard automaticallyOpensPushDeepLinks else {
+            Loggers.network.debug("Automatic deep link opening is disabled; host app is expected to handle URL: \(url, privacy: .public)")
+            return
+        }
+
+        let isWebLink = ["http", "https"].contains(url.scheme?.lowercased() ?? "")
+        // Web links must resolve as universal links into an app; never bounce the user to the browser.
+        let options: [UIApplication.OpenExternalURLOptionsKey: Any] = isWebLink ? [.universalLinksOnly: true] : [:]
+        urlOpener.open(url, options: options) { success in
+            if success {
+                Loggers.network.debug("Opened push deep link URL: \(url, privacy: .public)")
+            } else {
+                Loggers.network.debug("No app claimed push deep link URL: \(url, privacy: .public). Host app can handle it via the ATTNSDKDeepLinkReceived broadcast or consumeDeepLink().")
+            }
         }
     }
 }

--- a/Tests/Doubles/Spies/ATTNURLOpenerSpy.swift
+++ b/Tests/Doubles/Spies/ATTNURLOpenerSpy.swift
@@ -1,0 +1,24 @@
+//
+//  ATTNURLOpenerSpy.swift
+//  attentive-ios-sdk-framework
+//
+//  Created by Umair Sharif on 7/24/26.
+//
+
+import UIKit
+@testable import ATTNSDKFramework
+
+final class ATTNURLOpenerSpy: ATTNURLOpening {
+    private(set) var openWasCalled = false
+    private(set) var openedURLs: [URL] = []
+    private(set) var lastOptions: [UIApplication.OpenExternalURLOptionsKey: Any] = [:]
+
+    var openResult = true
+
+    func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler: ((Bool) -> Void)?) {
+        openWasCalled = true
+        openedURLs.append(url)
+        lastOptions = options
+        completionHandler?(openResult)
+    }
+}

--- a/Tests/Doubles/Spies/ATTNURLOpenerSpy.swift
+++ b/Tests/Doubles/Spies/ATTNURLOpenerSpy.swift
@@ -19,6 +19,11 @@ final class ATTNURLOpenerSpy: ATTNURLOpening {
         openWasCalled = true
         openedURLs.append(url)
         lastOptions = options
-        completionHandler?(openResult)
+        // Match the real opener's timing: `UIApplication.open`'s completion arrives on a later
+        // runloop turn, never synchronously. A synchronous callback here would let tests pass
+        // on ordering assumptions the production path doesn't guarantee.
+        if let completionHandler {
+            DispatchQueue.main.async { completionHandler(self.openResult) }
+        }
     }
 }

--- a/Tests/TestCases/ATTNSDKTests.swift
+++ b/Tests/TestCases/ATTNSDKTests.swift
@@ -396,6 +396,30 @@ final class ATTNSDKTests: XCTestCase {
         XCTAssertNil(sut.consumeDeepLink())
     }
 
+    func testNormalizeAndBroadcast_emptySchemeURL_doesNotOpenOrStore() {
+        // "://foo" parses via URL(string:) with scheme == "" (not nil) — it must not slip
+        // past validation into UIApplication.open.
+        let urlOpenerSpy = ATTNURLOpenerSpy()
+        sut.urlOpener = urlOpenerSpy
+
+        sut.normalizeAndBroadcast("://foo")
+
+        XCTAssertFalse(urlOpenerSpy.openWasCalled)
+        XCTAssertNil(sut.consumeDeepLink())
+    }
+
+    func testNormalizeAndBroadcast_scriptableSchemes_doNotOpenOrStore() {
+        let urlOpenerSpy = ATTNURLOpenerSpy()
+        sut.urlOpener = urlOpenerSpy
+
+        for blocked in ["javascript:alert(1)", "file:///etc/passwd", "data:text/html,hi", "about:blank", "vbscript:msgbox"] {
+            sut.normalizeAndBroadcast(blocked)
+
+            XCTAssertFalse(urlOpenerSpy.openWasCalled, "\(blocked) must not be opened")
+            XCTAssertNil(sut.consumeDeepLink(), "\(blocked) must not be stored")
+        }
+    }
+
     func testNormalizeAndBroadcast_postsDeepLinkNotification() {
         let urlOpenerSpy = ATTNURLOpenerSpy()
         sut.urlOpener = urlOpenerSpy

--- a/Tests/TestCases/ATTNSDKTests.swift
+++ b/Tests/TestCases/ATTNSDKTests.swift
@@ -344,6 +344,81 @@ final class ATTNSDKTests: XCTestCase {
             XCTAssertEqual(escaped["double"] as? Double, 1.5)
         }
 
+    // MARK: - Push deep link tests
+
+    func testNormalizeAndBroadcast_customSchemeURL_opensURLDirectly() {
+        let urlOpenerSpy = ATTNURLOpenerSpy()
+        sut.urlOpener = urlOpenerSpy
+
+        sut.normalizeAndBroadcast("myapp://cart")
+
+        XCTAssertEqual(urlOpenerSpy.openedURLs, [URL(string: "myapp://cart")!])
+        XCTAssertNil(urlOpenerSpy.lastOptions[.universalLinksOnly])
+    }
+
+    func testNormalizeAndBroadcast_httpsURL_opensAsUniversalLinkOnly() {
+        let urlOpenerSpy = ATTNURLOpenerSpy()
+        sut.urlOpener = urlOpenerSpy
+
+        sut.normalizeAndBroadcast("https://example.com/product/1")
+
+        XCTAssertEqual(urlOpenerSpy.openedURLs, [URL(string: "https://example.com/product/1")!])
+        XCTAssertEqual(urlOpenerSpy.lastOptions[.universalLinksOnly] as? Bool, true)
+    }
+
+    func testNormalizeAndBroadcast_trimsWhitespaceBeforeOpening() {
+        let urlOpenerSpy = ATTNURLOpenerSpy()
+        sut.urlOpener = urlOpenerSpy
+
+        sut.normalizeAndBroadcast("  myapp://cart\n")
+
+        XCTAssertEqual(urlOpenerSpy.openedURLs, [URL(string: "myapp://cart")!])
+    }
+
+    func testNormalizeAndBroadcast_autoOpenDisabled_doesNotOpenButKeepsPendingURL() {
+        let urlOpenerSpy = ATTNURLOpenerSpy()
+        sut.urlOpener = urlOpenerSpy
+        sut.automaticallyOpensPushDeepLinks = false
+
+        sut.normalizeAndBroadcast("myapp://cart")
+
+        XCTAssertFalse(urlOpenerSpy.openWasCalled)
+        XCTAssertEqual(sut.consumeDeepLink(), URL(string: "myapp://cart"))
+    }
+
+    func testNormalizeAndBroadcast_invalidURLString_doesNotOpenOrStore() {
+        let urlOpenerSpy = ATTNURLOpenerSpy()
+        sut.urlOpener = urlOpenerSpy
+
+        sut.normalizeAndBroadcast("not a url")
+
+        XCTAssertFalse(urlOpenerSpy.openWasCalled)
+        XCTAssertNil(sut.consumeDeepLink())
+    }
+
+    func testNormalizeAndBroadcast_postsDeepLinkNotification() {
+        let urlOpenerSpy = ATTNURLOpenerSpy()
+        sut.urlOpener = urlOpenerSpy
+
+        let notificationExpectation = expectation(forNotification: .ATTNSDKDeepLinkReceived, object: nil) { notification in
+            notification.userInfo?["attentivePushDeeplinkUrl"] as? URL == URL(string: "myapp://cart")
+        }
+
+        sut.normalizeAndBroadcast("myapp://cart")
+
+        wait(for: [notificationExpectation], timeout: 1.0)
+    }
+
+    func testConsumeDeepLink_secondCallReturnsNil() {
+        let urlOpenerSpy = ATTNURLOpenerSpy()
+        sut.urlOpener = urlOpenerSpy
+
+        sut.normalizeAndBroadcast("myapp://cart")
+
+        XCTAssertEqual(sut.consumeDeepLink(), URL(string: "myapp://cart"))
+        XCTAssertNil(sut.consumeDeepLink())
+    }
+
     func testOptIn_withoutPushToken_isQueuedAndSentAfterTokenRegistration() {
         sut.optInMarketingSubscription(email: "user@example.com", phone: nil, callback: nil)
 

--- a/Tests/TestCases/ATTNSDKTests.swift
+++ b/Tests/TestCases/ATTNSDKTests.swift
@@ -408,15 +408,54 @@ final class ATTNSDKTests: XCTestCase {
         XCTAssertNil(sut.consumeDeepLink())
     }
 
-    func testNormalizeAndBroadcast_scriptableSchemes_doNotOpenOrStore() {
+    func testNormalizeAndBroadcast_scriptableSchemes_doNotOpenButAreStillBroadcast() {
+        // Blocked schemes must never reach UIApplication.open, but hosts observing the
+        // broadcast (or polling consumeDeepLink()) keep visibility for logging/audit.
         let urlOpenerSpy = ATTNURLOpenerSpy()
         sut.urlOpener = urlOpenerSpy
 
         for blocked in ["javascript:alert(1)", "file:///etc/passwd", "data:text/html,hi", "about:blank", "vbscript:msgbox"] {
+            let notificationExpectation = expectation(forNotification: .ATTNSDKDeepLinkReceived, object: nil)
+
             sut.normalizeAndBroadcast(blocked)
 
             XCTAssertFalse(urlOpenerSpy.openWasCalled, "\(blocked) must not be opened")
-            XCTAssertNil(sut.consumeDeepLink(), "\(blocked) must not be stored")
+            XCTAssertEqual(sut.consumeDeepLink(), URL(string: blocked), "\(blocked) must still be stored for host visibility")
+            wait(for: [notificationExpectation], timeout: 1.0)
+        }
+    }
+
+    func testNormalizeAndBroadcast_privilegedSystemSchemes_doNotOpenButAreStillBroadcast() {
+        // tel:/sms:/itms-* trigger system prompts (dialer, composer, App Store) — an
+        // escalation a push tap must never cause. Broadcast still fires for host visibility.
+        let urlOpenerSpy = ATTNURLOpenerSpy()
+        sut.urlOpener = urlOpenerSpy
+
+        for blocked in [
+            "tel:+15551234", "telprompt:+15551234", "sms:+15551234", "mailto:a@b.com",
+            "facetime://+15551234", "facetime-audio://+15551234",
+            "itms-apps://apps.apple.com/app/id1", "itms-services://?action=download-manifest"
+        ] {
+            sut.normalizeAndBroadcast(blocked)
+
+            XCTAssertFalse(urlOpenerSpy.openWasCalled, "\(blocked) must not be opened")
+            XCTAssertEqual(sut.consumeDeepLink(), URL(string: blocked), "\(blocked) must still be stored for host visibility")
+        }
+    }
+
+    func testOpenableDeepLinkScheme_acceptsNonRFCSchemesThatiOS15Parses() {
+        // Underscores and leading digits are non-RFC but registrable in Info.plist, and the
+        // lenient pre-iOS 17 URL(string:) parses them — those taps must not be dropped.
+        // (Tested via the scheme helper: the iOS 17+ parser used by the test host refuses to
+        // construct such URLs at all, so the URL-level property can't be exercised directly.)
+        for scheme in ["myapp", "my-app", "my_app", "1password", "firebase_dynamiclinks", "web+shop", "com.example.app"] {
+            XCTAssertTrue(URL.attnIsOpenableDeepLinkScheme(scheme), "\(scheme) should be openable")
+        }
+    }
+
+    func testOpenableDeepLinkScheme_rejectsBlockedEmptyAndMalformedSchemes() {
+        for scheme in [nil, "", "my app", "javascript", "JAVASCRIPT", "file", "data", "tel", "sms", "mailto", "itms-services"] {
+            XCTAssertFalse(URL.attnIsOpenableDeepLinkScheme(scheme), "\(scheme ?? "nil") should be rejected")
         }
     }
 

--- a/Tests/TestCases/InboxViewModelTests.swift
+++ b/Tests/TestCases/InboxViewModelTests.swift
@@ -74,6 +74,36 @@ final class InboxViewModelTests: XCTestCase {
         await waitUntil("click tracking POST fires") { self.apiSpy.markMessageClickedWasCalled }
     }
 
+    func testClick_autoOpenDisabled_doesNotOpenButStillTracksAndBroadcasts() async {
+        // `automaticallyOpensInboxDeepLinks = false` suppresses only the SDK-initiated open;
+        // click tracking and the ATTNSDKInboxMessageTapped broadcast still fire.
+        let message = makeMessage(actionURLString: "https://example.com/sale")
+        await makeSUT(seeding: message, shouldOpenDeepLink: { false })
+
+        let notificationExpectation = expectation(forNotification: .ATTNSDKInboxMessageTapped, object: nil)
+
+        viewModel.click(message)
+
+        XCTAssertFalse(urlOpenerSpy.openWasCalled)
+        await fulfillment(of: [notificationExpectation], timeout: 1.0)
+        await waitUntil("click tracking POST fires") { self.apiSpy.markMessageClickedWasCalled }
+    }
+
+    func testClick_autoOpenDisabled_readAtTapTimeNotInitTime() async {
+        // The flag must be consulted when the tap happens, so hosts can toggle
+        // automaticallyOpensInboxDeepLinks after the inbox view is created.
+        let message = makeMessage(actionURLString: "https://example.com/sale")
+        var autoOpen = false
+        await makeSUT(seeding: message, shouldOpenDeepLink: { autoOpen })
+
+        viewModel.click(message)
+        XCTAssertFalse(urlOpenerSpy.openWasCalled)
+
+        autoOpen = true
+        viewModel.click(message)
+        XCTAssertEqual(urlOpenerSpy.openedURLs, [URL(string: "https://example.com/sale")])
+    }
+
     func testClick_unsafeActionURLScheme_doesNotOpenButStillTracks() async {
         // Server-supplied action_url with a scriptable scheme must never reach
         // UIApplication.open; the broadcast + click tracking still run so hosts can decide.
@@ -138,7 +168,11 @@ final class InboxViewModelTests: XCTestCase {
     /// Builds the manager + view model. `seeding` must be stubbed into the API spy *before*
     /// the manager exists: `InboxManager.init` fires its first-page fetch immediately, and
     /// `refresh()` coalesces with that init-time task, so a stub set afterwards is never read.
-    private func makeSUT(seeding message: Message? = nil, onTap: ((Message) -> Void)? = nil) async {
+    private func makeSUT(
+        seeding message: Message? = nil,
+        onTap: ((Message) -> Void)? = nil,
+        shouldOpenDeepLink: @escaping () -> Bool = { true }
+    ) async {
         if let message {
             apiSpy.stubbedInboxMessagesResponses = [InboxResponse(messages: [message], nextPageToken: nil)]
         }
@@ -151,7 +185,8 @@ final class InboxViewModelTests: XCTestCase {
             inboxManager: manager,
             style: InboxStyle(),
             onTap: onTap,
-            urlOpener: urlOpenerSpy
+            urlOpener: urlOpenerSpy,
+            shouldOpenDeepLink: shouldOpenDeepLink
         )
     }
 

--- a/Tests/TestCases/InboxViewModelTests.swift
+++ b/Tests/TestCases/InboxViewModelTests.swift
@@ -74,6 +74,18 @@ final class InboxViewModelTests: XCTestCase {
         await waitUntil("click tracking POST fires") { self.apiSpy.markMessageClickedWasCalled }
     }
 
+    func testClick_unsafeActionURLScheme_doesNotOpenButStillTracks() async {
+        // Server-supplied action_url with a scriptable scheme must never reach
+        // UIApplication.open; the broadcast + click tracking still run so hosts can decide.
+        let message = makeMessage(actionURLString: "javascript:alert(1)")
+        await makeSUT(seeding: message)
+
+        viewModel.click(message)
+
+        XCTAssertFalse(urlOpenerSpy.openWasCalled)
+        await waitUntil("click tracking POST fires") { self.apiSpy.markMessageClickedWasCalled }
+    }
+
     func testClick_withNilActionURL_doesNotOpenButStillTracks() async {
         let message = makeMessage()
         await makeSUT(seeding: message)

--- a/Tests/TestCases/InboxViewModelTests.swift
+++ b/Tests/TestCases/InboxViewModelTests.swift
@@ -11,20 +11,20 @@ import XCTest
 @MainActor
 final class InboxViewModelTests: XCTestCase {
     private var apiSpy: ATTNAPISpy!
+    private var urlOpenerSpy: ATTNURLOpenerSpy!
     private var manager: InboxManager!
     private var viewModel: InboxViewModel!
 
     override func setUp() async throws {
         try await super.setUp()
         apiSpy = ATTNAPISpy(domain: "test-domain")
-        manager = InboxManager(api: apiSpy) {
-            InboxIdentitySnapshot(visitorId: "v_test", pushToken: "abc123", email: nil, phone: nil)
-        }
-        viewModel = InboxViewModel(inboxManager: manager, style: InboxStyle())
+        urlOpenerSpy = ATTNURLOpenerSpy()
+        await makeSUT()
     }
 
     override func tearDown() async throws {
         apiSpy = nil
+        urlOpenerSpy = nil
         manager = nil
         viewModel = nil
         try await super.tearDown()
@@ -34,31 +34,155 @@ final class InboxViewModelTests: XCTestCase {
 
     func testClick_withActionURL_broadcastsIdAndURL() async {
         await assertClickBroadcast(
-            id: "msg-1",
-            actionURL: URL(string: "myapp://products/sale"),
+            message: makeMessage(id: "msg-1", actionURLString: "myapp://products/sale"),
             expectedURL: URL(string: "myapp://products/sale")
         )
     }
 
     func testClick_withNilActionURL_broadcastsIdOnly() async {
         await assertClickBroadcast(
-            id: "msg-2",
-            actionURL: nil,
+            message: makeMessage(id: "msg-2"),
             expectedURL: nil
         )
+    }
+
+    // MARK: - Tap routing (default handler)
+
+    func testClick_defaultHandler_opensActionURLAndTracksClick() async {
+        let message = makeMessage(actionURLString: "https://example.com/sale")
+        await makeSUT(seeding: message)
+
+        viewModel.click(message)
+
+        XCTAssertEqual(urlOpenerSpy.openedURLs, [URL(string: "https://example.com/sale")])
+        // Plain open, no `.universalLinksOnly`: unclaimed http(s) links must fall back to the
+        // browser (unlike push deep links, which never leave the app).
+        XCTAssertTrue(urlOpenerSpy.lastOptions.isEmpty)
+        await waitUntil("click tracking POST fires") { self.apiSpy.markMessageClickedWasCalled }
+        XCTAssertEqual(apiSpy.lastMarkClickedMessageId, message.id)
+    }
+
+    func testClick_openReportsFailure_doesNotCrash() async {
+        let message = makeMessage(actionURLString: "myapp://nobody-claims-this")
+        await makeSUT(seeding: message)
+        urlOpenerSpy.openResult = false
+
+        viewModel.click(message)
+
+        // Failure is logged and swallowed; tracking still fires.
+        XCTAssertTrue(urlOpenerSpy.openWasCalled)
+        await waitUntil("click tracking POST fires") { self.apiSpy.markMessageClickedWasCalled }
+    }
+
+    func testClick_withNilActionURL_doesNotOpenButStillTracks() async {
+        let message = makeMessage()
+        await makeSUT(seeding: message)
+
+        viewModel.click(message)
+
+        XCTAssertFalse(urlOpenerSpy.openWasCalled)
+        // The click POST is skipped without an actionURL (server 400s on blank action_url),
+        // but the tap still drives the read flip through markClicked.
+        await waitUntil("mark-read POST fires") { self.apiSpy.markMessagesReadWasCalled }
+        XCTAssertFalse(apiSpy.markMessageClickedWasCalled)
+    }
+
+    // MARK: - Tap routing (custom handler)
+
+    func testClick_customOnTap_receivesMessageAndSkipsOpen() async {
+        let message = makeMessage(actionURLString: "https://example.com/sale")
+        var tappedMessages: [Message] = []
+        await makeSUT(seeding: message, onTap: { tappedMessages.append($0) })
+
+        viewModel.click(message)
+
+        XCTAssertEqual(tappedMessages.map(\.id), [message.id])
+        XCTAssertFalse(urlOpenerSpy.openWasCalled, "custom handler must replace the default open")
+        // Click tracking is not overridable — it fires before the host handler runs.
+        await waitUntil("click tracking POST fires") { self.apiSpy.markMessageClickedWasCalled }
+    }
+
+    func testClick_customOnTap_stillBroadcastsNotification() async {
+        await makeSUT(onTap: { _ in })
+        await assertClickBroadcast(
+            message: makeMessage(id: "msg-3", actionURLString: "https://example.com"),
+            expectedURL: URL(string: "https://example.com")
+        )
+    }
+
+    func testClick_customOnTap_invokedEvenWithoutActionURL() async {
+        let message = makeMessage()
+        var tappedMessages: [Message] = []
+        await makeSUT(seeding: message, onTap: { tappedMessages.append($0) })
+
+        viewModel.click(message)
+
+        XCTAssertEqual(tappedMessages.map(\.id), [message.id])
+        XCTAssertFalse(urlOpenerSpy.openWasCalled)
+    }
+
+    // MARK: - Helpers
+
+    /// Builds the manager + view model. `seeding` must be stubbed into the API spy *before*
+    /// the manager exists: `InboxManager.init` fires its first-page fetch immediately, and
+    /// `refresh()` coalesces with that init-time task, so a stub set afterwards is never read.
+    private func makeSUT(seeding message: Message? = nil, onTap: ((Message) -> Void)? = nil) async {
+        if let message {
+            apiSpy.stubbedInboxMessagesResponses = [InboxResponse(messages: [message], nextPageToken: nil)]
+        }
+        manager = InboxManager(api: apiSpy) {
+            InboxIdentitySnapshot(visitorId: "v_test", pushToken: "abc123", email: nil, phone: nil)
+        }
+        // Coalesces with the init-time fetch, guaranteeing the seeded page is cached on return.
+        await manager.refresh()
+        viewModel = InboxViewModel(
+            inboxManager: manager,
+            style: InboxStyle(),
+            onTap: onTap,
+            urlOpener: urlOpenerSpy
+        )
+    }
+
+    private func makeMessage(id: Message.ID = "msg-1", actionURLString: String? = nil) -> Message {
+        Message(
+            id: id,
+            title: "Title",
+            body: "Body",
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000),
+            isRead: false,
+            actionURLString: actionURLString
+        )
+    }
+
+    /// Polls until `condition` is true, failing the test at `timeout`. Used for effects the VM
+    /// dispatches onto a detached Task (the markClicked call) rather than running inline.
+    private func waitUntil(
+        _ label: String,
+        timeout: TimeInterval = 1,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: @escaping () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            guard Date() < deadline else {
+                XCTFail("Timed out waiting for: \(label)", file: file, line: line)
+                return
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
     }
 
     /// Drives `viewModel.click`, waits for the notification, and asserts userInfo shape:
     /// `attentiveInboxMessageId` is always present; `attentiveInboxActionUrl` is present iff
     /// `expectedURL` is non-nil.
     private func assertClickBroadcast(
-        id: Message.ID,
-        actionURL: URL?,
+        message: Message,
         expectedURL: URL?,
         file: StaticString = #filePath,
         line: UInt = #line
     ) async {
-        let received = expectation(description: "notification received for \(id)")
+        let received = expectation(description: "notification received for \(message.id)")
         var capturedUserInfo: [AnyHashable: Any]?
         let observer = NotificationCenter.default.addObserver(
             forName: .ATTNSDKInboxMessageTapped,
@@ -70,16 +194,16 @@ final class InboxViewModelTests: XCTestCase {
         }
         defer { NotificationCenter.default.removeObserver(observer) }
 
-        viewModel.click(id: id, actionURL: actionURL)
+        viewModel.click(message)
 
         await fulfillment(of: [received], timeout: 1)
-        XCTAssertEqual(capturedUserInfo?["attentiveInboxMessageId"] as? String, id, file: file, line: line)
+        XCTAssertEqual(capturedUserInfo?["attentiveInboxMessageId"] as? String, message.id, file: file, line: line)
         if let expectedURL {
             XCTAssertEqual(capturedUserInfo?["attentiveInboxActionUrl"] as? URL, expectedURL, file: file, line: line)
         } else {
             XCTAssertNil(
                 capturedUserInfo?["attentiveInboxActionUrl"],
-                "actionURL key must be absent when the caller passes nil",
+                "actionURL key must be absent when the message has no actionURL",
                 file: file, line: line
             )
         }

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		F9CED4B42DF263E600780536 /* Notification+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CED4B32DF263E600780536 /* Notification+Extension.swift */; };
 		F9D1FE2F2DEB68B7005D569F /* ATTNRetryingNetworkClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D1FE2E2DEB68B7005D569F /* ATTNRetryingNetworkClient.swift */; };
 		FB080C712C1C755A00834BAA /* ATTNAPISpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB65536D2C1B7747008DB3B1 /* ATTNAPISpy.swift */; };
+		A1B2C3D42F70A10000000004 /* ATTNURLOpenerSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42F70A10000000003 /* ATTNURLOpenerSpy.swift */; };
 		FB080C722C1C755F00834BAA /* ATTNCreativeUrlProviderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB080C6F2C1C752E00834BAA /* ATTNCreativeUrlProviderSpy.swift */; };
 		FB080C7F2C1CC9E500834BAA /* ATTNCreativeUrlConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB080C7E2C1CC9E500834BAA /* ATTNCreativeUrlConfig.swift */; };
 		FB2983E42C0F73990039759C /* ATTNAppInfoMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2983D02C0F73990039759C /* ATTNAppInfoMock.swift */; };
@@ -71,6 +72,7 @@
 		FB35C18B2C0E3F27009FA048 /* ATTNEvent+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C18A2C0E3F27009FA048 /* ATTNEvent+Extension.swift */; };
 		FB35C18D2C0E3FAA009FA048 /* ATTNUserIdentity+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C18C2C0E3FAA009FA048 /* ATTNUserIdentity+Extension.swift */; };
 		FB35C1912C0E506D009FA048 /* ATTNEventRequestProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1902C0E506D009FA048 /* ATTNEventRequestProvider.swift */; };
+		A1B2C3D42F70A10000000002 /* ATTNURLOpening.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D42F70A10000000001 /* ATTNURLOpening.swift */; };
 		FB35C1932C0E524E009FA048 /* ATTNPurchaseEvent+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1922C0E524E009FA048 /* ATTNPurchaseEvent+Extension.swift */; };
 		FB35C1952C0E5292009FA048 /* ATTNAddToCartEvent+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1942C0E5292009FA048 /* ATTNAddToCartEvent+Extension.swift */; };
 		FB35C1972C0E52F3009FA048 /* ATTNProductViewEvent+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB35C1962C0E52F3009FA048 /* ATTNProductViewEvent+Extension.swift */; };
@@ -213,6 +215,7 @@
 		FB35C18A2C0E3F27009FA048 /* ATTNEvent+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ATTNEvent+Extension.swift"; sourceTree = "<group>"; };
 		FB35C18C2C0E3FAA009FA048 /* ATTNUserIdentity+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ATTNUserIdentity+Extension.swift"; sourceTree = "<group>"; };
 		FB35C1902C0E506D009FA048 /* ATTNEventRequestProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNEventRequestProvider.swift; sourceTree = "<group>"; };
+		A1B2C3D42F70A10000000001 /* ATTNURLOpening.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNURLOpening.swift; sourceTree = "<group>"; };
 		FB35C1922C0E524E009FA048 /* ATTNPurchaseEvent+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ATTNPurchaseEvent+Extension.swift"; sourceTree = "<group>"; };
 		FB35C1942C0E5292009FA048 /* ATTNAddToCartEvent+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ATTNAddToCartEvent+Extension.swift"; sourceTree = "<group>"; };
 		FB35C1962C0E52F3009FA048 /* ATTNProductViewEvent+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ATTNProductViewEvent+Extension.swift"; sourceTree = "<group>"; };
@@ -228,6 +231,7 @@
 		FB6553692C1B72D4008DB3B1 /* ATTNSDKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNSDKTests.swift; sourceTree = "<group>"; };
 		FB65536B2C1B74A9008DB3B1 /* ATTNAPIProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNAPIProtocol.swift; sourceTree = "<group>"; };
 		FB65536D2C1B7747008DB3B1 /* ATTNAPISpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNAPISpy.swift; sourceTree = "<group>"; };
+		A1B2C3D42F70A10000000003 /* ATTNURLOpenerSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNURLOpenerSpy.swift; sourceTree = "<group>"; };
 		FB84E3022C3F30FF0011936B /* ATTNDeeplinkHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNDeeplinkHandling.swift; sourceTree = "<group>"; };
 		FB86C03D2C40611A00E35580 /* ATTNAddToCartEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNAddToCartEventTests.swift; sourceTree = "<group>"; };
 		FB86C03F2C40669400E35580 /* ATTNProductViewEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNProductViewEventTests.swift; sourceTree = "<group>"; };
@@ -487,6 +491,7 @@
 			isa = PBXGroup;
 			children = (
 				FB35C1902C0E506D009FA048 /* ATTNEventRequestProvider.swift */,
+				A1B2C3D42F70A10000000001 /* ATTNURLOpening.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -522,6 +527,7 @@
 			isa = PBXGroup;
 			children = (
 				FB65536D2C1B7747008DB3B1 /* ATTNAPISpy.swift */,
+				A1B2C3D42F70A10000000003 /* ATTNURLOpenerSpy.swift */,
 				FB080C6F2C1C752E00834BAA /* ATTNCreativeUrlProviderSpy.swift */,
 			);
 			path = Spies;
@@ -808,6 +814,7 @@
 				FB35C1872C0E3929009FA048 /* ATTNEventTypes.swift in Sources */,
 				FBA9FA162C0A77AB00C65024 /* ATTNPrice.swift in Sources */,
 				FB35C1912C0E506D009FA048 /* ATTNEventRequestProvider.swift in Sources */,
+				A1B2C3D42F70A10000000002 /* ATTNURLOpening.swift in Sources */,
 				FB35C18B2C0E3F27009FA048 /* ATTNEvent+Extension.swift in Sources */,
 				FB60AF0B2C1211C700C61537 /* ATTNEventURLProvider.swift in Sources */,
 				FBA9FA132C0A77AB00C65024 /* ATTNEvent.swift in Sources */,
@@ -861,6 +868,7 @@
 			files = (
 				FB56D4E12C20925500AF7530 /* ProcessInfo+Extension.swift in Sources */,
 				FB080C712C1C755A00834BAA /* ATTNAPISpy.swift in Sources */,
+				A1B2C3D42F70A10000000004 /* ATTNURLOpenerSpy.swift in Sources */,
 				FB90EF0B2C109CB4004DFC4A /* ATTNAPIITTests.swift in Sources */,
 				FB90EF0F2C10A81E004DFC4A /* NSURLSessionMock.swift in Sources */,
 				FB2983E42C0F73990039759C /* ATTNAppInfoMock.swift in Sources */,


### PR DESCRIPTION
## Summary

Implements MSDK-213: the SDK now opens deeplinks on the host app's behalf when the user taps a push notification or an inbox message, matching the Android SDK's behavior. Previously both surfaces only broadcast the URL and left navigation entirely to the host.

## Key Changes

**Push notifications** — a tapped push carrying `attentive_open_action_url` now opens the link after the existing `ATTNSDKDeepLinkReceived` broadcast. Custom-scheme URLs route into the host app's URL handlers; `http(s)` URLs are opened with `.universalLinksOnly` so the user is never bounced to the browser. Hosts that already navigate on their own can set `automaticallyOpensPushDeepLinks = false`.

**Inbox messages** — tapping a row in the built-in inbox UI fires click tracking first, posts the existing `ATTNSDKInboxMessageTapped` broadcast, then opens the message's `actionURL`. Unlike push, unclaimed `http(s)` links here fall back to the browser (per the ticket's requirement). Two opt-outs: `automaticallyOpensInboxDeepLinks = false` suppresses only the SDK-initiated open (tracking + broadcast still fire), or pass an `onMessageTap` closure to `inboxView()` / `inboxViewController()` to replace the default routing entirely — it receives every tap (even URL-less messages, matching Android's `onMessageClick` override).

**URL validation** (revised per review): both paths broadcast **every URL that parses with a non-empty scheme** — host visibility is never gated on validation. Only the SDK-initiated open is gated: scriptable schemes (`javascript:`, `file:`, `data:`, `about:`, `vbscript:`) and privileged system-action schemes (`tel:`, `telprompt:`, `sms:`, `mailto:`, `facetime:`, `facetime-audio:`, `itms`/`itms-apps`/`itms-services:`) are never handed to `UIApplication`. The scheme-shape check deliberately admits non-RFC shapes (`my_app://`, `1password://`) that the lenient pre-iOS 17 parser accepts on iOS 15/16. URL opening goes through a new internal `ATTNURLOpening` protocol so both paths are unit-testable.

**Docs** — README gains an upgrade warning for hosts that already navigate off the broadcast/`consumeDeepLink()`; CHANGELOG gains an Unreleased section covering the behavior change and both opt-outs.

## Public API Impact

Additive and source-compatible: two new `@objc` public properties (`automaticallyOpensPushDeepLinks`, `automaticallyOpensInboxDeepLinks`, both default `true`) and two new optional parameters (`onMessageTap` on the inbox entry points). **Both defaults change existing runtime behavior**: hosts that navigate via the broadcasts today will see the SDK also open the URL unless they opt out. Inbox is pre-GA (alpha: JTV/Aero/JCP), so the blast radius there is limited; the push behavior change applies to push integrations adopted since the Oct 2025 push beta (when the broadcast shipped). Android precedent: SDK-driven navigation is Android's only push behavior (no broadcast alternative exists), and Android's inbox defaults to SDK-opens with an `onMessageClick` override — this PR converges iOS on that contract. Default-on vs. opt-in is under discussion in review threads.

## Verification

Unit tests only so far: full suite green on iPhone 17 simulator (iOS 26.5), including 11 `InboxViewModelTests` (default open, browser-fallback options, open-failure logging, custom-handler bypass, nil-URL, broadcast shape, auto-open opt-out, flag read at tap time) and 12 push/URL-validation tests in `ATTNSDKTests` (custom scheme, universal-links-only, whitespace, opt-out, invalid URL, empty scheme, blocked-scheme broadcast-but-never-open for scriptable and privileged schemes, non-RFC scheme acceptance, broadcast, consume). The plan's manual Bonni checks are still pending: universal link resolving into the app, Safari fallback, unclaimed custom scheme, and a custom `onMessageTap` integration.

## Risk

Medium. The main risk is double navigation in host apps that already open the broadcast URL themselves — mitigated by the documented opt-outs, a README upgrade callout, and a CHANGELOG warning, but on by default. This includes **foreground taps**: a push banner tapped while the app is active now navigates immediately where it previously only broadcast. Secondary risks: unexpected browser launches from inbox taps with unclaimed `http(s)` action URLs (intended per ticket), and threading (opens are dispatched to the main actor via `Task { @MainActor in }`). Server-supplied URLs are validated before the SDK opens them (blocked schemes are still broadcast for host visibility, never opened). No network, persistence, or event-payload changes.

## Observability

No SDK crash telemetry; regressions would surface through customer/Zendesk reports and `os.log` output (searchable in Console.app, plus the debug log overlay during integration). Both open paths log success/failure, and refused schemes and disabled-flag skips are logged explicitly.

## Rollback

Runtime mitigations exist without a release: hosts can set `automaticallyOpensPushDeepLinks = false` / `automaticallyOpensInboxDeepLinks = false` and/or pass `onMessageTap` to suppress SDK-initiated navigation. A full rollback otherwise requires a follow-up SDK release and host-app adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
