### PR TITLE
Specify iOS Bonni in TestFlight deploy Slack notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ commands:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "✅ TestFlight Build Deployed",
+                    "text": "✅ iOS Bonni TestFlight Build Deployed",
                     "emoji": true
                   }
                 },


### PR DESCRIPTION
## Summary

Updates the Slack notification sent to `#eng-mobile-sdk-releases` on a successful TestFlight deploy to identify the build as the **iOS Bonni** app ("✅ iOS Bonni TestFlight Build Deployed" instead of the generic "✅ TestFlight Build Deployed"), so readers of the shared releases channel can tell which app/platform the deploy is for.

## Verification

- Validated that `.circleci/config.yml` still parses as YAML and that the `notify-slack-on-testflight-success` Block Kit payload is valid JSON with the new header text.
- Full end-to-end verification will happen on the next `deploy-testflight` workflow run, which posts the updated message.

## Risk / Rollback

Low — CI-config-only change to a notification string; no SDK code, no public API, and no effect on the build or deploy steps themselves. Rollback is a one-line revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
