### PR TITLE
Skip version-bump branch creation and push for prereleases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -623,11 +623,12 @@ platform :ios do
       notes: release_notes
     )
 
-    # 5. Create version-bump branch and commit version bump
+    # 5. Create version-bump branch (stable only) and commit version bump.
+    #    Prereleases tag the current HEAD directly — no branch or PR to main.
     version_bump = "version-bump-#{new_version}"
     sh("git config user.name 'CI Bot'")
     sh("git config user.email 'ci@attentivemobile.com'")
-    sh("git checkout -b #{version_bump}")
+    sh("git checkout -b #{version_bump}") unless is_prerelease
 
     files = [
         ".version",
@@ -662,10 +663,14 @@ platform :ios do
 
       sh("git reset --hard HEAD~1")
 
-      push_to_git_remote(
-        local_branch: version_bump,
-        tags: false
-      )
+      if is_prerelease
+        UI.important("Prerelease: skipping version-bump branch push")
+      else
+        push_to_git_remote(
+          local_branch: version_bump,
+          tags: false
+        )
+      end
 
       set_github_release(
         repository_name: repository_name,
@@ -680,7 +685,7 @@ platform :ios do
       UI.error("Release failed during publish. Rolling back remote state...")
       sh("git push --delete origin #{new_version}") rescue nil
       sh("gh release delete #{new_version} -y") rescue nil
-      sh("git push --delete origin #{version_bump}") rescue nil
+      sh("git push --delete origin #{version_bump}") rescue nil unless is_prerelease
       UI.user_error!("Release failed and rolled back: #{e.message}")
     end
 


### PR DESCRIPTION
## Summary

Stop creating and pushing a `version-bump-<version>` branch when `create_release` runs as a prerelease. Beta releases now tag the current HEAD directly, matching the existing behavior of skipping the PR to main.

## Key Changes

The `create_release` lane already skipped opening a version-bump PR to main for prereleases, but it still created and pushed the `version-bump-<version>` branch, leaving stray branches on the remote after every beta. Now the branch is only created and pushed for stable releases; prereleases commit the version bump on the current HEAD, tag it, and publish the GitHub release as before. The rollback path is updated to match — it no longer tries to delete a version-bump branch that was never pushed.

## Verification

Code review of the lane logic only — this runs inside the `release-sdk` CircleCI workflow and isn't practical to exercise locally. It will be validated end-to-end by the next beta release; if it misbehaves, the failure surfaces in the workflow before anything ships to clients.

## Risk / Rollback

Low risk: CI release automation only, no SDK code or public API changes, and stable-release behavior is untouched. If a prerelease run fails, the lane's existing rollback deletes the tag and GitHub release, and the change can be reverted with a normal PR — nothing ships into host apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
