### PR TITLE
Separate TestFlight deploy toggle from prerelease flag in release-sdk workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,11 @@ parameters:
   is_prerelease:
     type: string
     default: "false"
+  # Controls whether the deploy-testflight job runs in the release-sdk workflow.
+  # Defaults to "true" so the standalone deploy-testflight workflow is unaffected.
+  deploy_to_testflight:
+    type: string
+    default: "true"
 
 # ========================
 # Executors
@@ -290,11 +295,11 @@ jobs:
     executor: macos-xcode
     steps:
       - run:
-          name: Check prerelease
-          command: echo "is_prerelease=<< pipeline.parameters.is_prerelease >>"
-      - unless:
+          name: Check TestFlight deploy flag
+          command: echo "deploy_to_testflight=<< pipeline.parameters.deploy_to_testflight >>"
+      - when:
           condition:
-            equal: ["true", << pipeline.parameters.is_prerelease >>]
+            equal: ["true", << pipeline.parameters.deploy_to_testflight >>]
           steps:
             - attach_workspace:
                 at: .
@@ -439,11 +444,11 @@ jobs:
     executor: macos-xcode
     steps:
       - run:
-          name: Check prerelease
-          command: echo "is_prerelease=<< pipeline.parameters.is_prerelease >>"
-      - unless:
+          name: Check TestFlight deploy flag
+          command: echo "deploy_to_testflight=<< pipeline.parameters.deploy_to_testflight >>"
+      - when:
           condition:
-            equal: ["true", << pipeline.parameters.is_prerelease >>]
+            equal: ["true", << pipeline.parameters.deploy_to_testflight >>]
           steps:
             - attach_workspace:
                 at: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
         description: "Deploy Bonni build to TestFlight after the release"
         required: false
         type: boolean
-        default: true
+        default: false
       release_notes:
         description: "Release notes (optional — single line only, use gh CLI for multiline. Auto-generated from commits if blank)"
         required: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,15 @@ on:
         required: true
         type: string
       is_prerelease:
-        description: "Mark as prerelease (beta). Skips PR to main and TestFlight deploy."
+        description: "Mark as prerelease (beta). Skips PR to main."
         required: false
         type: boolean
         default: false
+      deploy_to_testflight:
+        description: "Deploy Bonni build to TestFlight after the release"
+        required: false
+        type: boolean
+        default: true
       release_notes:
         description: "Release notes (optional — single line only, use gh CLI for multiline. Auto-generated from commits if blank)"
         required: false
@@ -37,13 +42,15 @@ jobs:
             --arg version "${{ inputs.version }}" \
             --arg notes "$RELEASE_NOTES" \
             --arg is_prerelease "${{ inputs.is_prerelease }}" \
+            --arg deploy_to_testflight "${{ inputs.deploy_to_testflight }}" \
             '{
               branch: "${{ github.ref_name }}",
               parameters: {
                 run_release: true,
                 release_version: $version,
                 release_notes: $notes,
-                is_prerelease: $is_prerelease
+                is_prerelease: $is_prerelease,
+                deploy_to_testflight: $deploy_to_testflight
               }
             }')
 


### PR DESCRIPTION
## Summary

Decouples the TestFlight deploy from the prerelease flag in the release pipeline. Previously, marking a release as prerelease implicitly skipped the TestFlight deploy; now a dedicated `deploy_to_testflight` checkbox on the Release SDK GitHub Action is the sole control, and it defaults to **off**.

## Key Changes

- The Release SDK workflow gains a `deploy_to_testflight` input (unchecked by default) that is passed through to CircleCI as a new pipeline parameter.
- In CircleCI, the `deploy-testflight` and `build-bonni-release` jobs in the `release-sdk` workflow now gate on this new parameter instead of `is_prerelease`. `build-bonni-release` is included because in the release workflow it exists solely to produce the Bonni build that TestFlight consumes.
- `is_prerelease` now only controls what it says: the GitHub prerelease flag and skipping the version-bump PR to main (via `fastlane create_release`). Its input description no longer mentions TestFlight.
- The CircleCI parameter defaults to `"true"` so the standalone `deploy-testflight` workflow (triggered by the other GitHub Action, which doesn't send the parameter) is unaffected.

**Behavior changes for release operators:**
- Stable releases no longer deploy to TestFlight by default — the box must be checked.
- Prereleases *can* now deploy to TestFlight if the box is checked (previously impossible).

## Verification

- `circleci config validate` passes on the modified config (with the private `attentive-mobile/circleci-orb` stubbed, since it isn't resolvable locally).
- YAML syntax check on the modified GitHub workflow.
- Not exercised end-to-end; the first real release run will confirm the parameter passthrough.

## Risk / Rollback

Low — CI-only, no SDK code or public API changes; nothing ships to host apps. Worst case is a skipped or unwanted TestFlight deploy on a release run, corrected by re-running via the standalone Deploy to TestFlight action. Rollback is a revert of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
