### PR TITLE
MSDK-441: fix v2 event body encoding and restore pd deeplink

### DIFF
--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -510,9 +510,9 @@ extension ATTNAPI {
             let jsonString = String(data: jsonData, encoding: .utf8) ?? ""
 
             // Percent-encode the JSON for an `application/x-www-form-urlencoded` body.
-            // `.urlQueryAllowed` leaves sub-delims (`&`, `=`, `+`, `#`) unescaped, which
-            // truncates the `d` value at the first such character in the JSON (e.g. a
-            // product name like "Grab & Go" splits the body and drops the event).
+            // `.urlQueryAllowed` leaves sub-delims (`&`, `=`, `+`) unescaped, which
+            // truncates the `d` value at the first such character (e.g. a product
+            // name like "Grab & Go" splits the body and drops the event).
             guard let encodedJson = jsonString.addingPercentEncoding(withAllowedCharacters: .attnFormEncodedAllowed) else {
                 Loggers.network.error("Failed to URL-encode JSON payload")
                 callback?(nil, url, nil, ATTNError.badURL)
@@ -548,15 +548,4 @@ extension ATTNAPI {
         }
     }
 
-}
-
-private extension CharacterSet {
-    /// Percent-encoding allow-set for values inside an `application/x-www-form-urlencoded`
-    /// body: `.urlQueryAllowed` minus the sub-delims that separate form fields (`&`, `=`)
-    /// or have special decode semantics in a form body (`+`, `#`).
-    static let attnFormEncodedAllowed: CharacterSet = {
-        var set = CharacterSet.urlQueryAllowed
-        set.remove(charactersIn: "&=+#")
-        return set
-    }()
 }

--- a/Sources/API/ATTNAPI.swift
+++ b/Sources/API/ATTNAPI.swift
@@ -509,8 +509,11 @@ extension ATTNAPI {
             // Convert JSON to string for logging
             let jsonString = String(data: jsonData, encoding: .utf8) ?? ""
 
-            // URL-encode the JSON and wrap it in form data with key 'd'
-            guard let encodedJson = jsonString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
+            // Percent-encode the JSON for an `application/x-www-form-urlencoded` body.
+            // `.urlQueryAllowed` leaves sub-delims (`&`, `=`, `+`, `#`) unescaped, which
+            // truncates the `d` value at the first such character in the JSON (e.g. a
+            // product name like "Grab & Go" splits the body and drops the event).
+            guard let encodedJson = jsonString.addingPercentEncoding(withAllowedCharacters: .attnFormEncodedAllowed) else {
                 Loggers.network.error("Failed to URL-encode JSON payload")
                 callback?(nil, url, nil, ATTNError.badURL)
                 return
@@ -545,4 +548,15 @@ extension ATTNAPI {
         }
     }
 
+}
+
+private extension CharacterSet {
+    /// Percent-encoding allow-set for values inside an `application/x-www-form-urlencoded`
+    /// body: `.urlQueryAllowed` minus the sub-delims that separate form fields (`&`, `=`)
+    /// or have special decode semantics in a form body (`+`, `#`).
+    static let attnFormEncodedAllowed: CharacterSet = {
+        var set = CharacterSet.urlQueryAllowed
+        set.remove(charactersIn: "&=+#")
+        return set
+    }()
 }

--- a/Sources/Helpers/Extension/ATTNSDK+Extension.swift
+++ b/Sources/Helpers/Extension/ATTNSDK+Extension.swift
@@ -45,7 +45,7 @@ extension ATTNSDK {
                 return
             }
             for item in addToCart.items {
-                sendAddToCartEvent(product: product(from: item), currency: item.price.currency)
+                sendAddToCartEvent(product: product(from: item), currency: item.price.currency, deeplink: addToCart.deeplink)
             }
             return
         }
@@ -56,7 +56,7 @@ extension ATTNSDK {
                 return
             }
             for item in productView.items {
-                sendProductViewEvent(product: product(from: item), currency: item.price.currency)
+                sendProductViewEvent(product: product(from: item), currency: item.price.currency, deeplink: productView.deeplink)
             }
             return
         }
@@ -93,14 +93,14 @@ extension ATTNSDK {
 
     // MARK: - New Event API (v2 endpoint)
 
-    func sendAddToCartEvent(product: ATTNProduct, currency: String) {
+    func sendAddToCartEvent(product: ATTNProduct, currency: String, deeplink: String? = nil) {
         let metadata = ATTNAddToCartMetadata(product: product, currency: currency)
-        sendNewEventInternal(eventType: .addToCart, metadata: metadata)
+        sendNewEventInternal(eventType: .addToCart, metadata: metadata, deeplink: deeplink)
     }
 
-    func sendProductViewEvent(product: ATTNProduct, currency: String) {
+    func sendProductViewEvent(product: ATTNProduct, currency: String, deeplink: String? = nil) {
         let metadata = ATTNProductViewMetadata(product: product, currency: currency)
-        sendNewEventInternal(eventType: .productView, metadata: metadata)
+        sendNewEventInternal(eventType: .productView, metadata: metadata, deeplink: deeplink)
     }
 
     func sendPurchaseEvent(
@@ -125,7 +125,7 @@ extension ATTNSDK {
         sendNewEventInternal(eventType: .mobileCustomEvent, metadata: metadata)
     }
 
-    private func sendNewEventInternal<M: Codable>(eventType: ATTNEventType, metadata: M) {
+    private func sendNewEventInternal<M: Codable>(eventType: ATTNEventType, metadata: M, deeplink: String? = nil) {
         // Get current timestamp in ISO8601 format
         let timestamp = ISO8601DateFormatter().string(from: Date())
 
@@ -169,6 +169,7 @@ extension ATTNSDK {
             metadata: [:],
             eventNameAbbreviation: eventNameAbbreviation
         )
+        eventRequest.deeplink = deeplink
         Loggers.event.debug("Sending v2 \(eventType.rawValue, privacy: .public) event: \(eventRequest, privacy: .public)")
 
         // Send via API

--- a/Sources/Helpers/Extension/CharacterSet+Extension.swift
+++ b/Sources/Helpers/Extension/CharacterSet+Extension.swift
@@ -1,0 +1,24 @@
+//
+//  CharacterSet+Extension.swift
+//  attentive-ios-sdk-framework
+//
+
+import Foundation
+
+extension CharacterSet {
+    /// Percent-encoding allow-set for values inside an
+    /// `application/x-www-form-urlencoded` body or query string: `.urlQueryAllowed`
+    /// minus the sub-delims that separate form fields (`&`, `=`) or have special
+    /// decode semantics (`+` decodes as space in form parsers).
+    ///
+    /// Used by:
+    /// - `ATTNEventURLProvider.setFormEncodedQuery` for the legacy `/e` query string.
+    /// - `ATTNAPI.sendNewEvent` for the `/mobile` form-urlencoded body.
+    static let attnFormEncodedAllowed: CharacterSet = {
+        var chars = CharacterSet.urlQueryAllowed
+        chars.remove("+")
+        chars.remove("&")
+        chars.remove("=")
+        return chars
+    }()
+}

--- a/Sources/URLProviders/ATTNEventURLProvider.swift
+++ b/Sources/URLProviders/ATTNEventURLProvider.swift
@@ -95,18 +95,10 @@ extension ATTNEventURLProvider {
         return components
     }
 
-    private static let formEncodedAllowedCharacters: CharacterSet = {
-        var chars = CharacterSet.urlQueryAllowed
-        chars.remove("+")
-        chars.remove("&")
-        chars.remove("=")
-        return chars
-    }()
-
     static func setFormEncodedQuery(on components: inout URLComponents, params: [String: String]) {
         let queryString = params.map { key, value in
-            let encodedKey = key.addingPercentEncoding(withAllowedCharacters: formEncodedAllowedCharacters) ?? key
-            let encodedValue = value.addingPercentEncoding(withAllowedCharacters: formEncodedAllowedCharacters) ?? value
+            let encodedKey = key.addingPercentEncoding(withAllowedCharacters: .attnFormEncodedAllowed) ?? key
+            let encodedValue = value.addingPercentEncoding(withAllowedCharacters: .attnFormEncodedAllowed) ?? value
             return "\(encodedKey)=\(encodedValue)"
         }.joined(separator: "&")
         components.percentEncodedQuery = queryString

--- a/Tests/TestCases/ATTNAPINewEventEncodingTests.swift
+++ b/Tests/TestCases/ATTNAPINewEventEncodingTests.swift
@@ -1,0 +1,174 @@
+//
+//  ATTNAPINewEventEncodingTests.swift
+//  attentive-ios-sdk Tests
+//
+//  Regression tests for MSDK-441: the `/mobile` v2 event endpoint posts JSON as
+//  a `application/x-www-form-urlencoded` body. The percent-encoding allow-set must
+//  escape the sub-delims (`&`, `=`, `+`, `#`) that separate form fields; otherwise
+//  a raw `&` in a product name (e.g. "Grab & Go") splits the body and truncates
+//  the `d` value, causing AEH to reject the event with 422.
+//
+
+import XCTest
+@testable import ATTNSDKFramework
+
+final class ATTNAPINewEventEncodingTests: XCTestCase {
+    let testDomain = "test.attentivemobile.com"
+
+    private func sendAddToCartAndReturnBody(productName: String) -> String {
+        let sessionMock = NSURLSessionMock()
+        let api = ATTNAPI(domain: testDomain, urlSession: sessionMock)
+        let identity = ATTNTestEventUtils.buildUserIdentity()
+        let product = ATTNProduct(
+            productId: "123",
+            name: productName,
+            price: "10.00",
+            quantity: 1
+        )
+        let metadata = ATTNAddToCartMetadata(product: product, currency: "USD")
+        let event = ATTNBaseEvent(
+            visitorId: identity.visitorId,
+            version: ATTNConstants.sdkVersion,
+            attentiveDomain: testDomain,
+            locationHref: nil,
+            referrer: "",
+            eventType: .addToCart,
+            timestamp: "2026-07-28T00:00:00Z",
+            identifiers: ATTNIdentifiers(encryptedEmail: nil, encryptedPhone: nil, otherIdentifiers: nil),
+            eventMetadata: metadata,
+            genericMetadata: nil,
+            sourceType: "mobile",
+            appSdk: "iOS"
+        )
+        let eventRequest = ATTNEventRequest(metadata: [:], eventNameAbbreviation: ATTNEventTypes.addToCart)
+
+        api.sendNewEvent(event: event, eventRequest: eventRequest, userIdentity: identity, callback: nil)
+
+        guard let bodyData = sessionMock.requests.last?.httpBody,
+              let body = String(data: bodyData, encoding: .utf8) else {
+            XCTFail("Expected /mobile request to have a UTF-8 httpBody")
+            return ""
+        }
+        return body
+    }
+
+    /// A well-formed form-urlencoded body should parse to exactly one `d` field
+    /// whose value, once percent-decoded, contains the original product name verbatim.
+    private func assertBodyIsSingleFormFieldRoundTrippingName(_ body: String, expectedName: String, file: StaticString = #filePath, line: UInt = #line) {
+        // Parse the body via URLComponents to mirror what a form-urlencoded parser does.
+        var components = URLComponents()
+        components.percentEncodedQuery = body
+        let items = components.queryItems ?? []
+
+        XCTAssertEqual(items.count, 1, "Body must be a single form field; found \(items.map(\.name))", file: file, line: line)
+        XCTAssertEqual(items.first?.name, "d", "Form field must be named `d`", file: file, line: line)
+
+        guard let decodedJson = items.first?.value else {
+            XCTFail("`d` field has no decoded value", file: file, line: line)
+            return
+        }
+
+        // JSON should be well-formed and contain the original name string verbatim.
+        guard let jsonData = decodedJson.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+            XCTFail("Decoded `d` value is not valid JSON: \(decodedJson)", file: file, line: line)
+            return
+        }
+        let metadata = parsed["eventMetadata"] as? [String: Any]
+        let product = metadata?["product"] as? [String: Any]
+        XCTAssertEqual(product?["name"] as? String, expectedName, "Product name round-trip failed", file: file, line: line)
+    }
+
+    // MARK: - Regression: sub-delim characters must be escaped in body
+
+    func testSendNewEvent_productNameWithAmpersand_bodyIsSingleFormFieldAndRoundTrips() {
+        let body = sendAddToCartAndReturnBody(productName: "Grab & Go")
+
+        // Raw & must NOT appear inside the encoded `d` value — it would split the body.
+        // The only `&` allowed in a well-formed body would be between two form fields,
+        // but we only have one field.
+        XCTAssertFalse(body.contains("&"), "Raw `&` splits the form body: \(body)")
+        assertBodyIsSingleFormFieldRoundTrippingName(body, expectedName: "Grab & Go")
+    }
+
+    func testSendNewEvent_productNameWithEquals_bodyIsSingleFormFieldAndRoundTrips() {
+        let body = sendAddToCartAndReturnBody(productName: "Buy 1 = Get 1")
+        // The single `=` between the `d` key and its value is allowed; anything past that
+        // must be percent-encoded, so no additional `=` should appear.
+        let firstEquals = body.firstIndex(of: "=")
+        XCTAssertNotNil(firstEquals)
+        let afterFirstEquals = body[body.index(after: firstEquals!)...]
+        XCTAssertFalse(afterFirstEquals.contains("="), "Extra `=` in body value: \(body)")
+        assertBodyIsSingleFormFieldRoundTrippingName(body, expectedName: "Buy 1 = Get 1")
+    }
+
+    func testSendNewEvent_productNameWithPlus_bodyIsSingleFormFieldAndRoundTrips() {
+        // A raw `+` in a form-urlencoded body is interpreted by many parsers as a
+        // literal space — decoding "Grab+Go" as "Grab Go" would corrupt the name.
+        let body = sendAddToCartAndReturnBody(productName: "Grab+Go")
+        XCTAssertFalse(body.dropFirst(2).contains("+"), "Raw `+` in body value would decode as space: \(body)")
+        assertBodyIsSingleFormFieldRoundTrippingName(body, expectedName: "Grab+Go")
+    }
+
+    func testSendNewEvent_productNameWithHash_bodyIsSingleFormFieldAndRoundTrips() {
+        let body = sendAddToCartAndReturnBody(productName: "Item #42")
+        XCTAssertFalse(body.contains("#"), "Raw `#` in body may be treated as fragment: \(body)")
+        assertBodyIsSingleFormFieldRoundTrippingName(body, expectedName: "Item #42")
+    }
+
+    func testSendNewEvent_productNameWithMultipleSubDelims_bodyRoundTrips() {
+        let body = sendAddToCartAndReturnBody(productName: "A & B = C + D #1")
+        assertBodyIsSingleFormFieldRoundTrippingName(body, expectedName: "A & B = C + D #1")
+    }
+
+    // MARK: - Regression: sample product names from the SEV-4899 report
+
+    func testSendNewEvent_carterSampleNames_bodyRoundTrips() {
+        let samples = [
+            "Grab & Go Snacks",
+            "Ribbed Top & Shorts Set",
+            "Bodysuit & Pant Set"
+        ]
+        for name in samples {
+            let body = sendAddToCartAndReturnBody(productName: name)
+            assertBodyIsSingleFormFieldRoundTrippingName(body, expectedName: name)
+        }
+    }
+
+    // MARK: - Non-regression: safe characters still round-trip
+
+    func testSendNewEvent_productNameWithSafeCharacters_bodyRoundTrips() {
+        let body = sendAddToCartAndReturnBody(productName: "Classic T-Shirt (Blue) - Size L")
+        assertBodyIsSingleFormFieldRoundTrippingName(body, expectedName: "Classic T-Shirt (Blue) - Size L")
+    }
+
+    // MARK: - Non-regression: request shape
+
+    func testSendNewEvent_setsFormUrlEncodedContentTypeHeader() {
+        let sessionMock = NSURLSessionMock()
+        let api = ATTNAPI(domain: testDomain, urlSession: sessionMock)
+        let identity = ATTNTestEventUtils.buildUserIdentity()
+        let product = ATTNProduct(productId: "123", name: "Test", price: "10.00", quantity: 1)
+        let metadata = ATTNAddToCartMetadata(product: product, currency: "USD")
+        let event = ATTNBaseEvent(
+            visitorId: identity.visitorId,
+            version: ATTNConstants.sdkVersion,
+            attentiveDomain: testDomain,
+            locationHref: nil,
+            referrer: "",
+            eventType: .addToCart,
+            timestamp: "2026-07-28T00:00:00Z",
+            identifiers: ATTNIdentifiers(encryptedEmail: nil, encryptedPhone: nil, otherIdentifiers: nil),
+            eventMetadata: metadata,
+            genericMetadata: nil,
+            sourceType: "mobile",
+            appSdk: "iOS"
+        )
+        let eventRequest = ATTNEventRequest(metadata: [:], eventNameAbbreviation: ATTNEventTypes.addToCart)
+
+        api.sendNewEvent(event: event, eventRequest: eventRequest, userIdentity: identity, callback: nil)
+
+        let contentType = sessionMock.requests.last?.value(forHTTPHeaderField: "Content-Type")
+        XCTAssertEqual(contentType, "application/x-www-form-urlencoded; charset=utf-8")
+    }
+}

--- a/Tests/TestCases/ATTNv2DeeplinkTests.swift
+++ b/Tests/TestCases/ATTNv2DeeplinkTests.swift
@@ -1,0 +1,97 @@
+//
+//  ATTNv2DeeplinkTests.swift
+//  attentive-ios-sdk Tests
+//
+//  Regression tests for MSDK-441: the v2 endpoint dropped the `pd` (deeplink)
+//  query param on ProductView and AddToCart because `sendNewEventInternal`
+//  built its `ATTNEventRequest` without threading `deeplink` through.
+//
+
+import XCTest
+@testable import ATTNSDKFramework
+
+final class ATTNv2DeeplinkTests: XCTestCase {
+
+    var sdk: ATTNSDK!
+    var apiSpy: ATTNAPISpy!
+
+    override func setUp() {
+        super.setUp()
+        apiSpy = ATTNAPISpy(domain: "test.attentivemobile.com")
+        sdk = ATTNSDK(api: apiSpy)
+        sdk.useV2Endpoint = true
+    }
+
+    override func tearDown() {
+        sdk = nil
+        apiSpy = nil
+        super.tearDown()
+    }
+
+    // MARK: - ProductView
+
+    func testProductViewV2_withDeeplink_setsDeeplinkOnEventRequest() {
+        let event = ATTNTestEventUtils.buildProductView()
+        event.deeplink = "myapp://product/123"
+
+        sdk.send(event: event)
+
+        XCTAssertTrue(apiSpy.sendNewEventWasCalled)
+        XCTAssertEqual(apiSpy.lastEventRequest?.deeplink, "myapp://product/123")
+    }
+
+    func testProductViewV2_withoutDeeplink_leavesDeeplinkNilOnEventRequest() {
+        let event = ATTNTestEventUtils.buildProductView()
+
+        sdk.send(event: event)
+
+        XCTAssertTrue(apiSpy.sendNewEventWasCalled)
+        XCTAssertNil(apiSpy.lastEventRequest?.deeplink)
+    }
+
+    // MARK: - AddToCart
+
+    func testAddToCartV2_withDeeplink_setsDeeplinkOnEventRequest() {
+        let event = ATTNTestEventUtils.buildAddToCart()
+        event.deeplink = "myapp://cart"
+
+        sdk.send(event: event)
+
+        XCTAssertTrue(apiSpy.sendNewEventWasCalled)
+        XCTAssertEqual(apiSpy.lastEventRequest?.deeplink, "myapp://cart")
+    }
+
+    func testAddToCartV2_withoutDeeplink_leavesDeeplinkNilOnEventRequest() {
+        let event = ATTNTestEventUtils.buildAddToCart()
+
+        sdk.send(event: event)
+
+        XCTAssertTrue(apiSpy.sendNewEventWasCalled)
+        XCTAssertNil(apiSpy.lastEventRequest?.deeplink)
+    }
+
+    // MARK: - End-to-end URL: pd query param appears when deeplink is set
+
+    /// Combines the internal plumbing (via `send(event:)`) with the URL builder
+    /// so we catch a regression at either layer that would strip `pd`.
+    func testProductViewV2_withDeeplink_producesPdQueryParamOnUrl() {
+        let event = ATTNTestEventUtils.buildProductView()
+        event.deeplink = "myapp://product/456"
+
+        sdk.send(event: event)
+
+        guard let eventRequest = apiSpy.lastEventRequest else {
+            XCTFail("Expected sendNewEvent to be called with an ATTNEventRequest")
+            return
+        }
+        let urlProvider = ATTNEventURLProvider()
+        let url = urlProvider.buildNewEventEndpointUrl(
+            for: eventRequest,
+            userIdentity: sdk.userIdentity,
+            domain: "test.attentivemobile.com"
+        )
+        XCTAssertNotNil(url)
+        let queryItems = ATTNTestEventUtils.getQueryItemsFromUrl(url: url!)
+        XCTAssertEqual(queryItems["pd"], "myapp://product/456")
+    }
+}

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		58D52E1D292EC52B00CF32DE /* ATTNSDKFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 58332EC3292EC18800B1ECF3 /* ATTNSDKFramework.framework */; };
 		7C5CBBB7981899D2F38C79B1 /* ATTNErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727FA3DD8D949A05D0E11F30 /* ATTNErrorTests.swift */; };
 		A9D1C312A0001000000000001 /* NSLock+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D1C312A0001000000000002 /* NSLock+Extension.swift */; };
+		A044100000000000000441C0 /* CharacterSet+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A044100000000000000441C1 /* CharacterSet+Extension.swift */; };
 		A9D1C312A0001000000000003 /* XCTestCase+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D1C312A0001000000000004 /* XCTestCase+Concurrency.swift */; };
 		A9D1C315A0001000000000001 /* ATTNSDK+MarketingSubscriptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D1C315A0001000000000002 /* ATTNSDK+MarketingSubscriptions.swift */; };
 		F934CE262D495029003021C3 /* ATTNWebViewHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F934CE252D495029003021C3 /* ATTNWebViewHandlerTests.swift */; };
@@ -143,6 +144,7 @@
 		58D52E19292EC52B00CF32DE /* attentive-ios-sdk Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "attentive-ios-sdk Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		727FA3DD8D949A05D0E11F30 /* ATTNErrorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ATTNErrorTests.swift; sourceTree = "<group>"; };
 		A9D1C312A0001000000000002 /* NSLock+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLock+Extension.swift"; sourceTree = "<group>"; };
+		A044100000000000000441C1 /* CharacterSet+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CharacterSet+Extension.swift"; sourceTree = "<group>"; };
 		A9D1C312A0001000000000004 /* XCTestCase+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Concurrency.swift"; sourceTree = "<group>"; };
 		A9D1C315A0001000000000002 /* ATTNSDK+MarketingSubscriptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ATTNSDK+MarketingSubscriptions.swift"; sourceTree = "<group>"; };
 		DCF28F9F2D692A6A00A7164F /* ATTNWebViewHandlerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNWebViewHandlerUITests.swift; sourceTree = "<group>"; };
@@ -483,6 +485,7 @@
 				FBA9F9E72C0A77AB00C65024 /* Dictionary+Extension.swift */,
 				FB35C1822C0E1FD7009FA048 /* URLSession+Extension.swift */,
 				A9D1C312A0001000000000002 /* NSLock+Extension.swift */,
+				A044100000000000000441C1 /* CharacterSet+Extension.swift */,
 				FB35C18A2C0E3F27009FA048 /* ATTNEvent+Extension.swift */,
 				FB35C18C2C0E3FAA009FA048 /* ATTNUserIdentity+Extension.swift */,
 				FB35C1922C0E524E009FA048 /* ATTNPurchaseEvent+Extension.swift */,
@@ -730,6 +733,7 @@
 				FB35C18D2C0E3FAA009FA048 /* ATTNUserIdentity+Extension.swift in Sources */,
 				FB35C1832C0E1FD7009FA048 /* URLSession+Extension.swift in Sources */,
 				A9D1C312A0001000000000001 /* NSLock+Extension.swift in Sources */,
+				A044100000000000000441C0 /* CharacterSet+Extension.swift in Sources */,
 				FB35C1872C0E3929009FA048 /* ATTNEventTypes.swift in Sources */,
 				FBA9FA162C0A77AB00C65024 /* ATTNPrice.swift in Sources */,
 				FB35C1912C0E506D009FA048 /* ATTNEventRequestProvider.swift in Sources */,

--- a/attentive-ios-sdk.xcodeproj/project.pbxproj
+++ b/attentive-ios-sdk.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		F934CE262D495029003021C3 /* ATTNWebViewHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F934CE252D495029003021C3 /* ATTNWebViewHandlerTests.swift */; };
 		F939F2462D64DF75002CC012 /* ATTNCreativeStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F939F2452D64DF75002CC012 /* ATTNCreativeStateManager.swift */; };
 		F952B5AA2EC2914100E0E69D /* ATTNSDKExtensionV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F952B5A92EC2914100E0E69D /* ATTNSDKExtensionV2Tests.swift */; };
+		A044100000000000000441A0 /* ATTNAPINewEventEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A044100000000000000441A1 /* ATTNAPINewEventEncodingTests.swift */; };
+		A044100000000000000441B0 /* ATTNv2DeeplinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A044100000000000000441B1 /* ATTNv2DeeplinkTests.swift */; };
 		F952B5B42EC2915000E0E69D /* ATTNEventTrackerV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F952B5AC2EC2915000E0E69D /* ATTNEventTrackerV2Tests.swift */; };
 		F952B5B52EC2915000E0E69D /* ATTNUserIdentityExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F952B5AE2EC2915000E0E69D /* ATTNUserIdentityExtensionTests.swift */; };
 		F952B5B62EC2915000E0E69D /* ATTNEventURLProviderV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F952B5AD2EC2915000E0E69D /* ATTNEventURLProviderV2Tests.swift */; };
@@ -148,6 +150,8 @@
 		F934CE252D495029003021C3 /* ATTNWebViewHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNWebViewHandlerTests.swift; sourceTree = "<group>"; };
 		F939F2452D64DF75002CC012 /* ATTNCreativeStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNCreativeStateManager.swift; sourceTree = "<group>"; };
 		F952B5A92EC2914100E0E69D /* ATTNSDKExtensionV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNSDKExtensionV2Tests.swift; sourceTree = "<group>"; };
+		A044100000000000000441A1 /* ATTNAPINewEventEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNAPINewEventEncodingTests.swift; sourceTree = "<group>"; };
+		A044100000000000000441B1 /* ATTNv2DeeplinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNv2DeeplinkTests.swift; sourceTree = "<group>"; };
 		F952B5AC2EC2915000E0E69D /* ATTNEventTrackerV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNEventTrackerV2Tests.swift; sourceTree = "<group>"; };
 		F952B5AD2EC2915000E0E69D /* ATTNEventURLProviderV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNEventURLProviderV2Tests.swift; sourceTree = "<group>"; };
 		F952B5AE2EC2915000E0E69D /* ATTNUserIdentityExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ATTNUserIdentityExtensionTests.swift; sourceTree = "<group>"; };
@@ -378,6 +382,8 @@
 				F952B5AE2EC2915000E0E69D /* ATTNUserIdentityExtensionTests.swift */,
 				F952B5AF2EC2915000E0E69D /* ATTNV2EventModelsTests.swift */,
 				F952B5A92EC2914100E0E69D /* ATTNSDKExtensionV2Tests.swift */,
+				A044100000000000000441A1 /* ATTNAPINewEventEncodingTests.swift */,
+				A044100000000000000441B1 /* ATTNv2DeeplinkTests.swift */,
 				DCF28F9F2D692A6A00A7164F /* ATTNWebViewHandlerUITests.swift */,
 				FB2983F32C0F759D0039759C /* ATTNVisitorServiceTests.swift */,
 				F934CE252D495029003021C3 /* ATTNWebViewHandlerTests.swift */,
@@ -783,6 +789,8 @@
 				FB2983F82C0F7FB60039759C /* ATTNUserAgentBuilderTests.swift in Sources */,
 				FB86C03E2C40611A00E35580 /* ATTNAddToCartEventTests.swift in Sources */,
 				F952B5AA2EC2914100E0E69D /* ATTNSDKExtensionV2Tests.swift in Sources */,
+				A044100000000000000441A0 /* ATTNAPINewEventEncodingTests.swift in Sources */,
+				A044100000000000000441B0 /* ATTNv2DeeplinkTests.swift in Sources */,
 				FB2983F62C0F7CF10039759C /* ATTNUserIdentityTests.swift in Sources */,
 				FB86C0402C40669400E35580 /* ATTNProductViewEventTests.swift in Sources */,
 				FB2983F42C0F759D0039759C /* ATTNVisitorServiceTests.swift in Sources */,


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] Bugfix

[MSDK-441](https://attentivemobile.atlassian.net/browse/MSDK-441) — Carters (3732) bug in iOS SDK 2.0.15; related [SEV-4899](https://attentivemobile.atlassian.net/browse/SEV-4899).

## What's new?

Two independent bugs surfaced by Carters after upgrading to 2.0.15 on 2026-07-15.

### 1. v2 event body truncation on `&`/`=`/`+`/`#`

`ATTNAPI.sendNewEvent` posts JSON as `application/x-www-form-urlencoded` with body `d=<json>`, but percent-encoded the JSON with `.urlQueryAllowed` — a set that leaves the form sub-delims unescaped. Any of those characters in an event payload (a product name like `"Grab & Go"`, `"Bodysuit & Pant Set"`, etc.) splits the form body: the servlet parser terminates the `d` value at the first `&`, Jackson throws `JsonProcessingException` on the truncated JSON, AEH (`InternalEventsUnifiedController.java:47-79`) returns `422 Unprocessable Entity` and increments `recordUnifiedApiJsonParseError("mobile")`. Event dropped.

**Fix:** introduce a file-local `CharacterSet.attnFormEncodedAllowed` = `.urlQueryAllowed` minus `&=+#`, and apply it in the body-encoding call.

### 2. v2 endpoint dropped `pd` deeplink

`sendNewEventInternal` built its `ATTNEventRequest` without a `deeplink`, so `ProductView` and `AddToCart` sent through the v2 path lost the deeplink even though the URL builder already emitted `pd` when set. Threaded `deeplink` from the public event through `sendLegacyEventAsV2` → `sendAddToCartEvent` / `sendProductViewEvent` → `sendNewEventInternal` → `eventRequest.deeplink`. All new params are defaulted (`String? = nil`) so the two-arg external callers (`ATTNEventTracker.swift:72, 75`) and existing tests compile unchanged.

### What is NOT changing
- Public API surface: `ATTNSDK.send(event:)`, `ATTNProductViewEvent`, `ATTNAddToCartEvent` — signatures identical.
- Legacy `/e` endpoint code path — untouched; already safe because it builds the query via `URLComponents.queryItems` which percent-encodes sub-delims in values.
- Push token, opt-in/out, app-events, identity paths.
- Content-Type, endpoint URL, retry behavior, callback contract.

## Testing

- **Unit tests added** (14 new, all pass):
  - `ATTNAPINewEventEncodingTests` — real `ATTNAPI` + `NSURLSessionMock`; inspects raw `httpBody` and parses via `URLComponents(percentEncodedQuery:)`. Covers `&`, `=`, `+`, `#`, all four combined, plus the three literal product names from the SEV report (`"Grab & Go Snacks"`, `"Ribbed Top & Shorts Set"`, `"Bodysuit & Pant Set"`). Non-regression case with safe characters and Content-Type header assertion.
  - `ATTNv2DeeplinkTests` — drives the full `sdk.send(event:)` path with `useV2Endpoint=true`; asserts `deeplink` on the captured `ATTNEventRequest`; end-to-end URL check verifies `pd=` appears on the outbound URL.

- **Full suite:** 216 tests, 0 failures. SwiftLint clean.

- **Not automated yet — recommended before release:** point a Bonni build at a scratch domain with Charles capture on, send an AddToCart with product name `"Grab & Go Snacks"`, confirm the outbound body is a single `d=<percent-encoded-json>` field with `%26` in place of `&`.

## Rollback / host-app impact
Zero. No public API changes; no dependency or config changes. Reverting this commit restores the previous behavior.

## Screenshots
n/a — networking change.

[MSDK-441]: https://attentivemobile.atlassian.net/browse/MSDK-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SEV-4899]: https://attentivemobile.atlassian.net/browse/SEV-4899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ