### PR TITLE
MSDK-312: fix root causes of concurrency & webview test flake

### DIFF
--- a/Tests/TestCases/ATTNUserIdentityTests.swift
+++ b/Tests/TestCases/ATTNUserIdentityTests.swift
@@ -101,7 +101,7 @@ final class ATTNUserIdentityTests: XCTestCase {
 
     func testMergeAndRead_concurrentReadersAndWriters_doesNotCrash() {
         let identity = ATTNUserIdentity(identifiers: [ATTNIdentifierType.email: "seed@test.com"])
-        runConcurrently(iterations: 200, timeout: 15, queueLabels: ["writer", "reader"]) { i, queueIndex in
+        runConcurrently(iterations: 200, queueLabels: ["writer", "reader"]) { i, queueIndex in
             if queueIndex == 0 {
                 identity.mergeIdentifiers([ATTNIdentifierType.email: "user\(i)@test.com"])
             } else {
@@ -117,7 +117,7 @@ final class ATTNUserIdentityTests: XCTestCase {
         // with clearUser() logging outside its critical section, each os_log
         // call is still on the timed path (the dispatch block doesn't finish
         // until the log returns), and CircleCI's log capture serializes os_log
-        // at ~75ms/call, which at 200 iterations would blow the timeout.
+        // at ~75ms/call, which at 200 iterations adds ~15s of pure log latency.
         let identity = ATTNUserIdentity(
             identifiers: [:],
             visitorService: ATTNVisitorService(
@@ -125,7 +125,7 @@ final class ATTNUserIdentityTests: XCTestCase {
                 logger: Logger(OSLog.disabled)
             )
         )
-        runConcurrently(iterations: 200, timeout: 15, queueLabels: ["merge", "clear"]) { i, queueIndex in
+        runConcurrently(iterations: 200, queueLabels: ["merge", "clear"]) { i, queueIndex in
             if queueIndex == 0 {
                 identity.mergeIdentifiers([ATTNIdentifierType.email: "user\(i)@test.com"])
             } else {

--- a/Tests/TestCases/ATTNWebViewHandlerTests.swift
+++ b/Tests/TestCases/ATTNWebViewHandlerTests.swift
@@ -61,7 +61,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
 
         handler.launchCreative(parentView: parentView, creativeId: "testCreative")
 
-        waitForExpectations(timeout: 5.0) { error in
+        waitForExpectations(timeout: 30.0) { error in
             XCTAssertNil(error, "WebView was not added in time")
         }
 
@@ -81,7 +81,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
         handler.launchCreative(parentView: parentView, creativeId: "first")
         handler.launchCreative(parentView: parentView, creativeId: "second")
 
-        waitForExpectations(timeout: 10.0) { error in
+        waitForExpectations(timeout: 30.0) { error in
             XCTAssertNil(error, "WebView should have been created by the first call")
         }
 
@@ -125,7 +125,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
 
         handler.closeCreative()
 
-        waitForExpectations(timeout: 5.0) { error in
+        waitForExpectations(timeout: 30.0) { error in
             XCTAssertNil(error, "WebView was not removed in time")
         }
 
@@ -156,7 +156,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
 
         handler.launchCreative(parentView: parentView, creativeId: "willTimeout", handler: handlerClosure)
 
-        wait(for: [notOpenedExpectation, removalExpectation], timeout: 10.0)
+        wait(for: [notOpenedExpectation, removalExpectation], timeout: 30.0)
 
         XCTAssertEqual(receivedStatus, ATTNCreativeTriggerStatus.notOpened, "handler must be told the creative did not open")
         XCTAssertNil(mockWebViewProvider.webView, "webView reference must be cleared after timeout")
@@ -191,7 +191,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
         let setupExpectation = expectation(description: "webView setup")
         mockWebViewProvider.webViewSetupExpectation = setupExpectation
         stubHandler.launchCreative(parentView: parentView, creativeId: "willJSTimeout", handler: handlerClosure)
-        wait(for: [setupExpectation], timeout: 10.0)
+        wait(for: [setupExpectation], timeout: 30.0)
 
         // MockWKWebView.load() doesn't trigger a real WKNavigation, so didFinish
         // won't fire on its own. Simulate WebKit invoking it — which then dispatches
@@ -201,7 +201,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
         }
         stubHandler.webView(webView, didFinish: nil)
 
-        wait(for: [notOpenedExpectation, removalExpectation], timeout: 10.0)
+        wait(for: [notOpenedExpectation, removalExpectation], timeout: 30.0)
 
         XCTAssertEqual(receivedStatus, ATTNCreativeTriggerStatus.notOpened)
         XCTAssertNil(mockWebViewProvider.webView)
@@ -233,7 +233,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
         // (generously) for the first .notOpened, THEN hold a settle window in
         // which any duplicate would arrive. A fixed launch-anchored sleep flakes
         // when a loaded CI machine delays the first callback past the window.
-        wait(for: [firstNotOpened], timeout: 10.0)
+        wait(for: [firstNotOpened], timeout: 30.0)
 
         let settled = expectation(description: "settle window for duplicate callbacks")
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
@@ -256,13 +256,13 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
         let firstSetup = expectation(description: "webView1 setup")
         mockWebViewProvider.webViewSetupExpectation = firstSetup
         handler.launchCreative(parentView: parentView, creativeId: "first")
-        wait(for: [firstSetup], timeout: 10.0)
+        wait(for: [firstSetup], timeout: 30.0)
 
         // Close launch #1 so state → .closed and the next launch is allowed.
         let closeExpectation = expectation(description: "webView1 removed")
         mockWebViewProvider.webViewRemovalExpectation = closeExpectation
         handler.closeCreative()
-        wait(for: [closeExpectation], timeout: 10.0)
+        wait(for: [closeExpectation], timeout: 30.0)
 
         // Reset the fulfillment tracking so launch #2's setup expectation can fire.
         mockWebViewProvider.resetExpectations()
@@ -273,7 +273,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
         let secondSetup = expectation(description: "webView2 setup")
         mockWebViewProvider.webViewSetupExpectation = secondSetup
         handler.launchCreative(parentView: parentView, creativeId: "second")
-        wait(for: [secondSetup], timeout: 10.0)
+        wait(for: [secondSetup], timeout: 30.0)
         guard let webView2 = mockWebViewProvider.webView as? CustomWebView else {
             return XCTFail("expected CustomWebView after launch #2")
         }
@@ -320,7 +320,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
 
         handler.launchCreative(parentView: parentView, creativeId: creativeId)
 
-        waitForExpectations(timeout: 5.0) { error in
+        waitForExpectations(timeout: 30.0) { error in
             XCTAssertNil(error, "WebView did not set up and load URL in time")
             let actualURL = (self.mockWebViewProvider.webView as? MockWKWebView)?.loadedURL
             XCTAssertEqual(actualURL, expectedURL, "WebView should load the correct URL")

--- a/Tests/TestCases/ATTNWebViewHandlerTests.swift
+++ b/Tests/TestCases/ATTNWebViewHandlerTests.swift
@@ -22,15 +22,27 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
     var mockUrlProvider: MockCreativeUrlProvider!
     var handler: ATTNWebViewHandler!
 
+    /// Every `launchCreative` call arms a native teardown timer for
+    /// `launchTimeoutInterval`. Tests that are NOT about that timer must use an
+    /// interval that cannot elapse mid-test — otherwise every assertion between
+    /// launch and close silently races the timer, and on a slow CI machine the
+    /// timer wins and tears the webview down under the test's feet. Tests that
+    /// ARE about the timer build their own handler via `makeHandler(timeout:)`.
+    private static let neverFiresTimeout: TimeInterval = 3600
+
     override func setUp() {
         super.setUp()
         mockWebViewProvider = MockWebViewProvider()
         mockUrlProvider = MockCreativeUrlProvider()
-        handler = ATTNWebViewHandler(
+        handler = makeHandler(timeout: Self.neverFiresTimeout)
+    }
+
+    private func makeHandler(timeout: TimeInterval) -> ATTNWebViewHandler {
+        ATTNWebViewHandler(
             webViewProvider: mockWebViewProvider,
             creativeUrlBuilder: mockUrlProvider,
             stateManager: ATTNCreativeStateManager(),
-            launchTimeoutInterval: 0.2
+            launchTimeoutInterval: timeout
         )
     }
 
@@ -123,6 +135,10 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
     }
 
     func testLaunchCreative_NativeTimeout_TearsDownWebViewAndReportsNotOpened() {
+        // This test IS about the native timeout — use a fast one so the test is
+        // quick, and wait generously: the assertions are anchored on the
+        // timeout's observable effects (callback + removal), not on wall clock.
+        handler = makeHandler(timeout: 0.2)
         let parentView = UIView()
 
         let notOpenedExpectation = expectation(description: "handler receives .notOpened")
@@ -140,7 +156,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
 
         handler.launchCreative(parentView: parentView, creativeId: "willTimeout", handler: handlerClosure)
 
-        wait(for: [notOpenedExpectation, removalExpectation], timeout: 2.0)
+        wait(for: [notOpenedExpectation, removalExpectation], timeout: 10.0)
 
         XCTAssertEqual(receivedStatus, ATTNCreativeTriggerStatus.notOpened, "handler must be told the creative did not open")
         XCTAssertNil(mockWebViewProvider.webView, "webView reference must be cleared after timeout")
@@ -167,7 +183,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
             webViewProvider: mockWebViewProvider,
             creativeUrlBuilder: MockCreativeUrlProvider(),
             stateManager: ATTNCreativeStateManager(),
-            launchTimeoutInterval: 5.0  // don't let native timer fire during this test
+            launchTimeoutInterval: Self.neverFiresTimeout  // the JS path is driven manually; the native timer must never race it
         )
         stubHandler.stubbedJSResult = .success("TIMED OUT" as Any)
         handler = stubHandler
@@ -175,7 +191,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
         let setupExpectation = expectation(description: "webView setup")
         mockWebViewProvider.webViewSetupExpectation = setupExpectation
         stubHandler.launchCreative(parentView: parentView, creativeId: "willJSTimeout", handler: handlerClosure)
-        wait(for: [setupExpectation], timeout: 2.0)
+        wait(for: [setupExpectation], timeout: 10.0)
 
         // MockWKWebView.load() doesn't trigger a real WKNavigation, so didFinish
         // won't fire on its own. Simulate WebKit invoking it — which then dispatches
@@ -185,7 +201,7 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
         }
         stubHandler.webView(webView, didFinish: nil)
 
-        wait(for: [notOpenedExpectation, removalExpectation], timeout: 3.0)
+        wait(for: [notOpenedExpectation, removalExpectation], timeout: 10.0)
 
         XCTAssertEqual(receivedStatus, ATTNCreativeTriggerStatus.notOpened)
         XCTAssertNil(mockWebViewProvider.webView)
@@ -193,15 +209,18 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
     }
 
     func testTimeout_DoesNotFireNotOpenedTwice_WhenBothTimeoutsRace() {
+        // This test IS about the native timeout — use a fast one.
+        handler = makeHandler(timeout: 0.2)
         let parentView = UIView()
 
         var notOpenedCount = 0
         var otherStatuses: [String] = []
-        let allDone = expectation(description: "some time to observe extra callbacks")
+        let firstNotOpened = expectation(description: "first .notOpened arrives")
 
         let handlerClosure: ATTNCreativeTriggerCompletionHandler = { status in
             if status == ATTNCreativeTriggerStatus.notOpened {
                 notOpenedCount += 1
+                if notOpenedCount == 1 { firstNotOpened.fulfill() }
             } else {
                 otherStatuses.append(status)
             }
@@ -210,11 +229,17 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
 
         handler.launchCreative(parentView: parentView, creativeId: "raceTest", handler: handlerClosure)
 
-        // Wait past the injected 0.2s timeout plus a margin for any late callbacks.
+        // Anchor on the timeout's observable effect rather than wall clock: wait
+        // (generously) for the first .notOpened, THEN hold a settle window in
+        // which any duplicate would arrive. A fixed launch-anchored sleep flakes
+        // when a loaded CI machine delays the first callback past the window.
+        wait(for: [firstNotOpened], timeout: 10.0)
+
+        let settled = expectation(description: "settle window for duplicate callbacks")
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            allDone.fulfill()
+            settled.fulfill()
         }
-        wait(for: [allDone], timeout: 3.0)
+        wait(for: [settled], timeout: 5.0)
 
         XCTAssertEqual(notOpenedCount, 1, ".notOpened must fire exactly once even if both timeout paths run")
         XCTAssertTrue(otherStatuses.isEmpty, "must not additionally emit .closed or .opened on the timeout path; got \(otherStatuses)")
@@ -231,23 +256,24 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
         let firstSetup = expectation(description: "webView1 setup")
         mockWebViewProvider.webViewSetupExpectation = firstSetup
         handler.launchCreative(parentView: parentView, creativeId: "first")
-        wait(for: [firstSetup], timeout: 2.0)
+        wait(for: [firstSetup], timeout: 10.0)
 
         // Close launch #1 so state → .closed and the next launch is allowed.
         let closeExpectation = expectation(description: "webView1 removed")
         mockWebViewProvider.webViewRemovalExpectation = closeExpectation
         handler.closeCreative()
-        wait(for: [closeExpectation], timeout: 2.0)
+        wait(for: [closeExpectation], timeout: 10.0)
 
         // Reset the fulfillment tracking so launch #2's setup expectation can fire.
         mockWebViewProvider.resetExpectations()
 
-        // Launch #2 on the SAME handler → epoch 2. This uses the injected fast
-        // timeout, but we assert on state BEFORE that timeout fires.
+        // Launch #2 on the SAME handler → epoch 2. The stale-timeout callback is
+        // injected manually below, so this test needs no live native timer — the
+        // setUp handler's never-firing timeout means nothing races these asserts.
         let secondSetup = expectation(description: "webView2 setup")
         mockWebViewProvider.webViewSetupExpectation = secondSetup
         handler.launchCreative(parentView: parentView, creativeId: "second")
-        wait(for: [secondSetup], timeout: 2.0)
+        wait(for: [secondSetup], timeout: 10.0)
         guard let webView2 = mockWebViewProvider.webView as? CustomWebView else {
             return XCTFail("expected CustomWebView after launch #2")
         }
@@ -257,10 +283,12 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
         // in `.launching`. It should be silently dropped by the epoch guard.
         handler.reportNotOpenedAndTearDown(epoch: 1, reason: "STALE native timeout from launch #1")
 
-        // Give creativeQueue a chance to run the guarded call.
+        // Give creativeQueue a chance to run the guarded call. This is a negative
+        // check (the stale callback must be dropped), so the window errs long: too
+        // short and a regression could slip through unobserved on a slow machine.
         let settled = expectation(description: "creativeQueue drained")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { settled.fulfill() }
-        wait(for: [settled], timeout: 1.0)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { settled.fulfill() }
+        wait(for: [settled], timeout: 5.0)
 
         XCTAssertNotNil(mockWebViewProvider.webView, "stale-epoch callback must NOT tear down launch #2's webview")
         XCTAssertFalse(parentView.subviews.isEmpty, "stale-epoch callback must NOT detach launch #2's webview from its parent")
@@ -273,10 +301,14 @@ final class ATTNWebViewHandlerIntegrationTests: XCTestCase {
 
         let loadExpectation = self.expectation(description: "WebView load is triggered")
 
+        // Fresh state manager (not .shared — another test leaving .shared in a
+        // non-.closed state would silently no-op this launch) and a timeout that
+        // can't fire while we're still asserting on the loaded URL.
         let testHandler = TestWebViewHandler(
             webViewProvider: mockWebViewProvider,
             creativeUrlBuilder: MockCreativeUrlProvider(),
-            stateManager: ATTNCreativeStateManager.shared
+            stateManager: ATTNCreativeStateManager(),
+            launchTimeoutInterval: Self.neverFiresTimeout
         )
         testHandler.onMakeWebView = { mockWebView in
             mockWebView.onLoad = {

--- a/Tests/XCTestCase+Concurrency.swift
+++ b/Tests/XCTestCase+Concurrency.swift
@@ -11,16 +11,31 @@ extension XCTestCase {
     /// role index (0..<queueLabels.count) so callers can interleave different
     /// operations — e.g. one role merging while another clears.
     ///
-    /// Parallelism is bounded via `DispatchQueue.concurrentPerform` (worker
+    /// Two things here are load-bearing for CI stability; both exist because a
+    /// test that hammers one lock is a lock *convoy* — its wall-clock time is
+    /// `handoffs × thread-wakeup-latency`, and on a busy CI VM wakeup latency
+    /// for low-priority threads is tens of milliseconds, not microseconds:
+    ///
+    /// 1. The work runs at `.userInteractive` QoS — the same priority the
+    ///    XCTest main thread gets when a test calls `concurrentPerform`
+    ///    directly. Dispatching via plain `DispatchQueue.global()` ran the
+    ///    workers at `.default` QoS, and on loaded CI VMs each lock handoff
+    ///    then paid a full scheduling delay: the identical workload measured
+    ///    0.002s driven from the test thread vs 13.5s driven at default QoS
+    ///    in the same CI run.
+    /// 2. The timeout is a *deadlock detector*, not a performance assertion —
+    ///    a real deadlock never completes, so a generous bound detects it just
+    ///    as well while leaving headroom for scheduler noise the test doesn't
+    ///    control. Don't tighten it to "what the test usually takes".
+    ///
+    /// Parallelism stays bounded via `DispatchQueue.concurrentPerform` (worker
     /// threads capped near core count). Don't replace this with per-block
     /// `queue.async`: when every block parks on the same contended lock, GCD
     /// keeps spawning workers (~64/queue) and the resulting context-switch
-    /// thrash made these tests take seconds-to-timeout on small shared CI VMs
-    /// while passing in milliseconds locally. The timeout guard stays so a real
-    /// deadlock fails the test cleanly instead of hanging the CI job.
+    /// thrash is even worse.
     func runConcurrently(
         iterations: Int,
-        timeout: TimeInterval = 5,
+        timeout: TimeInterval = 60,
         queueLabels: [String] = ["concurrent"],
         file: StaticString = #file,
         line: UInt = #line,
@@ -29,7 +44,7 @@ extension XCTestCase {
         let roleCount = queueLabels.count
         let group = DispatchGroup()
         group.enter()
-        DispatchQueue.global().async {
+        DispatchQueue.global(qos: .userInteractive).async {
             DispatchQueue.concurrentPerform(iterations: iterations * roleCount) { k in
                 block(k / roleCount, k % roleCount)
             }


### PR DESCRIPTION
## Summary

Fixes the root causes of the two chronic CI flakes in `ATTNUserIdentityTests` and `ATTNWebViewHandlerIntegrationTests` (most recently pipeline 603). Previous attempts (timeout bumps, iteration cuts, storage stubbing, log silencing, bounded parallelism) tuned parameters around the failures without removing the mechanisms; both mechanisms are now structurally eliminated. Test-only change — no SDK source is touched.

## Key Changes

**Identity concurrency tests: QoS-starved lock convoy.** `runConcurrently` drove its contended-`NSLock` stress workload through `DispatchQueue.global()` at `.default` QoS while the main thread parked in `group.wait`. A test hammering one lock is a lock convoy — wall time is `handoffs × thread-wakeup latency` — and on loaded CI VMs, wakeup latency for default-QoS threads is tens of milliseconds. Pipeline 603 captured the smoking gun: the identical workload ran in **0.002s** when driven from the (high-priority) test thread and **13.5s** through the helper, seconds apart in the same run. The helper now runs its workers at `.userInteractive`, and its timeout is documented as a deadlock detector (generous by design) rather than a performance bound.

**WebView suite: every test raced a live 0.2s teardown timer.** The shared `setUp` handler used `launchTimeoutInterval: 0.2`, so every launch armed a real teardown timer and every assertion between launch and close silently raced it; on a slow runner the timer won and tore down the webview mid-test ("expected CustomWebView after launch #2"). The shared handler now uses a timeout that cannot elapse mid-test; only the tests actually exercising the timeout build a short-timeout handler, and they anchor waits on the timeout's observable effects instead of wall-clock sleeps. Event-anchored waits are widened to 30s (they return instantly on success; CI showed real 8–9s scheduler stalls). Also: `testLaunchCreative_ShouldLoadCorrectURL` no longer uses the shared state manager (cross-test pollution risk), and the multi-launch settle window widened 0.05s → 0.5s (negative check — too short risks false-pass).

## Verification

- Full unit suite passes locally: 227 tests, 0 failures (iPhone 17 simulator, iOS 26.1, Xcode 26.x via direct `xcodebuild`).
- Both suites stress-tested locally with `-test-iterations 15 -run-tests-until-failure`: 345 test executions, 0 failures.
- **7 consecutive green CI runs** on this branch (pipelines 606–613, m4pro.medium, Xcode 26.1.1).
- CI-measured proof of mechanism (pipeline 609 timings): `testClearUser_concurrentClearAndMerge` **0.004s** (previously >15s timeout) and `testMergeAndRead_concurrentReadersAndWriters` **0.002s** (previously 13.48s) — ~4 orders of magnitude, on CI hardware.
- CircleCI's flake detector flags exactly one historically flaky test in this project — `testClearUser_concurrentClearAndMerge_doesNotCrash`, at two different line numbers across commits — confirming the historical flake is confined to what this PR fixes.

## Risk / Rollback

Low: test-target only, no public API or SDK behavior change, nothing ships to host apps. Race coverage is preserved (same iteration counts, same interleavings — only worker priority and wait budgets changed). Rollback is a plain revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
