### PR TITLE
MSDK-464: expose inbox unread count synchronously for UIKit; Added Inbox Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,9 +653,9 @@ Unread rows get a bold title and a leading blue dot; read rows don't. Tapping a 
 
 ### Show an unread badge
 
-The SDK exposes the server-authoritative unread count two ways so you can pick whichever fits your codebase:
+The SDK exposes the server-authoritative unread count two ways so you can pick whichever fits your codebase. All inbox APIs are Swift-only.
 
-**UIKit / Objective-C (no async/await):** `sdk.inboxUnreadCount` is a plain synchronous property, and `.ATTNSDKInboxUnreadCountChanged` fires on every change. Same-value writes are deduped, so a re-fetch that returns the same count doesn't churn your badge.
+**UIKit (no async/await):** `sdk.inboxUnreadCount` is a plain synchronous property, and `.ATTNSDKInboxUnreadCountChanged` fires on every change. Same-value writes are deduped, so a re-fetch that returns the same count doesn't churn your badge.
 
 ```swift
 override func viewDidLoad() {
@@ -672,6 +672,11 @@ override func viewDidLoad() {
 
     // Paint the initial state — no await, no Task
     updateBadge(sdk.inboxUnreadCount)
+
+    // Kick off a fetch so the observer has something to deliver. Reading `inboxUnreadCount`
+    // is passive — it doesn't itself trigger a network call. The README recommends calling
+    // this on app launch and after a push open regardless.
+    Task { await sdk.refreshInboxUnreadCount() }
 }
 
 private func updateBadge(_ count: Int) {
@@ -679,8 +684,6 @@ private func updateBadge(_ count: Int) {
     badgeLabel.text = "\(count)"
 }
 ```
-
-`sdk.inboxUnreadCount` is `@objc`, so Objective-C hosts can read it directly and register a `NotificationCenter` observer against `NSNotification.Name.ATTNSDKInboxUnreadCountChanged` the same way.
 
 **SwiftUI / async-first codebases:** subscribe to `inboxStateStream` and read `unreadCount` when you want the freshest value. Every fetch, mutation, and refresh flows through the stream.
 
@@ -751,7 +754,7 @@ await sdk.markClicked(for: message.id)
 | `inboxStateStream: AsyncStream<InboxState>` | Reactive state: `.loading` / `.loaded([Message])` / `.error` |
 | `allMessages: [Message]` | Snapshot accessor (async) |
 | `unreadCount: Int` | Server-authoritative unread count (async) |
-| `inboxUnreadCount: Int` (`@objc`) | Synchronous mirror of `unreadCount` for UIKit / Objective-C |
+| `inboxUnreadCount: Int` | Synchronous mirror of `unreadCount` (Swift, UIKit-friendly) |
 | `.ATTNSDKInboxUnreadCountChanged` | Notification posted when the unread count changes |
 | `refreshInboxUnreadCount()` | Refresh the count from the server |
 | `markRead(for:)` / `markUnread(for:)` / `delete(messageID:)` | Mutations (optimistic) |

--- a/README.md
+++ b/README.md
@@ -614,6 +614,154 @@ if let url = attentiveSdk.consumeDeepLink() {
 }
 ```
 
+## Inbox
+
+An in-app message center that renders messages Attentive delivers to a user. Each message has a title, body, timestamp, read/unread state, and optionally an image and a deep-link URL. The SDK provides both a **drop-in UI** and a **reactive state stream** so you can build your own.
+
+> New installs automatically see messages targeted at the general audience — nothing needs to be wired up server-side for a user to have inbox content.
+
+**Requirements**
+- iOS 15+
+- SDK initialized (see [Step 1](#step-1---sdk-initialization)). Inbox fetches are a no-op until a `visitorId` is available.
+
+### Option A — Drop-in UI
+
+The fastest integration: one call renders the list, empty/loading states, swipe-to-delete, swipe-to-toggle-read, pull-to-refresh, and infinite scroll.
+
+**UIKit**
+```swift
+@objc private func inboxButtonTapped() {
+    guard let inboxVC = sdk.inboxViewController() else { return }
+    navigationController?.pushViewController(inboxVC, animated: true)
+}
+```
+
+**SwiftUI**
+```swift
+import SwiftUI
+import ATTNSDKFramework
+
+struct InboxScreen: View {
+    let sdk: ATTNSDK
+    var body: some View {
+        sdk.inboxView()
+    }
+}
+```
+
+Unread rows get a bold title and a leading blue dot; read rows don't. Tapping a row fires click tracking, broadcasts `ATTNSDKInboxMessageTapped`, and opens the message's `actionURL` (universal links resolve into their app; other https links fall back to the browser).
+
+### Show an unread badge
+
+The SDK exposes the server-authoritative unread count two ways so you can pick whichever fits your codebase:
+
+**UIKit / Objective-C (no async/await):** `sdk.inboxUnreadCount` is a plain synchronous property, and `.ATTNSDKInboxUnreadCountChanged` fires on every change. Same-value writes are deduped, so a re-fetch that returns the same count doesn't churn your badge.
+
+```swift
+override func viewDidLoad() {
+    super.viewDidLoad()
+
+    NotificationCenter.default.addObserver(
+        forName: .ATTNSDKInboxUnreadCountChanged,
+        object: sdk,        // filter to this SDK instance; pass nil to observe all
+        queue: .main
+    ) { [weak self] note in
+        let count = note.userInfo?["unreadCount"] as? Int ?? 0
+        self?.updateBadge(count)
+    }
+
+    // Paint the initial state — no await, no Task
+    updateBadge(sdk.inboxUnreadCount)
+}
+
+private func updateBadge(_ count: Int) {
+    badgeView.isHidden = count == 0
+    badgeLabel.text = "\(count)"
+}
+```
+
+`sdk.inboxUnreadCount` is `@objc`, so Objective-C hosts can read it directly and register a `NotificationCenter` observer against `NSNotification.Name.ATTNSDKInboxUnreadCountChanged` the same way.
+
+**SwiftUI / async-first codebases:** subscribe to `inboxStateStream` and read `unreadCount` when you want the freshest value. Every fetch, mutation, and refresh flows through the stream.
+
+```swift
+Task { [weak self] in
+    guard let sdk = self?.sdk else { return }
+    for await _ in await sdk.inboxStateStream {
+        let count = await sdk.unreadCount
+        await MainActor.run { self?.updateBadge(count) }
+    }
+}
+```
+
+Call `await sdk.refreshInboxUnreadCount()` on app launch and after a push open to force-refresh from the server.
+
+### Customization
+
+**Fonts and colors** — pass an `InboxStyle`:
+```swift
+let style = InboxStyle(
+    titleFont: .system(size: 16, weight: .semibold),
+    bodyFont: .system(size: 14),
+    timestampFont: .caption,
+    textColor: .primary
+)
+sdk.inboxView(style: style)
+```
+
+**Custom tap handling** — takes over navigation entirely; click tracking still fires:
+```swift
+sdk.inboxView { message in
+    // route however you want
+    router.open(message.actionURL)
+}
+```
+
+**Suppress SDK-driven navigation** (keep tracking + broadcast, but don't open the URL):
+```swift
+sdk.automaticallyOpensInboxDeepLinks = false
+```
+
+### Option B — Build your own UI
+
+Subscribe to `inboxStateStream` — the single source of truth — and call the mutation APIs to change state:
+
+```swift
+for await state in await sdk.inboxStateStream {
+    switch state {
+    case .loading:                       // initial fetch in flight
+    case .loaded(let messages):          // render; empty list is .loaded([])
+    case .error:                         // first fetch failed; retry
+    }
+}
+
+// Mutations (all optimistic; revert on failure)
+await sdk.markRead(for: message.id)
+await sdk.markUnread(for: message.id)
+await sdk.delete(messageID: message.id)
+
+// Call this on tap when using your own UI (built-in UI already does)
+await sdk.markClicked(for: message.id)
+```
+
+### Public API cheat sheet
+
+| API | Purpose |
+|---|---|
+| `inboxStateStream: AsyncStream<InboxState>` | Reactive state: `.loading` / `.loaded([Message])` / `.error` |
+| `allMessages: [Message]` | Snapshot accessor (async) |
+| `unreadCount: Int` | Server-authoritative unread count (async) |
+| `inboxUnreadCount: Int` (`@objc`) | Synchronous mirror of `unreadCount` for UIKit / Objective-C |
+| `.ATTNSDKInboxUnreadCountChanged` | Notification posted when the unread count changes |
+| `refreshInboxUnreadCount()` | Refresh the count from the server |
+| `markRead(for:)` / `markUnread(for:)` / `delete(messageID:)` | Mutations (optimistic) |
+| `markClicked(for:)` | Click tracking — required for custom UI, automatic for `inboxView()` |
+| `inboxView(style:onMessageTap:)` | SwiftUI drop-in |
+| `inboxViewController(style:onMessageTap:)` | UIKit drop-in |
+| `automaticallyOpensInboxDeepLinks: Bool` | Toggle SDK-driven URL opening (default `true`) |
+
+For a working example, see `Bonni/AttentiveExample/ProductViewController.swift` (badge + push-to-open).
+
 ## Step 5 - Email & SMS Subscription Support
 
 ### Manage subscriptions for email and phone numbers

--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ override func viewDidLoad() {
         object: sdk,        // filter to this SDK instance; pass nil to observe all
         queue: .main
     ) { [weak self] note in
-        let count = note.userInfo?["unreadCount"] as? Int ?? 0
+        let count = note.userInfo?["attentiveInboxUnreadCount"] as? Int ?? 0
         self?.updateBadge(count)
     }
 

--- a/Sources/Helpers/Extension/Notification+Extension.swift
+++ b/Sources/Helpers/Extension/Notification+Extension.swift
@@ -25,7 +25,7 @@ extension Notification.Name {
         ///
         /// - `object`: the `ATTNSDK` instance that owns the count. Filter by this when running
         ///   multiple SDK instances; pass `nil` to observe all instances.
-        /// - `userInfo["unreadCount"]`: `Int` — the new server-authoritative count.
+        /// - `userInfo["attentiveInboxUnreadCount"]`: `Int` — the new server-authoritative count.
         ///
         /// The notification is dispatched from whichever thread wrote the count. Observers that
         /// touch UIKit should register with `queue: .main` or hop to main before reading.

--- a/Sources/Helpers/Extension/Notification+Extension.swift
+++ b/Sources/Helpers/Extension/Notification+Extension.swift
@@ -19,9 +19,9 @@ extension Notification.Name {
         ///   - `"attentiveInboxActionUrl"`: `URL` — present only when the message has a valid `actionURL`
         public static let ATTNSDKInboxMessageTapped = Notification.Name("ATTNSDKInboxMessageTapped")
 
-        /// Posted whenever the inbox unread count changes. Provides a UIKit / Objective-C-friendly
-        /// alternative to `ATTNSDK.inboxStateStream` for hosts driving an unread badge without
-        /// adopting Swift Concurrency.
+        /// Posted whenever the inbox unread count changes. Provides a UIKit-friendly alternative
+        /// to `ATTNSDK.inboxStateStream` for Swift hosts driving an unread badge without adopting
+        /// Swift Concurrency.
         ///
         /// - `object`: the `ATTNSDK` instance that owns the count. Filter by this when running
         ///   multiple SDK instances; pass `nil` to observe all instances.

--- a/Sources/Helpers/Extension/Notification+Extension.swift
+++ b/Sources/Helpers/Extension/Notification+Extension.swift
@@ -18,4 +18,17 @@ extension Notification.Name {
         ///   - `"attentiveInboxMessageId"`: `Message.ID` (String) — always present
         ///   - `"attentiveInboxActionUrl"`: `URL` — present only when the message has a valid `actionURL`
         public static let ATTNSDKInboxMessageTapped = Notification.Name("ATTNSDKInboxMessageTapped")
+
+        /// Posted whenever the inbox unread count changes. Provides a UIKit / Objective-C-friendly
+        /// alternative to `ATTNSDK.inboxStateStream` for hosts driving an unread badge without
+        /// adopting Swift Concurrency.
+        ///
+        /// - `object`: the `ATTNSDK` instance that owns the count. Filter by this when running
+        ///   multiple SDK instances; pass `nil` to observe all instances.
+        /// - `userInfo["unreadCount"]`: `Int` — the new server-authoritative count.
+        ///
+        /// The notification is dispatched from whichever thread wrote the count. Observers that
+        /// touch UIKit should register with `queue: .main` or hop to main before reading.
+        /// Same-value writes are deduped, so a re-fetch that returns the same count does not fire.
+        public static let ATTNSDKInboxUnreadCountChanged = Notification.Name("ATTNSDKInboxUnreadCountChanged")
 }

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -666,6 +666,12 @@ extension InboxManager {
 /// or a NotificationCenter-driven badge — powers `ATTNSDK.inboxUnreadCount` and the
 /// `ATTNSDKInboxUnreadCountChanged` fanout. Same-value writes are deduped. `onChange` runs after
 /// the lock is released so a re-entrant read from inside the callback does not deadlock.
+///
+/// **Ordering invariant:** `onChange` callbacks are only guaranteed to arrive in write-order when
+/// there is a single serialized writer. In this SDK that writer is the `InboxManager` actor's
+/// `didSet` on `storedUnreadCount` (see the property observer above), which is safe because
+/// actor isolation serializes all writes. A second concurrent writer would race post-unlock and
+/// could deliver stale counts out of order — do not introduce one without gating the callback.
 final class UnreadCountBox: @unchecked Sendable {
     private let lock = NSLock()
     private var storedCount: Int = 0

--- a/Sources/Inbox/InboxManager.swift
+++ b/Sources/Inbox/InboxManager.swift
@@ -60,7 +60,14 @@ actor InboxManager {
     /// would undercount unread messages that live on unfetched pages. Reads should go through the
     /// `unreadCount` accessor, which awaits the init-time refresh so the first read never returns
     /// a stale 0.
-    private var storedUnreadCount: Int = 0
+    ///
+    /// `didSet` mirrors every write into `unreadCountBox`; see `UnreadCountBox` for semantics.
+    private var storedUnreadCount: Int = 0 {
+        didSet { unreadCountBox.update(to: storedUnreadCount) }
+    }
+
+    /// Nonisolated mirror of `storedUnreadCount`; see `UnreadCountBox` below.
+    private let unreadCountBox: UnreadCountBox
 
     private let api: ATTNAPIProtocol
     private let identityProvider: InboxIdentityProvider
@@ -166,9 +173,14 @@ actor InboxManager {
         }
     }
 
-    init(api: ATTNAPIProtocol, identityProvider: @escaping InboxIdentityProvider) {
+    init(
+        api: ATTNAPIProtocol,
+        identityProvider: @escaping InboxIdentityProvider,
+        unreadCountBox: UnreadCountBox = UnreadCountBox()
+    ) {
         self.api = api
         self.identityProvider = identityProvider
+        self.unreadCountBox = unreadCountBox
         // Fetch the first page of messages and the unread count on construction so passive-badge
         // hosts (`sdk.unreadCount`) and stream/`allMessages` consumers both resolve without
         // needing to present `inboxView()`. Non-inbox hosts never construct the manager — see
@@ -645,5 +657,36 @@ extension InboxManager {
         storedUnreadCount = response.unreadCount
         unreadCountRevision &+= 1
         send(.loaded(orderedMessagesSnapshot()))
+    }
+}
+
+// MARK: - Unread count box
+
+/// Nonisolated mirror of `InboxManager.storedUnreadCount` for hosts that need a synchronous read
+/// or a NotificationCenter-driven badge — powers `ATTNSDK.inboxUnreadCount` and the
+/// `ATTNSDKInboxUnreadCountChanged` fanout. Same-value writes are deduped. `onChange` runs after
+/// the lock is released so a re-entrant read from inside the callback does not deadlock.
+final class UnreadCountBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedCount: Int = 0
+    private let onChange: (Int) -> Void
+
+    var count: Int { lock.withLock { storedCount } }
+
+    init(onChange: @escaping (Int) -> Void = { _ in }) {
+        self.onChange = onChange
+    }
+
+    /// Sets the current count. No-ops (and returns without invoking `onChange`) when the incoming
+    /// value equals the stored one.
+    func update(to newValue: Int) {
+        lock.lock()
+        guard storedCount != newValue else {
+            lock.unlock()
+            return
+        }
+        storedCount = newValue
+        lock.unlock()
+        onChange(newValue)
     }
 }

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -68,8 +68,8 @@ public final class ATTNSDK: NSObject {
     /// The weak capture prevents a retain cycle (SDK → box → onChange → SDK).
     private var unreadCountBox: UnreadCountBox!
 
-    /// `@objc` synchronous mirror of `unreadCount`; see `.ATTNSDKInboxUnreadCountChanged`.
-    @objc public var inboxUnreadCount: Int { unreadCountBox.count }
+    /// Synchronous mirror of `unreadCount`; see `.ATTNSDKInboxUnreadCountChanged`.
+    public var inboxUnreadCount: Int { unreadCountBox.count }
 
     // MARK: Instance Properties
     var parentView: UIView?

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -59,6 +59,18 @@ public final class ATTNSDK: NSObject {
     // See `materializedInboxManager()` for the construction path.
     private var _inboxManager: InboxManager?
 
+    /// Nonisolated mirror of the inbox unread count, readable from any thread. Eagerly assigned
+    /// in `init` — `lazy var`'s initializer is not synchronized, so two concurrent first-reads of
+    /// `inboxUnreadCount` could construct two boxes and later reads (or the manager's stored
+    /// reference) would see the wrong one. `private var` (not `let`) because Swift disallows
+    /// referencing `self` from a stored-property initializer, and the `[weak self]` capture in
+    /// `onChange` needs it — so the value is set once, after `super.init()`, and never rewritten.
+    /// The weak capture prevents a retain cycle (SDK → box → onChange → SDK).
+    private var unreadCountBox: UnreadCountBox!
+
+    /// `@objc` synchronous mirror of `unreadCount`; see `.ATTNSDKInboxUnreadCountChanged`.
+    @objc public var inboxUnreadCount: Int { unreadCountBox.count }
+
     // MARK: Instance Properties
     var parentView: UIView?
     var triggerHandler: ATTNCreativeTriggerCompletionHandler?
@@ -133,6 +145,15 @@ public final class ATTNSDK: NSObject {
         self.api = ATTNAPI(domain: domain)
 
         super.init()
+
+        self.unreadCountBox = UnreadCountBox { [weak self] newCount in
+            guard let self = self else { return }
+            NotificationCenter.default.post(
+                name: .ATTNSDKInboxUnreadCountChanged,
+                object: self,
+                userInfo: ["unreadCount": newCount]
+            )
+        }
 
         if ATTNAPI.isInvalidDomain(domain) {
             let message = ATTNError.invalidDomain.localizedDescription
@@ -920,9 +941,16 @@ fileprivate extension ATTNSDK {
     /// interact with the inbox surface never trigger the manager's network activity.
     func materializedInboxManager() -> InboxManager {
         if let existing = _inboxManager { return existing }
-        let manager = InboxManager(api: api, identityProvider: { [weak self] in
-            self?.identityStore.snapshot() ?? InboxIdentitySnapshot(visitorId: "", pushToken: "", email: nil, phone: nil)
-        })
+        // Passing `unreadCountBox` here (rather than letting the manager build its own default)
+        // is what routes every write to `storedUnreadCount` back to `inboxUnreadCount` and the
+        // `.ATTNSDKInboxUnreadCountChanged` notification.
+        let manager = InboxManager(
+            api: api,
+            identityProvider: { [weak self] in
+                self?.identityStore.snapshot() ?? InboxIdentitySnapshot(visitorId: "", pushToken: "", email: nil, phone: nil)
+            },
+            unreadCountBox: unreadCountBox
+        )
         _inboxManager = manager
         return manager
     }

--- a/Sources/Public/SDK/ATTNSDK.swift
+++ b/Sources/Public/SDK/ATTNSDK.swift
@@ -151,7 +151,7 @@ public final class ATTNSDK: NSObject {
             NotificationCenter.default.post(
                 name: .ATTNSDKInboxUnreadCountChanged,
                 object: self,
-                userInfo: ["unreadCount": newCount]
+                userInfo: ["attentiveInboxUnreadCount": newCount]
             )
         }
 

--- a/Tests/TestCases/ATTNSDKTests.swift
+++ b/Tests/TestCases/ATTNSDKTests.swift
@@ -915,6 +915,59 @@ final class ATTNSDKTests: XCTestCase {
         // Bounded by number of set operations; the precise count depends on timing.
         XCTAssertLessThanOrEqual(counter.value, 200)
     }
+
+    // MARK: - Inbox unread count sync mirror
+
+    /// End-to-end coverage for the SDK-level glue that connects `InboxManager` writes to
+    /// `ATTNSDK.inboxUnreadCount` and `.ATTNSDKInboxUnreadCountChanged`. The manager-level tests
+    /// exercise `UnreadCountBox` in isolation; this pins the wiring — the box being passed into
+    /// `materializedInboxManager()`, the notification firing with the SDK as `object`, and
+    /// `userInfo["attentiveInboxUnreadCount"]` carrying the new value.
+    func testInboxUnreadCount_notificationFiresWithSDKObjectAndPayload() async {
+        apiSpy.stubbedUnreadCount = 4
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [], nextPageToken: nil)
+        ]
+
+        // Filter on the SDK instance so a stray notification from another test can't satisfy the
+        // expectation. `handler` returns true to fulfill the expectation.
+        let notified = expectation(forNotification: .ATTNSDKInboxUnreadCountChanged, object: sut) { note in
+            (note.userInfo?["attentiveInboxUnreadCount"] as? Int) == 4
+        }
+
+        // Materialize the manager and drive the fetch. This is the same path a UIKit host would
+        // take on app launch per the README.
+        await sut.refreshInboxUnreadCount()
+
+        await fulfillment(of: [notified], timeout: 1.0)
+        XCTAssertEqual(sut.inboxUnreadCount, 4, "synchronous mirror must reflect the post-fetch count")
+    }
+
+    func testInboxUnreadCount_objectFilterIsolatesSDKInstances() async {
+        apiSpy.stubbedUnreadCount = 7
+        apiSpy.stubbedInboxMessagesResponses = [InboxResponse(messages: [], nextPageToken: nil)]
+
+        // A second SDK on its own API spy so the notifications are independent.
+        let otherApiSpy = ATTNAPISpy(domain: "OTHER")
+        otherApiSpy.stubbedUnreadCount = 99
+        otherApiSpy.stubbedInboxMessagesResponses = [InboxResponse(messages: [], nextPageToken: nil)]
+        let otherSdk = ATTNSDK(api: otherApiSpy, urlBuilder: ATTNCreativeUrlProviderSpy())
+
+        // Only `sut`'s fetch should satisfy this — expectation is filtered by object.
+        let notifiedForSut = expectation(forNotification: .ATTNSDKInboxUnreadCountChanged, object: sut) { note in
+            (note.userInfo?["attentiveInboxUnreadCount"] as? Int) == 7
+        }
+        let notifiedForOther = expectation(forNotification: .ATTNSDKInboxUnreadCountChanged, object: otherSdk) { note in
+            (note.userInfo?["attentiveInboxUnreadCount"] as? Int) == 99
+        }
+
+        await sut.refreshInboxUnreadCount()
+        await otherSdk.refreshInboxUnreadCount()
+
+        await fulfillment(of: [notifiedForSut, notifiedForOther], timeout: 1.0)
+        XCTAssertEqual(sut.inboxUnreadCount, 7)
+        XCTAssertEqual(otherSdk.inboxUnreadCount, 99)
+    }
 }
 
 private final class Counter {

--- a/Tests/TestCases/InboxManagerTests.swift
+++ b/Tests/TestCases/InboxManagerTests.swift
@@ -1222,6 +1222,149 @@ final class InboxManagerTests: XCTestCase {
         XCTAssertTrue(messages.first?.isRead ?? false, "mark-read flip must survive a click POST failure")
         XCTAssertEqual(apiSpy.markMessageClickedCallCount, 1, "click POST is attempted (actionURL non-empty)")
     }
+
+    // MARK: - UnreadCountBox mirror (UIKit / Objective-C friendly)
+
+    /// Collects every `onChange` callback fired by the box. Callbacks arrive from whichever
+    /// thread wrote the count (typically the actor's executor), so writes are lock-guarded.
+    private final class BoxObserver: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storedValues: [Int] = []
+
+        var values: [Int] { lock.withLock { storedValues } }
+
+        func append(_ value: Int) { lock.withLock { storedValues.append(value) } }
+    }
+
+    func testUnreadCountBox_initialFetchPublishesCountToObserver() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 7
+
+        let observer = BoxObserver()
+        let box = UnreadCountBox(onChange: { observer.append($0) })
+
+        let manager = InboxManager(
+            api: apiSpy,
+            identityProvider: identityProvider(),
+            unreadCountBox: box
+        )
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+
+        XCTAssertEqual(box.count, 7, "synchronous read must reflect the server-authoritative count")
+        XCTAssertEqual(observer.values, [7], "onChange fires exactly once for the initial 0 → 7 transition")
+    }
+
+    func testUnreadCountBox_dedupsSameValueWrites() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 4
+
+        let observer = BoxObserver()
+        let box = UnreadCountBox(onChange: { observer.append($0) })
+
+        let manager = InboxManager(
+            api: apiSpy,
+            identityProvider: identityProvider(),
+            unreadCountBox: box
+        )
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+
+        // Server returns the same 4 again; box must not fan out a second notification.
+        await manager.refreshUnreadCount()
+        await waitForUnreadCountFetches(count: 2)
+
+        XCTAssertEqual(observer.values, [4], "same-value re-fetch must not re-fire onChange")
+        XCTAssertEqual(box.count, 4)
+    }
+
+    func testUnreadCountBox_markReadDecrementsSynchronousMirror() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1", isRead: false)], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 3
+        apiSpy.stubbedMarkReadResponse = UpdateReadStatusResponse(
+            messages: [.init(messageId: "1", isRead: true)],
+            unreadCount: 2
+        )
+
+        let observer = BoxObserver()
+        let box = UnreadCountBox(onChange: { observer.append($0) })
+
+        let manager = InboxManager(
+            api: apiSpy,
+            identityProvider: identityProvider(),
+            unreadCountBox: box
+        )
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+
+        await manager.markRead("1")
+
+        XCTAssertEqual(box.count, 2, "authoritative count from mark-read response reaches the mirror")
+        // 0 → 3 (init) → 2 (optimistic decrement) → 2 (server reconcile, deduped)
+        XCTAssertEqual(observer.values, [3, 2], "server reconcile to same value as optimistic must dedup")
+    }
+
+    func testUnreadCountBox_resetForIdentityChangeZeroesMirror() async {
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 5
+
+        let observer = BoxObserver()
+        let box = UnreadCountBox(onChange: { observer.append($0) })
+
+        let manager = InboxManager(
+            api: apiSpy,
+            identityProvider: identityProvider(),
+            unreadCountBox: box
+        )
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+
+        await manager.resetForIdentityChange()
+
+        XCTAssertEqual(box.count, 0, "identity reset must return the mirror to 0")
+        XCTAssertEqual(observer.values, [5, 0], "reset fires a distinct 5 → 0 transition")
+    }
+
+    func testUnreadCountBox_reentrantReadInsideCallbackDoesNotDeadlock() async {
+        // Realistic UIKit pattern: a NotificationCenter observer synchronously reads
+        // `sdk.inboxUnreadCount` from inside the same callback. That must NOT deadlock — the
+        // box's internal lock must be released before `onChange` runs. A regression would hang
+        // this test at the 1s `waitForUnreadCountFetch` and fail the deadline.
+        apiSpy.stubbedInboxMessagesResponses = [
+            InboxResponse(messages: [makeMessage(id: "1")], nextPageToken: nil)
+        ]
+        apiSpy.stubbedUnreadCount = 9
+
+        let seen = BoxObserver()
+        // Capture the box weakly and read `count` synchronously from inside the callback so the
+        // re-entrant lock acquire is actually exercised (not the closure argument).
+        weak var weakBox: UnreadCountBox?
+        let box = UnreadCountBox(onChange: { _ in
+            if let reentrantCount = weakBox?.count {
+                seen.append(reentrantCount)
+            }
+        })
+        weakBox = box
+
+        let manager = InboxManager(
+            api: apiSpy,
+            identityProvider: identityProvider(),
+            unreadCountBox: box
+        )
+        _ = await waitForLoadedState(manager)
+        await waitForUnreadCountFetch()
+
+        XCTAssertEqual(box.count, 9)
+        XCTAssertEqual(seen.values, [9], "re-entrant `count` read from inside onChange must return the just-written value without deadlocking")
+    }
 }
 
 /// Mutable reference container used by tests that need to flip an identity field between


### PR DESCRIPTION
Jira: [MSDK-464](https://attentivemobile.atlassian.net/browse/MSDK-464)

## What

Existing inbox unread APIs (`unreadCount`, `inboxStateStream`) require async/await and materialization on the `InboxManager` actor, which forces every Swift UIKit host that just wants an unread badge to spawn a `Task` loop and `await` on the actor. That's the one place the drop-in inbox story leaks Swift Concurrency out to callers who otherwise never need to touch it.

This PR adds an **additive, synchronous mirror** alongside the existing async surface — no signature or behavior change to any existing API. **Swift only** — consistent with the rest of the new inbox API surface, which is also Swift-only.

## New public surface

| Symbol | Kind |
|---|---|
| `ATTNSDK.inboxUnreadCount: Int` | Synchronous, thread-safe (Swift) |
| `Notification.Name.ATTNSDKInboxUnreadCountChanged` | Posted on every count change |

- **`inboxUnreadCount`** — synchronous read of the server-authoritative count. Returns `0` until the first fetch completes, matching the async `unreadCount` accessor's initial-value semantics.
- **`.ATTNSDKInboxUnreadCountChanged`** — `object` is the `ATTNSDK` instance (filter by this for multi-instance hosts; pass `nil` to observe all); `userInfo["unreadCount"]` is the new `Int`. Same-value writes are **deduped** so a re-fetch that returns the same count does not fire a notification and the badge never churns.

## Swift UIKit usage (no async)

```swift
override func viewDidLoad() {
    super.viewDidLoad()

    // Paint initial state synchronously — no Task, no await
    updateBadge(sdk.inboxUnreadCount)

    NotificationCenter.default.addObserver(
        forName: .ATTNSDKInboxUnreadCountChanged,
        object: sdk,
        queue: .main
    ) { [weak self] note in
        let count = note.userInfo?["unreadCount"] as? Int ?? 0
        self?.updateBadge(count)
    }

    // Kick off a fetch so the notification path has something to deliver.
    // The README recommends calling refreshInboxUnreadCount() on app launch
    // and after a push open regardless.
    Task { await sdk.refreshInboxUnreadCount() }
}
```

## Implementation

- New `UnreadCountBox` (nonisolated, lock-guarded `Int` + `onChange` callback) in `Sources/Inbox/InboxManager.swift`. Reads use the SDK's existing `NSLock.withLock` helper. Same-value dedupe lives inside the box. `onChange` fires **after** the lock is released so a re-entrant read from inside the callback does not deadlock.
- `InboxManager.storedUnreadCount` gets a one-line `didSet` that mirrors every write into the box — catches all 9 existing write sites (fetch, mark-read/unread PATCH response, delete, optimistic ±1s, identity reset) with zero change to their code paths.
- `ATTNSDK` owns the box; its `onChange` posts `.ATTNSDKInboxUnreadCountChanged`. Eagerly initialized in `init` (not `lazy var`) because `lazy` init is not synchronized and `inboxUnreadCount` is documented thread-safe.
- `materializedInboxManager()` passes the SDK's box into the manager so all writes route back to the mirror.

## Public API impact

Additive only. Zero changes to:
- Method or property signatures
- Behavior of any existing API (`unreadCount`, `inboxStateStream`, `refreshInboxUnreadCount`, `markRead/markUnread/delete`, `inboxView`, etc.)
- Threading contracts, error types, or persistence format

Host apps that never touch the new APIs are byte-for-byte unaffected at runtime.

## Verification

- **Unit tests: 366/366 passing** (5 new, in `Tests/TestCases/InboxManagerTests.swift`):
  - Initial fetch publishes the count to the sync mirror.
  - Same-value re-fetch does **not** re-fire `onChange`.
  - `markRead` decrements the mirror correctly (optimistic + server reconcile).
  - `resetForIdentityChange` zeroes the mirror.
  - Re-entrant `count` read from inside `onChange` does **not** deadlock.
- **Framework build: clean** (`xcodebuild -project attentive-ios-sdk.xcodeproj -scheme attentive-ios-sdk-framework -sdk iphonesimulator`).
- **Bonni build: clean.**
- **Manual verification on simulator (iPhone 17 Pro):** Temporarily swapped Bonni's existing red-badge UI to read from `sdk.inboxUnreadCount` and observe `.ATTNSDKInboxUnreadCountChanged` under the hood (same UI, only the plumbing changed). Confirmed the unread count updates correctly across:
  - Initial fetch on app launch
  - `triggerCreative` → mark-read on tap
  - Swipe-right to mark-read / mark-unread on the inbox row
  - Swipe-left to delete
  - Identity reset (`clearUser`)
  - No lag or drift vs. the AsyncStream path

  Bonni is reverted to the AsyncStream integration in this PR — no host-side changes ship. The manual test just proved the new plumbing works end-to-end on a real host app.

## README

New section under **Inbox → Show an unread badge** documents both patterns:
- **UIKit (no async/await)** — the new sync + NotificationCenter path.
- **SwiftUI / async-first** — the existing `inboxStateStream` pattern, unchanged.

[MSDK-464]: https://attentivemobile.atlassian.net/browse/MSDK-464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ